### PR TITLE
ci: bump dorny/paths-filter v3 → v4 (Node 24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Decide whether to run
         id: changed
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           working-directory: aster-lang-core
           filters: |


### PR DESCRIPTION
GitHub Actions 弃用警告：dorny/paths-filter@v3 跑在 Node 20 runtime（2026-06-16 起强制 Node 24，2026-09-16 移除）。

升级到 v4.0.1（`node24` runtime）。API（base/filters/outputs）不变，纯版本号替换。

🤖 Generated with [Claude Code](https://claude.com/claude-code)