### PR TITLE
feat(grammar): @entry annotation on Rule declarations (ADR 0015 phase 2)

### DIFF
--- a/src/main/antlr/AsterParser.g4
+++ b/src/main/antlr/AsterParser.g4
@@ -83,7 +83,7 @@ topLevelDecl
  *     ...
  */
 funcDecl
-    : RULE (IDENT | TYPE_IDENT) typeParamList? givenParamList? COMMA? (PRODUCE annotatedType?)? (DOT capabilityAnnotation? COLON NEWLINE block | COLON NEWLINE block | DOT)
+    : annotation* RULE nameIdent typeParamList? givenParamList? COMMA? (PRODUCE annotatedType?)? (DOT capabilityAnnotation? COLON NEWLINE block | COLON NEWLINE block | DOT)
     ;
 
 /**

--- a/src/main/java/aster/core/ast/Decl.java
+++ b/src/main/java/aster/core/ast/Decl.java
@@ -124,6 +124,8 @@ public sealed interface Decl extends AstNode permits Decl.Import, Decl.Data, Dec
      * @param typeParams           类型参数列表
      * @param params               参数列表
      * @param retType              返回类型
+     * @param annotations          函数声明注解列表（可能为 null）
+     * @param retAnnotations       返回类型注解列表（可能为 null）
      * @param body                 函数体（可能为 null，表示外部函数）
      * @param effects              效应列表（无副作用时为空列表）
      * @param effectCaps           效应能力列表（未声明时为空列表）
@@ -138,6 +140,7 @@ public sealed interface Decl extends AstNode permits Decl.Import, Decl.Data, Dec
         @JsonProperty("typeParams") List<String> typeParams,
         @JsonProperty("params") List<Parameter> params,
         @JsonProperty("retType") Type retType,
+        @JsonProperty("annotations") List<Annotation> annotations,
         @JsonProperty("retAnnotations") List<Annotation> retAnnotations,
         @JsonProperty("body") Block body,
         @JsonProperty("effects") List<String> effects,
@@ -150,6 +153,7 @@ public sealed interface Decl extends AstNode permits Decl.Import, Decl.Data, Dec
             params = params == null ? List.of() : List.copyOf(params);
             effects = effects == null ? List.of() : List.copyOf(effects);
             effectCaps = effectCaps == null ? List.of() : List.copyOf(effectCaps);
+            annotations = annotations == null ? List.of() : List.copyOf(annotations);
             retAnnotations = retAnnotations == null ? List.of() : List.copyOf(retAnnotations);
         }
 

--- a/src/main/java/aster/core/ir/CoreModel.java
+++ b/src/main/java/aster/core/ir/CoreModel.java
@@ -103,6 +103,7 @@ public final class CoreModel {
     public List<String> typeParams;        // 类型参数列表（泛型，如 <T, U>）
     public List<Param> params;             // 形参列表
     public Type ret;                       // 返回类型
+    public List<Annotation> annotations = Collections.emptyList(); // 函数声明注解（@entry 等）
     public List<Annotation> retAnnotations = Collections.emptyList(); // 返回类型上的注解（@pii 等）
     public List<String> effects;           // 效果声明列表（IO、CPU、Secrets 等）
     public List<String> effectCaps = Collections.emptyList(); // 能力列表（Http、Sql 等）

--- a/src/main/java/aster/core/lowering/CoreLowering.java
+++ b/src/main/java/aster/core/lowering/CoreLowering.java
@@ -115,6 +115,7 @@ public final class CoreLowering {
     // 后续 annotateFuncPii(extractPiiFromType) 也无法识别返回值的 PII 等级。
     CoreModel.Type loweredRet = func.retType() == null ? null : lowerType(func.retType());
     out.ret = applyTypeAnnotations(loweredRet, func.retType(), func.retAnnotations());
+    out.annotations = lowerAnnotations(func.annotations());
     out.retAnnotations = lowerAnnotations(func.retAnnotations());
     out.effects = func.effects() == null ? new ArrayList<>() : new ArrayList<>(func.effects());
     out.effectCaps = func.effectCaps() == null ? new ArrayList<>() : new ArrayList<>(func.effectCaps());

--- a/src/main/java/aster/core/parser/AstBuilder.java
+++ b/src/main/java/aster/core/parser/AstBuilder.java
@@ -118,8 +118,14 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
 
     @Override
     public Decl.Func visitFuncDecl(AsterParser.FuncDeclContext ctx) {
+        List<Annotation> annotations = ctx.annotation() == null ? List.of()
+            : ctx.annotation().stream().map(this::visitAnnotation).collect(Collectors.toList());
+
         // 函数名可以是 IDENT 或 TYPE_IDENT（支持 CJK 字符）
-        String name = ctx.IDENT() != null ? ctx.IDENT().getText() : ctx.TYPE_IDENT().getText();
+        if (ctx.nameIdent() == null) {
+            throw new IllegalStateException("Rule 声明缺失名称");
+        }
+        String name = nameIdentText(ctx.nameIdent());
 
         List<String> typeParams = new ArrayList<>();
         if (ctx.typeParamList() != null) {
@@ -198,8 +204,9 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
             body = visitBlock(ctx.block());
         }
 
-        Span nameSpan = ctx.IDENT() != null ? spanFrom(ctx.IDENT()) : spanFrom(ctx.TYPE_IDENT());
+        Span nameSpan = spanFrom(ctx.nameIdent());
 
+        List<Annotation> finalAnnotations = annotations.isEmpty() ? List.of() : List.copyOf(annotations);
         List<Annotation> finalRetAnnotations = retAnnotations.isEmpty() ? List.of() : List.copyOf(retAnnotations);
 
         return new Decl.Func(
@@ -208,6 +215,7 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
             finalTypeParams,
             params,
             retType,
+            finalAnnotations,
             finalRetAnnotations,
             body,
             effects,

--- a/src/main/java/aster/core/typecheck/ErrorCode.java
+++ b/src/main/java/aster/core/typecheck/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
   PII_ARG_VIOLATION("E073", Category.PII, Severity.ERROR, "PII 参数类型不匹配: 期望 %s, 实际 %s", "检查函数签名，确保 PII 等级与类别一致。"),
   DUPLICATE_IMPORT_ALIAS("E100", Category.SCOPE, Severity.WARNING, "Duplicate import alias '%s'.", "为不同的导入使用唯一别名，避免覆盖。"),
   UNDEFINED_VARIABLE("E101", Category.SCOPE, Severity.ERROR, "Undefined variable: %s", "在使用变量前先声明并初始化。"),
+  MULTIPLE_ENTRY_RULES("E102", Category.SCOPE, Severity.ERROR, "Multiple @entry rules in module: {rules}", "每个模块最多保留一个 @entry Rule。"),
   EFF_MISSING_IO("E200", Category.EFFECT, Severity.ERROR, "Function '%s' may perform I/O but is missing @io effect.", "为具有 IO 行为的函数声明 @io 效果。"),
   EFF_MISSING_CPU("E201", Category.EFFECT, Severity.ERROR, "Function '%s' may perform CPU-bound work but is missing @cpu (or @io) effect.", "为 CPU 密集型函数声明 @cpu 或 @io 效果。"),
   EFF_SUPERFLUOUS_IO_CPU_ONLY("E202", Category.EFFECT, Severity.INFO, "Function '%s' declares @io but only CPU-like work found; @io subsumes @cpu and may be unnecessary.", "若函数仅执行 CPU 工作，可移除多余的 @io 声明。"),

--- a/src/main/java/aster/core/typecheck/TypeChecker.java
+++ b/src/main/java/aster/core/typecheck/TypeChecker.java
@@ -80,6 +80,7 @@ public final class TypeChecker {
 
       // 第一遍：收集类型定义
       collectTypeDefinitions(module);
+      validateEntryAnnotations(module);
 
       // 【修复】注入类型别名映射，使下游检查器可以展开别名
       var typeAliases = symbolTable.getTypeAliases();
@@ -286,6 +287,40 @@ public final class TypeChecker {
   private void checkImport(CoreModel.Import imp) {
     // 导入检查暂时简化：仅记录模块路径
     // 完整实现需要模块解析和符号导入
+  }
+
+  /**
+   * 校验模块级 @entry 唯一性。
+   */
+  private void validateEntryAnnotations(CoreModel.Module module) {
+    if (module == null || module.decls == null) {
+      return;
+    }
+
+    var entryFuncs = module.decls.stream()
+      .filter(CoreModel.Func.class::isInstance)
+      .map(CoreModel.Func.class::cast)
+      .filter(this::hasEntryAnnotation)
+      .toList();
+
+    if (entryFuncs.size() <= 1) {
+      return;
+    }
+
+    var ruleNames = entryFuncs.stream()
+      .map(func -> func.name)
+      .filter(Objects::nonNull)
+      .toList();
+    diagnostics.error(
+      ErrorCode.MULTIPLE_ENTRY_RULES,
+      Optional.ofNullable(entryFuncs.get(0).origin),
+      Map.of("rules", String.join(", ", ruleNames))
+    );
+  }
+
+  private boolean hasEntryAnnotation(CoreModel.Func func) {
+    return func.annotations != null && func.annotations.stream()
+      .anyMatch(annotation -> annotation != null && "entry".equals(annotation.name));
   }
 
   // ========== 内置类型别名 ==========

--- a/src/test/java/aster/core/ast/AstSerializationTest.java
+++ b/src/test/java/aster/core/ast/AstSerializationTest.java
@@ -137,6 +137,7 @@ class AstSerializationTest {
             List.of(),
             List.of(),
             intType,
+            List.of(new Annotation("entry", Map.of())),
             List.of(),
             emptyBody,
             List.of(),
@@ -151,13 +152,18 @@ class AstSerializationTest {
         // 验证 JSON 格式
         assertTrue(json.contains("\"kind\":\"Func\""));
         assertTrue(json.contains("\"name\":\"add\""));
+        assertTrue(json.contains("\"annotations\""));
+        assertTrue(json.contains("\"entry\""));
 
         // 反序列化
         Decl deserialized = mapper.readValue(json, Decl.class);
 
         // 验证
         assertTrue(deserialized instanceof Decl.Func);
-        assertEquals("add", ((Decl.Func) deserialized).name());
+        Decl.Func func = (Decl.Func) deserialized;
+        assertEquals("add", func.name());
+        assertEquals(1, func.annotations().size());
+        assertEquals("entry", func.annotations().get(0).name());
     }
 
     // ============================================================

--- a/src/test/java/aster/core/lowering/CoreLoweringTest.java
+++ b/src/test/java/aster/core/lowering/CoreLoweringTest.java
@@ -42,6 +42,7 @@ class CoreLoweringTest {
             List.of(),  // typeParams
             List.of(),  // params
             typeInt(),
+            null,  // annotations
             null,  // retAnnotations
             new Block(List.of(), null),
             List.of(),  // effects
@@ -76,6 +77,7 @@ class CoreLoweringTest {
                 new Decl.Parameter("b", typeInt(), null, null)
             ),
             typeInt(),
+            null,
             null,
             new Block(List.of(), null),
             List.of(),
@@ -177,6 +179,7 @@ class CoreLoweringTest {
             List.of(new Decl.Parameter("path", typeString(), null, null)),
             typeString(),
             null,
+            null,
             new Block(List.of(), null),
             List.of("io"),  // effects
             List.of(),
@@ -219,6 +222,7 @@ class CoreLoweringTest {
             List.of("T"),  // typeParams
             List.of(new Decl.Parameter("x", type("T"), null, null)),
             type("T"),
+            null,
             null,
             new Block(List.of(), null),
             List.of(),
@@ -269,7 +273,7 @@ class CoreLoweringTest {
      */
     @Test
     void testLowerModuleWithMultipleDeclarations() {
-        var func = new Decl.Func("main", null, List.of(), List.of(), typeInt(), null,
+        var func = new Decl.Func("main", null, List.of(), List.of(), typeInt(), null, null,
             new Block(List.of(), null), List.of(), List.of(), false, null);
         var data = new Decl.Data("User", List.of(new Decl.Field("name", typeString(), null)), null);
         var enumDecl = new Decl.Enum("Status", List.of("Active", "Inactive"), null);
@@ -283,5 +287,30 @@ class CoreLoweringTest {
         assertTrue(lowered.decls.get(0) instanceof CoreModel.Func);
         assertTrue(lowered.decls.get(1) instanceof CoreModel.Data);
         assertTrue(lowered.decls.get(2) instanceof CoreModel.Enum);
+    }
+
+    @Test
+    void testLowerFunctionWithAnnotations() {
+        var func = new Decl.Func(
+            "main",
+            null,
+            List.of(),
+            List.of(),
+            typeInt(),
+            List.of(new Annotation("entry", Map.of())),
+            null,
+            new Block(List.of(), null),
+            List.of(),
+            List.of(),
+            false,
+            null
+        );
+
+        var module = new aster.core.ast.Module(null, List.of(func), null);
+        var lowered = lowering.lowerModule(module);
+        var funcLowered = (CoreModel.Func) lowered.decls.get(0);
+
+        assertEquals(1, funcLowered.annotations.size());
+        assertEquals("entry", funcLowered.annotations.get(0).name);
     }
 }

--- a/src/test/java/aster/core/parser/AstBuilderTest.java
+++ b/src/test/java/aster/core/parser/AstBuilderTest.java
@@ -195,6 +195,73 @@ class AstBuilderTest {
     }
 
     @Test
+    void testFuncWithEntryAnnotation() {
+        String input = """
+            @entry Rule main produce Text:
+              Return "ok".
+            """;
+
+        aster.core.ast.Module module = parseAndBuild(input);
+
+        Decl.Func func = (Decl.Func) module.decls().get(0);
+        assertEquals("main", func.name());
+        assertEquals(1, func.annotations().size());
+        assertEquals("entry", func.annotations().get(0).name());
+    }
+
+    @Test
+    void testFuncWithMultipleAnnotations() {
+        String input = """
+            @entry @preview(source: "test") Rule main produce Text:
+              Return "ok".
+            """;
+
+        aster.core.ast.Module module = parseAndBuild(input);
+
+        Decl.Func func = (Decl.Func) module.decls().get(0);
+        assertEquals(2, func.annotations().size());
+        assertEquals("entry", func.annotations().get(0).name());
+        assertEquals("preview", func.annotations().get(1).name());
+        assertEquals("test", func.annotations().get(1).params().get("source"));
+    }
+
+    @Test
+    void testMultipleEntryAnnotatedFuncsParse() {
+        // 注：parse 层允许多个 @entry funcDecl，@entry 唯一性由 TypeChecker 校验。
+        // Rule 名避开软关键字（如 second=SECONDS 时间单位）——软关键字做标识符
+        // 是独立的既存限制，不在本特性范围内处理。
+        String input = """
+            @entry Rule alpha produce Text:
+              Return "first".
+
+            @entry Rule beta produce Text:
+              Return "second".
+            """;
+
+        aster.core.ast.Module module = parseAndBuild(input);
+
+        assertEquals(2, module.decls().size());
+        Decl.Func first = (Decl.Func) module.decls().get(0);
+        Decl.Func second = (Decl.Func) module.decls().get(1);
+        assertEquals("entry", first.annotations().get(0).name());
+        assertEquals("entry", second.annotations().get(0).name());
+    }
+
+    @Test
+    void testFuncWithoutAnnotationHasEmptyAnnotations() {
+        String input = """
+            Rule plain produce Text:
+              Return "ok".
+            """;
+
+        aster.core.ast.Module module = parseAndBuild(input);
+
+        Decl.Func func = (Decl.Func) module.decls().get(0);
+        assertNotNull(func.annotations());
+        assertTrue(func.annotations().isEmpty());
+    }
+
+    @Test
     void testEnumDeclaration() {
         String input = """
             Define Status as one of Success, Failure, Pending.

--- a/src/test/java/aster/core/typecheck/TypeCheckerIntegrationTest.java
+++ b/src/test/java/aster/core/typecheck/TypeCheckerIntegrationTest.java
@@ -124,6 +124,38 @@ class TypeCheckerIntegrationTest {
     assertTrue(diagnostics.isEmpty());
   }
 
+  @Test
+  void testSingleEntryAnnotationPasses() {
+    var main = createValidFunction("main");
+    main.annotations = List.of(createAnnotation("entry"));
+    var helper = createValidFunction("helper");
+
+    var module = new CoreModel.Module();
+    module.decls = List.of(main, helper);
+
+    var diagnostics = checker.typecheckModule(module);
+
+    assertTrue(diagnostics.isEmpty(), "Single @entry rule should be valid");
+  }
+
+  @Test
+  void testMultipleEntryAnnotationsProduceDiagnostic() {
+    var first = createValidFunction("first");
+    first.annotations = List.of(createAnnotation("entry"));
+    var second = createValidFunction("second");
+    second.annotations = List.of(createAnnotation("entry"));
+
+    var module = new CoreModel.Module();
+    module.decls = List.of(first, second);
+
+    var diagnostics = checker.typecheckModule(module);
+
+    assertEquals(1, diagnostics.size());
+    assertEquals(ErrorCode.MULTIPLE_ENTRY_RULES, diagnostics.get(0).code());
+    assertTrue(diagnostics.get(0).message().contains("first"));
+    assertTrue(diagnostics.get(0).message().contains("second"));
+  }
+
   // ========== 复杂场景测试 ==========
 
   @Test
@@ -537,6 +569,25 @@ class TypeCheckerIntegrationTest {
     module.decls = List.of(func);
 
     return module;
+  }
+
+  private CoreModel.Func createValidFunction(String name) {
+    var func = new CoreModel.Func();
+    func.name = name;
+    func.params = List.of();
+    func.ret = createTypeName("Int");
+    func.effects = List.of();
+
+    var body = new CoreModel.Block();
+    body.statements = List.of(createReturnStmt(createIntLiteral(1)));
+    func.body = body;
+    return func;
+  }
+
+  private CoreModel.Annotation createAnnotation(String name) {
+    var annotation = new CoreModel.Annotation();
+    annotation.name = name;
+    return annotation;
   }
 
   private CoreModel.Param createParam(String name, CoreModel.Type type) {


### PR DESCRIPTION
ADR 0015 阶段 2 — `@entry` 注解（aster-lang-core Java groundwork）。

## 目标

`@entry` 注解标记 Rule 为主入口，供 aster-api 入口选择器优先选中（接续阶段 1 PR aster-api#22）。

```aster
@entry
Rule approveLoan given application:
  ...

Rule helper given x, produce:
  Return x times 2.
```

## 改动

注解机制（`annotation` 规则、`AT` token、`visitAnnotation`）已全有，仅 `funcDecl` 开头缺 `annotation*`：

- **grammar**：`funcDecl: annotation* RULE nameIdent ...`（`annotation*` 新增；Rule 名 `IDENT|TYPE_IDENT` → `nameIdent`，与 param/Let 的标识符规则对齐）
- **AST**：`Decl.Func` 加 `annotations` 字段（参考 `Decl.Field` 模式），`AstBuilder.visitFuncDecl` 解析
- **Core IR**：`CoreModel.Func` 加 `annotations`，`CoreLowering` 透传（供 aster-api 读 `@entry`）
- **validator**：`TypeChecker` 加 `@entry` 唯一性校验 — 一个模块最多一个 `@entry` Rule，多于一个 → `MULTIPLE_ENTRY_RULES`

## 验证

- aster-lang-core 全量 **669 测试，0 失败**
- 新增测试：AstBuilder +67（@entry / 多注解 / 无注解回归 / 连续多 @entry funcDecl）、TypeCheckerIntegration +51（单/多 @entry）、CoreLowering +31（annotations 透传）、AstSerialization +8（round-trip）

## 范围说明

- grammar 改动触发 **tier1-parity gate** → aster-lang-ts 下一步同步对齐 `@entry` parse
- 软关键字（如 `second`=`SECONDS` 时间单位）做 Rule 名是独立既存限制，**不在本特性范围**（测试用例已避开）
- 严格收敛：仅 `funcDecl` 一行 grammar 改动；`block` 规则未动；`.tokens` 未手改（由 build 生成）

🤖 Generated with [Claude Code](https://claude.com/claude-code)