### PR TITLE
feat(grammar): Use ... version N clause (ADR 0015 phase 3b-1)

### DIFF
--- a/src/main/antlr/AsterLexer.g4
+++ b/src/main/antlr/AsterLexer.g4
@@ -123,6 +123,7 @@ OF: 'of';
 
 // 导入相关
 USE: 'Use' | 'use';
+VERSION: 'version';
 
 // 语句关键字
 LET: 'Let';

--- a/src/main/antlr/AsterParser.g4
+++ b/src/main/antlr/AsterParser.g4
@@ -167,6 +167,7 @@ nameIdent
     : IDENT
     | TYPE_IDENT
     | TYPE
+    | VERSION
     ;
 
 /**
@@ -194,9 +195,10 @@ variantList
  * 语法:
  *   Use io.Http.
  *   Use io.Http as HttpClient.
+ *   Use io.Http version 2 as HttpClient.
  */
 importDecl
-    : USE qualifiedName (AS importAlias)? DOT
+    : USE qualifiedName (VERSION INT_LITERAL)? (AS importAlias)? DOT
     ;
 
 /**

--- a/src/main/java/aster/core/ast/Decl.java
+++ b/src/main/java/aster/core/ast/Decl.java
@@ -26,12 +26,14 @@ public sealed interface Decl extends AstNode permits Decl.Import, Decl.Data, Dec
      * Import 导入声明
      *
      * @param path  模块路径（允许多段）
-     * @param alias 别名（可能为 null）
-     * @param span  源码位置信息
+     * @param version 钉住的模块版本（可能为 null）
+     * @param alias   别名（可能为 null）
+     * @param span    源码位置信息
      */
     @JsonTypeName("Import")
     record Import(
         @JsonProperty("path") String path,
+        @JsonProperty("version") Integer version,
         @JsonProperty("alias") String alias,
         @JsonProperty("span") Span span
     ) implements Decl {

--- a/src/main/java/aster/core/ir/CoreModel.java
+++ b/src/main/java/aster/core/ir/CoreModel.java
@@ -70,6 +70,7 @@ public final class CoreModel {
   @JsonTypeName("Import")
   public static final class Import implements Decl {
     public String path;     // 被导入模块路径
+    public Integer version; // 钉住的模块版本（可选）
     public String alias;    // 别名（可选，为 null 表示使用原名）
     public Origin origin;
   }

--- a/src/main/java/aster/core/lowering/CoreLowering.java
+++ b/src/main/java/aster/core/lowering/CoreLowering.java
@@ -67,6 +67,7 @@ public final class CoreLowering {
   private CoreModel.Import lowerImport(Decl.Import imp) {
     CoreModel.Import out = new CoreModel.Import();
     out.path = imp.path();
+    out.version = imp.version();
     out.alias = imp.alias();
     out.origin = spanToOrigin(imp.span());
     return out;

--- a/src/main/java/aster/core/parser/AstBuilder.java
+++ b/src/main/java/aster/core/parser/AstBuilder.java
@@ -433,6 +433,9 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
         if (ctx.TYPE() != null) {
             return ctx.TYPE().getText();
         }
+        if (ctx.VERSION() != null) {
+            return ctx.VERSION().getText();
+        }
         throw new IllegalStateException("无法解析 name 标识符");
     }
 
@@ -543,6 +546,9 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
     @Override
     public Decl.Import visitImportDecl(AsterParser.ImportDeclContext ctx) {
         String path = visitQualifiedName(ctx.qualifiedName());
+        Integer version = ctx.INT_LITERAL() == null
+            ? null
+            : Integer.parseInt(ctx.INT_LITERAL().getText());
         String alias = null;
         if (ctx.importAlias() != null) {
             AsterParser.ImportAliasContext aliasCtx = ctx.importAlias();
@@ -552,7 +558,7 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
                 alias = aliasCtx.IDENT().getText();
             }
         }
-        return new Decl.Import(path, alias, spanFrom(ctx));
+        return new Decl.Import(path, version, alias, spanFrom(ctx));
     }
 
     // ============================================================

--- a/src/test/java/aster/core/ast/AstSerializationTest.java
+++ b/src/test/java/aster/core/ast/AstSerializationTest.java
@@ -60,7 +60,7 @@ class AstSerializationTest {
     @Test
     void testImportDecl() throws Exception {
         // 创建 Import 声明
-        Decl.Import importDecl = new Decl.Import("std.io", null, createSpan(1, 1, 1, 15));
+        Decl.Import importDecl = new Decl.Import("std.io", 2, null, createSpan(1, 1, 1, 15));
 
         // 序列化
         String json = mapper.writeValueAsString(importDecl);
@@ -68,6 +68,7 @@ class AstSerializationTest {
         // 验证 JSON 格式
         assertTrue(json.contains("\"kind\":\"Import\""));
         assertTrue(json.contains("\"path\":\"std.io\""));
+        assertTrue(json.contains("\"version\":2"));
 
         // 反序列化
         Decl deserialized = mapper.readValue(json, Decl.class);
@@ -75,6 +76,7 @@ class AstSerializationTest {
         // 验证
         assertTrue(deserialized instanceof Decl.Import);
         assertEquals("std.io", ((Decl.Import) deserialized).path());
+        assertEquals(2, ((Decl.Import) deserialized).version());
     }
 
     @Test

--- a/src/test/java/aster/core/lowering/CoreLoweringTest.java
+++ b/src/test/java/aster/core/lowering/CoreLoweringTest.java
@@ -154,6 +154,7 @@ class CoreLoweringTest {
     void testLowerImport() {
         var importDecl = new Decl.Import(
             "std.io",
+            2,
             "IO",
             null
         );
@@ -164,6 +165,7 @@ class CoreLoweringTest {
 
         assertNotNull(importLowered);
         assertEquals("std.io", importLowered.path);
+        assertEquals(2, importLowered.version);
         assertEquals("IO", importLowered.alias);
     }
 

--- a/src/test/java/aster/core/parser/AstBuilderTest.java
+++ b/src/test/java/aster/core/parser/AstBuilderTest.java
@@ -590,29 +590,61 @@ class AstBuilderTest {
     @Test
     void parseImportWithoutAlias() {
         String input = """
-            Use data.List.
+            Use x.
             """;
 
         aster.core.ast.Module module = parseAndBuild(input);
 
         assertEquals(1, module.decls().size());
         Decl.Import importDecl = (Decl.Import) module.decls().get(0);
-        assertEquals("data.List", importDecl.path());
+        assertEquals("x", importDecl.path());
+        assertNull(importDecl.version());
         assertNull(importDecl.alias());
     }
 
     @Test
     void parseImportWithAlias() {
         String input = """
-            Use io.Http as HttpClient.
+            Use x as Y.
             """;
 
         aster.core.ast.Module module = parseAndBuild(input);
 
         assertEquals(1, module.decls().size());
         Decl.Import importDecl = (Decl.Import) module.decls().get(0);
-        assertEquals("io.Http", importDecl.path());
-        assertEquals("HttpClient", importDecl.alias());
+        assertEquals("x", importDecl.path());
+        assertNull(importDecl.version());
+        assertEquals("Y", importDecl.alias());
+    }
+
+    @Test
+    void parseImportWithVersionAndAlias() {
+        String input = """
+            Use x version 2 as Y.
+            """;
+
+        aster.core.ast.Module module = parseAndBuild(input);
+
+        assertEquals(1, module.decls().size());
+        Decl.Import importDecl = (Decl.Import) module.decls().get(0);
+        assertEquals("x", importDecl.path());
+        assertEquals(2, importDecl.version());
+        assertEquals("Y", importDecl.alias());
+    }
+
+    @Test
+    void parseImportWithVersionWithoutAlias() {
+        String input = """
+            Use x version 2.
+            """;
+
+        aster.core.ast.Module module = parseAndBuild(input);
+
+        assertEquals(1, module.decls().size());
+        Decl.Import importDecl = (Decl.Import) module.decls().get(0);
+        assertEquals("x", importDecl.path());
+        assertEquals(2, importDecl.version());
+        assertNull(importDecl.alias());
     }
 
     @Test
@@ -626,7 +658,22 @@ class AstBuilderTest {
         assertEquals(1, module.decls().size());
         Decl.Import importDecl = (Decl.Import) module.decls().get(0);
         assertEquals("a.b.c.D", importDecl.path());
+        assertNull(importDecl.version());
         assertNull(importDecl.alias());
+    }
+
+    @Test
+    void parseVersionAsRuleName() {
+        String input = """
+            Rule version produce Text:
+                Return "ok".
+            """;
+
+        aster.core.ast.Module module = parseAndBuild(input);
+
+        assertEquals(1, module.decls().size());
+        Decl.Func func = (Decl.Func) module.decls().get(0);
+        assertEquals("version", func.name());
     }
 
     @Test


### PR DESCRIPTION
ADR 0015 阶段 3b-1 — 跨模块钉版本引用的语法基础。

## 背景

阶段3 跨模块运行时需要钉版本：`Use risk.Scoring version 2 as Score.`。查证发现现有 grammar 的 `as v2` 中 `v2` 是命名别名（用于 `v2.computeScore` 调用前缀），无处表达版本号。本 PR 扩 grammar 让**版本号与命名别名分离**（用户决策）。

## 改动

- **lexer**：加 `VERSION` token（`'version'`）
- **grammar**：`importDecl: USE qualifiedName (VERSION INT_LITERAL)? (AS importAlias)? DOT`；`nameIdent` 加 `| VERSION`（软关键字——`version` 仍可作 Rule/字段名，避免阶段2 `SECONDS` 踩坑重演）
- **AST**：`Decl.Import` 加 `Integer version`（可空）；`CoreModel.Import` 加 `version`；`CoreLowering` 透传
- **AstBuilder**：解析 `INT_LITERAL` → version；nameIdent 处理 VERSION token

## 验证

- 全量 **672 测试 0 失败**（669 基线 + 3 新增）
- 含 `version` 作 Rule 名的软关键字回归测试
- 向后兼容：`Use x.` / `Use x as Y.` 无 version 仍解析，version=null
- 严格收敛：仅 grammar+AST+lowering+parse；`block` 规则未动；`.tokens` 未手改

## 范围

不含 linker/checkImport（PR-3b-3）。grammar 改动触发 **tier1-parity** → aster-lang-ts 下一步对齐 `version` 子句（现有 parity fixture 无 version，应 PASS）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)