### PR TITLE
feat(module): ModuleGraphLinker — merge + symbol rename (ADR 0015 phase 3b-3)

### DIFF
--- a/src/main/java/aster/core/module/LinkException.java
+++ b/src/main/java/aster/core/module/LinkException.java
@@ -1,0 +1,15 @@
+package aster.core.module;
+
+import java.io.Serial;
+
+/**
+ * Module graph 合并阶段的结构性错误。
+ */
+public final class LinkException extends RuntimeException {
+  @Serial
+  private static final long serialVersionUID = 1L;
+
+  public LinkException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/aster/core/module/LinkedProgram.java
+++ b/src/main/java/aster/core/module/LinkedProgram.java
@@ -1,0 +1,13 @@
+package aster.core.module;
+
+import aster.core.ir.CoreModel;
+import java.util.Map;
+
+/**
+ * Linker 输出：已合并的单 Module 与 mangled 名称追踪表。
+ *
+ * @param merged     可直接交给 Truffle loader 的 Core module
+ * @param traceNames mangled 顶层名 -> 原始 module.symbol
+ */
+public record LinkedProgram(CoreModel.Module merged, Map<String, String> traceNames) {
+}

--- a/src/main/java/aster/core/module/ModuleGraph.java
+++ b/src/main/java/aster/core/module/ModuleGraph.java
@@ -1,0 +1,112 @@
+package aster.core.module;
+
+import aster.core.ir.CoreModel;
+import java.util.*;
+
+/**
+ * aster-api 解析完成后传给 core linker 的纯数据模块图。
+ *
+ * @param root    入口模块 key
+ * @param modules 已解析模块，必须包含 root
+ * @param imports import 边：from 模块通过 alias 指向 to 模块
+ */
+public record ModuleGraph(
+  ModuleKey root,
+  Map<ModuleKey, CoreModel.Module> modules,
+  List<ImportEdge> imports
+) {
+
+  public ModuleGraph {
+    Objects.requireNonNull(root, "root");
+    modules = Map.copyOf(Objects.requireNonNull(modules, "modules"));
+    imports = List.copyOf(imports == null ? List.of() : imports);
+    if (!modules.containsKey(root)) {
+      throw new IllegalArgumentException("modules must contain root: " + root);
+    }
+    for (var edge : imports) {
+      if (!modules.containsKey(edge.fromKey())) {
+        throw new IllegalArgumentException("import edge fromKey is not in modules: " + edge.fromKey());
+      }
+      if (!modules.containsKey(edge.toKey())) {
+        throw new IllegalArgumentException("import edge toKey is not in modules: " + edge.toKey());
+      }
+    }
+  }
+
+  /**
+   * import 边。importAlias 是源码中的 alias；无 alias 时由 resolver 填入默认可见名。
+   */
+  public record ImportEdge(ModuleKey fromKey, String importAlias, ModuleKey toKey) {
+    public ImportEdge {
+      Objects.requireNonNull(fromKey, "fromKey");
+      Objects.requireNonNull(toKey, "toKey");
+      if (importAlias == null || importAlias.isBlank()) {
+        throw new IllegalArgumentException("importAlias must not be blank");
+      }
+    }
+  }
+
+  /**
+   * 返回依赖优先的拓扑序；检测到环时抛 LinkException。
+   */
+  public List<ModuleKey> topologicalOrder() {
+    var byFrom = new HashMap<ModuleKey, List<ModuleKey>>();
+    for (var edge : imports) {
+      byFrom.computeIfAbsent(edge.fromKey(), ignored -> new ArrayList<>()).add(edge.toKey());
+    }
+
+    var order = new ArrayList<ModuleKey>();
+    var state = new HashMap<ModuleKey, VisitState>();
+    var stack = new ArrayDeque<ModuleKey>();
+
+    for (var key : modules.keySet()) {
+      visit(key, byFrom, state, stack, order);
+    }
+    return List.copyOf(order);
+  }
+
+  public List<ImportEdge> importsFrom(ModuleKey key) {
+    return imports.stream()
+      .filter(edge -> edge.fromKey().equals(key))
+      .toList();
+  }
+
+  private void visit(
+    ModuleKey key,
+    Map<ModuleKey, List<ModuleKey>> byFrom,
+    Map<ModuleKey, VisitState> state,
+    Deque<ModuleKey> stack,
+    List<ModuleKey> order
+  ) {
+    var current = state.get(key);
+    if (current == VisitState.DONE) {
+      return;
+    }
+    if (current == VisitState.VISITING) {
+      var cycle = new ArrayList<String>();
+      for (var item : stack) {
+        cycle.add(item.moduleName() + "@" + item.version());
+        if (item.equals(key)) {
+          break;
+        }
+      }
+      Collections.reverse(cycle);
+      cycle.add(key.moduleName() + "@" + key.version());
+      throw new LinkException("Module import cycle detected: " + String.join(" -> ", cycle));
+    }
+
+    state.put(key, VisitState.VISITING);
+    stack.push(key);
+    for (var dep : byFrom.getOrDefault(key, List.of())) {
+      visit(dep, byFrom, state, stack, order);
+    }
+    stack.pop();
+    state.put(key, VisitState.DONE);
+    order.add(key);
+  }
+
+  private enum VisitState {
+    VISITING,
+    DONE
+  }
+}

--- a/src/main/java/aster/core/module/ModuleGraphLinker.java
+++ b/src/main/java/aster/core/module/ModuleGraphLinker.java
@@ -1,0 +1,444 @@
+package aster.core.module;
+
+import aster.core.ir.CoreModel;
+import java.util.*;
+
+/**
+ * 将已解析 module graph 合并成单 Core module，并重写跨模块顶层符号引用。
+ */
+public final class ModuleGraphLinker {
+
+  public LinkedProgram link(ModuleGraph graph) {
+    Objects.requireNonNull(graph, "graph");
+    if (graph.modules().size() == 1 && graph.imports().isEmpty()) {
+      return new LinkedProgram(graph.modules().get(graph.root()), Map.of());
+    }
+
+    var topLevelNames = collectTopLevelNames(graph.modules());
+    var renameMaps = buildRenameMaps(graph.root(), topLevelNames);
+    var traceNames = buildTraceNames(renameMaps);
+
+    for (var key : graph.topologicalOrder()) {
+      var module = graph.modules().get(key);
+      var rewriter = new SymbolRewriter(
+        key,
+        graph.importsFrom(key),
+        topLevelNames,
+        renameMaps.getOrDefault(key, Map.of())
+      );
+      rewriter.rewriteModule(module);
+    }
+
+    var merged = new CoreModel.Module();
+    merged.name = graph.modules().get(graph.root()).name;
+    merged.origin = graph.modules().get(graph.root()).origin;
+    merged.decls = new ArrayList<>();
+    for (var key : graph.topologicalOrder()) {
+      var module = graph.modules().get(key);
+      if (module.decls == null) {
+        continue;
+      }
+      for (var decl : module.decls) {
+        if (!(decl instanceof CoreModel.Import)) {
+          merged.decls.add(decl);
+        }
+      }
+    }
+
+    return new LinkedProgram(merged, Map.copyOf(traceNames));
+  }
+
+  private Map<ModuleKey, Set<String>> collectTopLevelNames(Map<ModuleKey, CoreModel.Module> modules) {
+    var result = new HashMap<ModuleKey, Set<String>>();
+    for (var entry : modules.entrySet()) {
+      var names = new HashSet<String>();
+      var decls = entry.getValue().decls;
+      if (decls != null) {
+        for (var decl : decls) {
+          switch (decl) {
+            case CoreModel.Func func -> names.add(func.name);
+            case CoreModel.Data data -> names.add(data.name);
+            case CoreModel.Enum enumDecl -> names.add(enumDecl.name);
+            case CoreModel.Import ignored -> {
+            }
+          }
+        }
+      }
+      names.remove(null);
+      result.put(entry.getKey(), Set.copyOf(names));
+    }
+    return Map.copyOf(result);
+  }
+
+  private Map<ModuleKey, Map<String, String>> buildRenameMaps(
+    ModuleKey root,
+    Map<ModuleKey, Set<String>> topLevelNames
+  ) {
+    var result = new HashMap<ModuleKey, Map<String, String>>();
+    for (var entry : topLevelNames.entrySet()) {
+      var key = entry.getKey();
+      if (key.equals(root)) {
+        result.put(key, Map.of());
+        continue;
+      }
+      var rename = new HashMap<String, String>();
+      for (var name : entry.getValue()) {
+        rename.put(name, key.mangle() + name);
+      }
+      result.put(key, Map.copyOf(rename));
+    }
+    return Map.copyOf(result);
+  }
+
+  private Map<String, String> buildTraceNames(Map<ModuleKey, Map<String, String>> renameMaps) {
+    var trace = new LinkedHashMap<String, String>();
+    for (var entry : renameMaps.entrySet()) {
+      for (var rename : entry.getValue().entrySet()) {
+        trace.put(rename.getValue(), entry.getKey().moduleName() + "." + rename.getKey());
+      }
+    }
+    return trace;
+  }
+
+  private static final class SymbolRewriter {
+    private final ModuleKey currentKey;
+    private final Map<String, ModuleKey> importsByAlias;
+    private final Map<ModuleKey, Set<String>> topLevelNames;
+    private final Map<String, String> currentRenames;
+    private final Deque<Set<String>> localScopes = new ArrayDeque<>();
+
+    SymbolRewriter(
+      ModuleKey currentKey,
+      List<ModuleGraph.ImportEdge> imports,
+      Map<ModuleKey, Set<String>> topLevelNames,
+      Map<String, String> currentRenames
+    ) {
+      this.currentKey = currentKey;
+      this.topLevelNames = topLevelNames;
+      this.currentRenames = currentRenames;
+      var aliases = new HashMap<String, ModuleKey>();
+      for (var edge : imports) {
+        aliases.put(edge.importAlias(), edge.toKey());
+      }
+      this.importsByAlias = Map.copyOf(aliases);
+    }
+
+    void rewriteModule(CoreModel.Module module) {
+      if (module == null || module.decls == null) {
+        return;
+      }
+      for (var decl : module.decls) {
+        rewriteDecl(decl);
+      }
+    }
+
+    private void rewriteDecl(CoreModel.Decl decl) {
+      switch (decl) {
+        case CoreModel.Func func -> {
+          func.name = rewriteCurrentTopLevelName(func.name);
+          withScope(paramNames(func.params), () -> {
+            rewriteParams(func.params);
+            rewriteType(func.ret);
+            rewriteBlock(func.body);
+          });
+        }
+        case CoreModel.Data data -> {
+          data.name = rewriteCurrentTopLevelName(data.name);
+          if (data.fields != null) {
+            for (var field : data.fields) {
+              rewriteType(field.type);
+            }
+          }
+        }
+        case CoreModel.Enum enumDecl -> enumDecl.name = rewriteCurrentTopLevelName(enumDecl.name);
+        case CoreModel.Import ignored -> {
+        }
+      }
+    }
+
+    private void rewriteParams(List<CoreModel.Param> params) {
+      if (params == null) {
+        return;
+      }
+      for (var param : params) {
+        rewriteType(param.type);
+      }
+    }
+
+    private void rewriteType(CoreModel.Type type) {
+      if (type == null) {
+        return;
+      }
+      switch (type) {
+        case CoreModel.TypeName typeName -> typeName.name = rewriteSymbolName(typeName.name, false);
+        case CoreModel.TypeVar ignored -> {
+        }
+        case CoreModel.TypeApp typeApp -> {
+          typeApp.base = rewriteSymbolName(typeApp.base, false);
+          rewriteTypes(typeApp.args);
+        }
+        case CoreModel.Result result -> {
+          rewriteType(result.ok);
+          rewriteType(result.err);
+        }
+        case CoreModel.Maybe maybe -> rewriteType(maybe.type);
+        case CoreModel.Option option -> rewriteType(option.type);
+        case CoreModel.ListT list -> rewriteType(list.type);
+        case CoreModel.MapT map -> {
+          rewriteType(map.key);
+          rewriteType(map.val);
+        }
+        case CoreModel.FuncType funcType -> {
+          rewriteTypes(funcType.params);
+          rewriteType(funcType.ret);
+        }
+        case CoreModel.PiiType pii -> rewriteType(pii.baseType);
+      }
+    }
+
+    private void rewriteTypes(List<CoreModel.Type> types) {
+      if (types == null) {
+        return;
+      }
+      for (var type : types) {
+        rewriteType(type);
+      }
+    }
+
+    private void rewriteStmt(CoreModel.Stmt stmt) {
+      if (stmt == null) {
+        return;
+      }
+      switch (stmt) {
+        case CoreModel.Let let -> {
+          rewriteExpr(let.expr);
+          addLocal(let.name);
+        }
+        case CoreModel.Set set -> rewriteExpr(set.expr);
+        case CoreModel.Return ret -> rewriteExpr(ret.expr);
+        case CoreModel.If ifStmt -> {
+          rewriteExpr(ifStmt.cond);
+          rewriteBlock(ifStmt.thenBlock);
+          rewriteBlock(ifStmt.elseBlock);
+        }
+        case CoreModel.Match match -> {
+          rewriteExpr(match.expr);
+          if (match.cases != null) {
+            for (var kase : match.cases) {
+              rewriteCase(kase);
+            }
+          }
+        }
+        case CoreModel.Scope scope -> withScope(Set.of(), () -> rewriteStatements(scope.statements));
+        case CoreModel.Block block -> rewriteBlock(block);
+        case CoreModel.Start start -> rewriteExpr(start.expr);
+        case CoreModel.Wait ignored -> {
+          // wait names 是本地任务名，不参与顶层符号重命名。
+        }
+        case CoreModel.Workflow workflow -> {
+          if (workflow.steps != null) {
+            for (var step : workflow.steps) {
+              rewriteBlock(step.body);
+              rewriteBlock(step.compensate);
+            }
+          }
+        }
+      }
+    }
+
+    private void rewriteCase(CoreModel.Case kase) {
+      if (kase == null) {
+        return;
+      }
+      var binders = new HashSet<String>();
+      rewritePattern(kase.pattern, binders);
+      withScope(binders, () -> rewriteStmt(kase.body));
+    }
+
+    private void rewritePattern(CoreModel.Pattern pattern, Set<String> binders) {
+      if (pattern == null) {
+        return;
+      }
+      switch (pattern) {
+        case CoreModel.PatNull ignored -> {
+        }
+        case CoreModel.PatCtor ctor -> {
+          ctor.typeName = rewriteSymbolName(ctor.typeName, false);
+          if (ctor.args != null) {
+            for (var arg : ctor.args) {
+              rewritePattern(arg, binders);
+            }
+          }
+          if (ctor.names != null) {
+            binders.addAll(ctor.names);
+          }
+        }
+        case CoreModel.PatName name -> {
+          if (name.name != null) {
+            binders.add(name.name);
+          }
+        }
+        case CoreModel.PatInt ignored -> {
+        }
+      }
+    }
+
+    private void rewriteBlock(CoreModel.Block block) {
+      if (block == null) {
+        return;
+      }
+      withScope(Set.of(), () -> rewriteStatements(block.statements));
+    }
+
+    private void rewriteStatements(List<CoreModel.Stmt> statements) {
+      if (statements == null) {
+        return;
+      }
+      for (var stmt : statements) {
+        rewriteStmt(stmt);
+      }
+    }
+
+    private void rewriteExpr(CoreModel.Expr expr) {
+      if (expr == null) {
+        return;
+      }
+      switch (expr) {
+        case CoreModel.Name name -> {
+          if (!isLocal(name.name)) {
+            name.name = rewriteSymbolName(name.name, true);
+          }
+        }
+        case CoreModel.Bool ignored -> {
+        }
+        case CoreModel.IntE ignored -> {
+        }
+        case CoreModel.LongE ignored -> {
+        }
+        case CoreModel.DoubleE ignored -> {
+        }
+        case CoreModel.StringE ignored -> {
+        }
+        case CoreModel.NullE ignored -> {
+        }
+        case CoreModel.Ok ok -> rewriteExpr(ok.expr);
+        case CoreModel.Err err -> rewriteExpr(err.expr);
+        case CoreModel.Some some -> rewriteExpr(some.expr);
+        case CoreModel.NoneE ignored -> {
+        }
+        case CoreModel.Construct construct -> {
+          construct.typeName = rewriteSymbolName(construct.typeName, false);
+          if (construct.fields != null) {
+            for (var field : construct.fields) {
+              rewriteExpr(field.expr);
+            }
+          }
+        }
+        case CoreModel.Call call -> {
+          rewriteExpr(call.target);
+          if (call.args != null) {
+            for (var arg : call.args) {
+              rewriteExpr(arg);
+            }
+          }
+        }
+        case CoreModel.Lambda lambda -> withScope(paramNames(lambda.params), () -> {
+          rewriteParams(lambda.params);
+          rewriteType(lambda.ret);
+          rewriteBlock(lambda.body);
+          // captures 是局部闭包变量名，不参与顶层符号重命名。
+        });
+        case CoreModel.Await await -> rewriteExpr(await.expr);
+      }
+    }
+
+    private String rewriteSymbolName(String name, boolean allowUnqualifiedImport) {
+      if (name == null) {
+        return null;
+      }
+      var dot = name.indexOf('.');
+      if (dot > 0 && dot < name.length() - 1) {
+        var alias = name.substring(0, dot);
+        var symbol = name.substring(dot + 1);
+        var toKey = importsByAlias.get(alias);
+        if (toKey != null) {
+          return toKey.mangle() + symbol;
+        }
+      }
+
+      var localRename = currentRenames.get(name);
+      if (localRename != null) {
+        return localRename;
+      }
+
+      if (allowUnqualifiedImport) {
+        var imported = findImportedTopLevel(name);
+        if (imported != null) {
+          return imported.mangle() + name;
+        }
+      }
+
+      return name;
+    }
+
+    private ModuleKey findImportedTopLevel(String name) {
+      if (topLevelNames.getOrDefault(currentKey, Set.of()).contains(name)) {
+        return null;
+      }
+      ModuleKey found = null;
+      for (var toKey : importsByAlias.values()) {
+        if (topLevelNames.getOrDefault(toKey, Set.of()).contains(name)) {
+          if (found != null && !found.equals(toKey)) {
+            return null;
+          }
+          found = toKey;
+        }
+      }
+      return found;
+    }
+
+    private String rewriteCurrentTopLevelName(String name) {
+      return currentRenames.getOrDefault(name, name);
+    }
+
+    private Set<String> paramNames(List<CoreModel.Param> params) {
+      if (params == null || params.isEmpty()) {
+        return Set.of();
+      }
+      var names = new HashSet<String>();
+      for (var param : params) {
+        if (param.name != null) {
+          names.add(param.name);
+        }
+      }
+      return names;
+    }
+
+    private void withScope(Set<String> initialNames, Runnable action) {
+      localScopes.push(new HashSet<>(initialNames));
+      try {
+        action.run();
+      } finally {
+        localScopes.pop();
+      }
+    }
+
+    private void addLocal(String name) {
+      if (name != null && !localScopes.isEmpty()) {
+        localScopes.peek().add(name);
+      }
+    }
+
+    private boolean isLocal(String name) {
+      if (name == null) {
+        return false;
+      }
+      for (var scope : localScopes) {
+        if (scope.contains(name)) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+}

--- a/src/main/java/aster/core/module/ModuleKey.java
+++ b/src/main/java/aster/core/module/ModuleKey.java
@@ -1,0 +1,23 @@
+package aster.core.module;
+
+/**
+ * 已解析模块的稳定标识。
+ *
+ * @param moduleName 模块全名
+ * @param version    钉住版本
+ */
+public record ModuleKey(String moduleName, int version) {
+
+  public ModuleKey {
+    if (moduleName == null || moduleName.isBlank()) {
+      throw new IllegalArgumentException("moduleName must not be blank");
+    }
+  }
+
+  /**
+   * 生成合并后顶层符号的前缀，例如 risk.Scoring v2 -> risk_Scoring_v2__。
+   */
+  public String mangle() {
+    return moduleName.replace('.', '_') + "_v" + version + "__";
+  }
+}

--- a/src/main/java/aster/core/typecheck/ErrorCode.java
+++ b/src/main/java/aster/core/typecheck/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
   DUPLICATE_IMPORT_ALIAS("E100", Category.SCOPE, Severity.WARNING, "Duplicate import alias '%s'.", "为不同的导入使用唯一别名，避免覆盖。"),
   UNDEFINED_VARIABLE("E101", Category.SCOPE, Severity.ERROR, "Undefined variable: %s", "在使用变量前先声明并初始化。"),
   MULTIPLE_ENTRY_RULES("E102", Category.SCOPE, Severity.ERROR, "Multiple @entry rules in module: {rules}", "每个模块最多保留一个 @entry Rule。"),
+  IMPORT_SYMBOL_CONFLICT("E103", Category.SCOPE, Severity.WARNING, "Import symbol conflict: {symbol}", "调整 import alias 或本地顶层声明名称，避免导入符号冲突。"),
   EFF_MISSING_IO("E200", Category.EFFECT, Severity.ERROR, "Function '%s' may perform I/O but is missing @io effect.", "为具有 IO 行为的函数声明 @io 效果。"),
   EFF_MISSING_CPU("E201", Category.EFFECT, Severity.ERROR, "Function '%s' may perform CPU-bound work but is missing @cpu (or @io) effect.", "为 CPU 密集型函数声明 @cpu 或 @io 效果。"),
   EFF_SUPERFLUOUS_IO_CPU_ONLY("E202", Category.EFFECT, Severity.INFO, "Function '%s' declares @io but only CPU-like work found; @io subsumes @cpu and may be unnecessary.", "若函数仅执行 CPU 工作，可移除多余的 @io 声明。"),

--- a/src/main/java/aster/core/typecheck/TypeChecker.java
+++ b/src/main/java/aster/core/typecheck/TypeChecker.java
@@ -41,6 +41,8 @@ public final class TypeChecker {
   private final AsyncDisciplineChecker asyncChecker;
   private final PiiTypeChecker piiChecker;
   private final CapabilityChecker capabilityChecker;
+  private final java.util.Set<String> importAliases = new HashSet<>();
+  private final java.util.Set<String> moduleTopLevelNames = new HashSet<>();
 
   // ========== 构造器 ==========
 
@@ -72,6 +74,8 @@ public final class TypeChecker {
       return List.of();
     }
     diagnostics.clear();
+    importAliases.clear();
+    moduleTopLevelNames.clear();
     symbolTable.enterScope(SymbolTable.ScopeType.MODULE);
 
     try {
@@ -80,6 +84,7 @@ public final class TypeChecker {
 
       // 第一遍：收集类型定义
       collectTypeDefinitions(module);
+      collectTopLevelNames(module);
       validateEntryAnnotations(module);
 
       // 【修复】注入类型别名映射，使下游检查器可以展开别名
@@ -285,8 +290,57 @@ public final class TypeChecker {
    * 检查导入声明
    */
   private void checkImport(CoreModel.Import imp) {
-    // 导入检查暂时简化：仅记录模块路径
-    // 完整实现需要模块解析和符号导入
+    // TypeChecker 当前只看到单个 CoreModel.Module，没有 aster-api 解析后的
+    // ModuleGraph，因此不能验证外部模块存在性或导出符号集合。这里先做本模块
+    // 内可确定的轻量冲突检查；跨模块符号解析留给 ModuleResolver/linker 集成强化。
+    var visibleName = importVisibleName(imp);
+    if (visibleName == null || visibleName.isBlank()) {
+      return;
+    }
+    if (!importAliases.add(visibleName)) {
+      diagnostics.warning(
+        ErrorCode.IMPORT_SYMBOL_CONFLICT,
+        Optional.ofNullable(imp.origin),
+        Map.of("symbol", visibleName, "reason", "duplicate import alias")
+      );
+    }
+    if (moduleTopLevelNames.contains(visibleName)) {
+      diagnostics.warning(
+        ErrorCode.IMPORT_SYMBOL_CONFLICT,
+        Optional.ofNullable(imp.origin),
+        Map.of("symbol", visibleName, "reason", "conflicts with local top-level declaration")
+      );
+    }
+  }
+
+  private void collectTopLevelNames(CoreModel.Module module) {
+    if (module == null || module.decls == null) {
+      return;
+    }
+    for (var decl : module.decls) {
+      switch (decl) {
+        case CoreModel.Func func -> moduleTopLevelNames.add(func.name);
+        case CoreModel.Data data -> moduleTopLevelNames.add(data.name);
+        case CoreModel.Enum enumDecl -> moduleTopLevelNames.add(enumDecl.name);
+        case CoreModel.Import ignored -> {
+        }
+      }
+    }
+    moduleTopLevelNames.remove(null);
+  }
+
+  private String importVisibleName(CoreModel.Import imp) {
+    if (imp == null) {
+      return null;
+    }
+    if (imp.alias != null && !imp.alias.isBlank()) {
+      return imp.alias;
+    }
+    if (imp.path == null || imp.path.isBlank()) {
+      return null;
+    }
+    var dot = imp.path.lastIndexOf('.');
+    return dot >= 0 && dot < imp.path.length() - 1 ? imp.path.substring(dot + 1) : imp.path;
   }
 
   /**

--- a/src/test/java/aster/core/module/ModuleGraphLinkerTest.java
+++ b/src/test/java/aster/core/module/ModuleGraphLinkerTest.java
@@ -1,0 +1,389 @@
+package aster.core.module;
+
+import aster.core.ir.CoreModel;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ModuleGraphLinkerTest {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  void singleModuleWithoutImportsIsIdentity() {
+    var rootKey = new ModuleKey("app", 1);
+    var root = module("app", List.of(func("main", ret(name("x")))));
+    var graph = new ModuleGraph(rootKey, Map.of(rootKey, root), List.of());
+
+    var linked = new ModuleGraphLinker().link(graph);
+
+    assertSame(root, linked.merged());
+    assertTrue(linked.traceNames().isEmpty());
+  }
+
+  @Test
+  void twoModulesRewriteDottedAliasCallAndMergeWithoutImports() {
+    var rootKey = new ModuleKey("app", 1);
+    var libKey = new ModuleKey("lib", 1);
+    var root = module("app", List.of(importDecl("lib", 1, "L"), func("main", ret(call("L.f")))));
+    var lib = module("lib", List.of(func("f", ret(intE(1)))));
+    var graph = graph(rootKey, root, libKey, lib);
+
+    var linked = new ModuleGraphLinker().link(graph);
+
+    assertEquals("app", linked.merged().name);
+    assertEquals(2, linked.merged().decls.size());
+    assertEquals("lib_v1__f", ((CoreModel.Func) linked.merged().decls.get(0)).name);
+    var main = (CoreModel.Func) linked.merged().decls.get(1);
+    assertEquals("lib_v1__f", callTargetName(returnExpr(main)));
+    assertEquals("lib.f", linked.traceNames().get("lib_v1__f"));
+  }
+
+  @Test
+  void importedTopLevelConflictIsRenamedAway() {
+    var rootKey = new ModuleKey("app", 1);
+    var libKey = new ModuleKey("lib", 1);
+    var root = module("app", List.of(func("helper", ret(intE(1)))));
+    var lib = module("lib", List.of(func("helper", ret(intE(2)))));
+    var graph = new ModuleGraph(
+      rootKey,
+      Map.of(rootKey, root, libKey, lib),
+      List.of(new ModuleGraph.ImportEdge(rootKey, "L", libKey))
+    );
+
+    var linked = new ModuleGraphLinker().link(graph);
+
+    var names = linked.merged().decls.stream()
+      .map(CoreModel.Func.class::cast)
+      .map(func -> func.name)
+      .toList();
+    assertEquals(List.of("lib_v1__helper", "helper"), names);
+  }
+
+  @Test
+  void rewritesDottedAliasTypeConstructAndPatternReferences() {
+    var rootKey = new ModuleKey("app", 1);
+    var libKey = new ModuleKey("lib", 1);
+    var user = data("User", field("name", typeName("String")));
+    var make = func("make", ret(construct("L.User", fieldInit("name", stringE("Ada")))));
+    make.ret = typeName("L.User");
+    var match = func("matchUser", ret(intE(0)));
+    match.body = block(matchStmt(name("u"), kase(patCtor("L.User", patName("x")), ret(name("x")))));
+    var root = module("app", List.of(importDecl("lib", 1, "L"), make, match));
+    var lib = module("lib", List.of(user));
+    var graph = graph(rootKey, root, libKey, lib);
+
+    var linked = new ModuleGraphLinker().link(graph);
+
+    var makeOut = (CoreModel.Func) linked.merged().decls.get(1);
+    assertEquals("lib_v1__User", ((CoreModel.TypeName) makeOut.ret).name);
+    assertEquals("lib_v1__User", ((CoreModel.Construct) returnExpr(makeOut)).typeName);
+    var matchOut = (CoreModel.Func) linked.merged().decls.get(2);
+    var matchStmt = (CoreModel.Match) matchOut.body.statements.get(0);
+    assertEquals("lib_v1__User", ((CoreModel.PatCtor) matchStmt.cases.get(0).pattern).typeName);
+    assertEquals("x", ((CoreModel.Name) ((CoreModel.Return) matchStmt.cases.get(0).body).expr).name);
+  }
+
+  @Test
+  void rewritesNestedLambdaMatchIfWorkflowAndWrapperExpressions() throws Exception {
+    var rootKey = new ModuleKey("app", 1);
+    var libKey = new ModuleKey("lib", 1);
+    var nested = func("nested", ret(new CoreModel.NoneE()));
+    nested.ret = option(typeName("L.Box"));
+    nested.body = block(
+      let("local", name("L.f")),
+      ret(lambda(
+        List.of(param("f", funcType(List.of(typeName("L.Box")), typeName("L.Box")))),
+        option(typeApp("L.Box", typeName("String"))),
+        block(
+          ifStmt(call("L.pred"), block(ret(ok(call("L.f")))), block(ret(err(call("L.g"))))),
+          matchStmt(await(some(call("L.f"))), kase(patCtor("L.Box", patName("value")), ret(name("value")))),
+          start("task", call("L.f")),
+          waitStmt("task"),
+          workflow(block(ret(construct("L.Box", fieldInit("value", call("L.f"))))))
+        )
+      ))
+    );
+    var root = module("app", List.of(importDecl("lib", 1, "L"), nested));
+    var lib = module("lib", List.of(data("Box", field("value", typeName("String"))), func("f", ret(intE(1))), func("g", ret(intE(2))), func("pred", ret(boolE(true)))));
+
+    var linked = new ModuleGraphLinker().link(graph(rootKey, root, libKey, lib));
+    var json = MAPPER.writeValueAsString(linked.merged());
+
+    assertFalse(json.contains("L.f"));
+    assertFalse(json.contains("L.g"));
+    assertFalse(json.contains("L.pred"));
+    assertFalse(json.contains("L.Box"));
+    assertTrue(json.contains("lib_v1__f"));
+    assertTrue(json.contains("lib_v1__g"));
+    assertTrue(json.contains("lib_v1__pred"));
+    assertTrue(json.contains("lib_v1__Box"));
+
+    var nestedOut = (CoreModel.Func) linked.merged().decls.get(4);
+    assertEquals("local", ((CoreModel.Let) nestedOut.body.statements.get(0)).name);
+    var lambda = (CoreModel.Lambda) ((CoreModel.Return) nestedOut.body.statements.get(1)).expr;
+    assertEquals("f", lambda.params.get(0).name);
+    var matchPattern = (CoreModel.PatCtor) ((CoreModel.Match) lambda.body.statements.get(1)).cases.get(0).pattern;
+    assertEquals("value", ((CoreModel.PatName) matchPattern.args.get(0)).name);
+  }
+
+  @Test
+  void detectsImportCycles() {
+    var a = new ModuleKey("a", 1);
+    var b = new ModuleKey("b", 1);
+    var graph = new ModuleGraph(
+      a,
+      Map.of(a, module("a", List.of()), b, module("b", List.of())),
+      List.of(new ModuleGraph.ImportEdge(a, "B", b), new ModuleGraph.ImportEdge(b, "A", a))
+    );
+
+    assertThrows(LinkException.class, graph::topologicalOrder);
+  }
+
+  private ModuleGraph graph(ModuleKey rootKey, CoreModel.Module root, ModuleKey libKey, CoreModel.Module lib) {
+    return new ModuleGraph(
+      rootKey,
+      Map.of(rootKey, root, libKey, lib),
+      List.of(new ModuleGraph.ImportEdge(rootKey, "L", libKey))
+    );
+  }
+
+  private CoreModel.Module module(String name, List<CoreModel.Decl> decls) {
+    var module = new CoreModel.Module();
+    module.name = name;
+    module.decls = decls;
+    return module;
+  }
+
+  private CoreModel.Import importDecl(String path, int version, String alias) {
+    var imp = new CoreModel.Import();
+    imp.path = path;
+    imp.version = version;
+    imp.alias = alias;
+    return imp;
+  }
+
+  private CoreModel.Func func(String name, CoreModel.Stmt... statements) {
+    var func = new CoreModel.Func();
+    func.name = name;
+    func.params = List.of();
+    func.typeParams = List.of();
+    func.ret = typeName("Int");
+    func.effects = List.of();
+    func.body = block(statements);
+    return func;
+  }
+
+  private CoreModel.Data data(String name, CoreModel.Field... fields) {
+    var data = new CoreModel.Data();
+    data.name = name;
+    data.fields = List.of(fields);
+    return data;
+  }
+
+  private CoreModel.Field field(String name, CoreModel.Type type) {
+    var field = new CoreModel.Field();
+    field.name = name;
+    field.type = type;
+    return field;
+  }
+
+  private CoreModel.Param param(String name, CoreModel.Type type) {
+    var param = new CoreModel.Param();
+    param.name = name;
+    param.type = type;
+    return param;
+  }
+
+  private CoreModel.Block block(CoreModel.Stmt... statements) {
+    var block = new CoreModel.Block();
+    block.statements = List.of(statements);
+    return block;
+  }
+
+  private CoreModel.Return ret(CoreModel.Expr expr) {
+    var ret = new CoreModel.Return();
+    ret.expr = expr;
+    return ret;
+  }
+
+  private CoreModel.Let let(String local, CoreModel.Expr expr) {
+    var let = new CoreModel.Let();
+    let.name = local;
+    let.expr = expr;
+    return let;
+  }
+
+  private CoreModel.If ifStmt(CoreModel.Expr cond, CoreModel.Block thenBlock, CoreModel.Block elseBlock) {
+    var stmt = new CoreModel.If();
+    stmt.cond = cond;
+    stmt.thenBlock = thenBlock;
+    stmt.elseBlock = elseBlock;
+    return stmt;
+  }
+
+  private CoreModel.Match matchStmt(CoreModel.Expr expr, CoreModel.Case... cases) {
+    var match = new CoreModel.Match();
+    match.expr = expr;
+    match.cases = List.of(cases);
+    return match;
+  }
+
+  private CoreModel.Case kase(CoreModel.Pattern pattern, CoreModel.Stmt body) {
+    var kase = new CoreModel.Case();
+    kase.pattern = pattern;
+    kase.body = body;
+    return kase;
+  }
+
+  private CoreModel.Start start(String task, CoreModel.Expr expr) {
+    var start = new CoreModel.Start();
+    start.name = task;
+    start.expr = expr;
+    return start;
+  }
+
+  private CoreModel.Wait waitStmt(String... tasks) {
+    var wait = new CoreModel.Wait();
+    wait.names = List.of(tasks);
+    return wait;
+  }
+
+  private CoreModel.Workflow workflow(CoreModel.Block body) {
+    var workflow = new CoreModel.Workflow();
+    var step = new CoreModel.Step();
+    step.name = "step";
+    step.body = body;
+    step.compensate = block(ret(call("L.g")));
+    workflow.steps = List.of(step);
+    return workflow;
+  }
+
+  private CoreModel.PatCtor patCtor(String typeName, CoreModel.Pattern... args) {
+    var pat = new CoreModel.PatCtor();
+    pat.typeName = typeName;
+    pat.names = List.of();
+    pat.args = List.of(args);
+    return pat;
+  }
+
+  private CoreModel.PatName patName(String name) {
+    var pat = new CoreModel.PatName();
+    pat.name = name;
+    return pat;
+  }
+
+  private CoreModel.Name name(String name) {
+    var expr = new CoreModel.Name();
+    expr.name = name;
+    return expr;
+  }
+
+  private CoreModel.Call call(String target, CoreModel.Expr... args) {
+    var call = new CoreModel.Call();
+    call.target = name(target);
+    call.args = List.of(args);
+    return call;
+  }
+
+  private CoreModel.Lambda lambda(List<CoreModel.Param> params, CoreModel.Type ret, CoreModel.Block body) {
+    var lambda = new CoreModel.Lambda();
+    lambda.params = params;
+    lambda.ret = ret;
+    lambda.body = body;
+    lambda.captures = List.of();
+    return lambda;
+  }
+
+  private CoreModel.Await await(CoreModel.Expr expr) {
+    var await = new CoreModel.Await();
+    await.expr = expr;
+    return await;
+  }
+
+  private CoreModel.Ok ok(CoreModel.Expr expr) {
+    var ok = new CoreModel.Ok();
+    ok.expr = expr;
+    return ok;
+  }
+
+  private CoreModel.Err err(CoreModel.Expr expr) {
+    var err = new CoreModel.Err();
+    err.expr = expr;
+    return err;
+  }
+
+  private CoreModel.Some some(CoreModel.Expr expr) {
+    var some = new CoreModel.Some();
+    some.expr = expr;
+    return some;
+  }
+
+  private CoreModel.Construct construct(String typeName, CoreModel.FieldInit... fields) {
+    var construct = new CoreModel.Construct();
+    construct.typeName = typeName;
+    construct.fields = List.of(fields);
+    return construct;
+  }
+
+  private CoreModel.FieldInit fieldInit(String name, CoreModel.Expr expr) {
+    var field = new CoreModel.FieldInit();
+    field.name = name;
+    field.expr = expr;
+    return field;
+  }
+
+  private CoreModel.TypeName typeName(String name) {
+    var type = new CoreModel.TypeName();
+    type.name = name;
+    return type;
+  }
+
+  private CoreModel.TypeApp typeApp(String base, CoreModel.Type... args) {
+    var type = new CoreModel.TypeApp();
+    type.base = base;
+    type.args = List.of(args);
+    return type;
+  }
+
+  private CoreModel.Option option(CoreModel.Type type) {
+    var option = new CoreModel.Option();
+    option.type = type;
+    return option;
+  }
+
+  private CoreModel.FuncType funcType(List<CoreModel.Type> params, CoreModel.Type ret) {
+    var type = new CoreModel.FuncType();
+    type.params = params;
+    type.ret = ret;
+    return type;
+  }
+
+  private CoreModel.IntE intE(int value) {
+    var expr = new CoreModel.IntE();
+    expr.value = value;
+    return expr;
+  }
+
+  private CoreModel.Bool boolE(boolean value) {
+    var expr = new CoreModel.Bool();
+    expr.value = value;
+    return expr;
+  }
+
+  private CoreModel.StringE stringE(String value) {
+    var expr = new CoreModel.StringE();
+    expr.value = value;
+    return expr;
+  }
+
+  private CoreModel.Expr returnExpr(CoreModel.Func func) {
+    return ((CoreModel.Return) func.body.statements.get(0)).expr;
+  }
+
+  private String callTargetName(CoreModel.Expr expr) {
+    return ((CoreModel.Name) ((CoreModel.Call) expr).target).name;
+  }
+}

--- a/src/test/java/aster/core/typecheck/TypeCheckerIntegrationTest.java
+++ b/src/test/java/aster/core/typecheck/TypeCheckerIntegrationTest.java
@@ -156,6 +156,43 @@ class TypeCheckerIntegrationTest {
     assertTrue(diagnostics.get(0).message().contains("second"));
   }
 
+  @Test
+  void testImportAliasConflictProducesDiagnostic() {
+    var imp = new CoreModel.Import();
+    imp.path = "lib";
+    imp.version = 1;
+    imp.alias = "helper";
+    var helper = createValidFunction("helper");
+
+    var module = new CoreModel.Module();
+    module.decls = List.of(imp, helper);
+
+    var diagnostics = checker.typecheckModule(module);
+
+    assertTrue(diagnostics.stream()
+      .anyMatch(d -> d.code() == ErrorCode.IMPORT_SYMBOL_CONFLICT));
+  }
+
+  @Test
+  void testDuplicateImportAliasProducesDiagnostic() {
+    var first = new CoreModel.Import();
+    first.path = "lib.one";
+    first.version = 1;
+    first.alias = "Lib";
+    var second = new CoreModel.Import();
+    second.path = "lib.two";
+    second.version = 1;
+    second.alias = "Lib";
+
+    var module = new CoreModel.Module();
+    module.decls = List.of(first, second);
+
+    var diagnostics = checker.typecheckModule(module);
+
+    assertTrue(diagnostics.stream()
+      .anyMatch(d -> d.code() == ErrorCode.IMPORT_SYMBOL_CONFLICT));
+  }
+
   // ========== 复杂场景测试 ==========
 
   @Test


### PR DESCRIPTION
ADR 0015 阶段 3b-3 — 跨模块运行时核心：module graph 合并 + 符号重命名。

## 目标

把已解析的多模块 Core IR（由 aster-api ModuleResolver 从 DB 构建，纯数据）拓扑序合并成单 `CoreModel.Module`，符号前缀重命名避冲突 + 改写所有跨模块引用。aster-lang-truffle 消费单个合并 Module（`Loader.java:45` 假设 Import 已展开）。

## 改动

新增 `aster.core.module` 包：
- `ModuleKey(moduleName, version)`：`mangle()` → `risk_Scoring_v2__`
- `ModuleGraph`：root + {ModuleKey→Module} + import edges；`topologicalOrder()` 含 cycle 检测
- `ModuleGraphLinker.link → LinkedProgram`(merged Module + traceNames 原→mangled)

**符号重命名（SymbolRewriter）—— 正确性关键**：
- **sealed switch 覆盖 CoreModel 全部子类型**（Decl4/Expr15/Stmt11/Pattern4/Type10）→ 编译器强制 exhaustive，杜绝遍历遗漏（头号风险）
- 局部绑定栈保护局部名（Let/param/Lambda/PatName）不被误改，只重命名顶层声明引用
- dotted alias `L.f` → 查 import edge toKey → `toKey.mangle()+f`（跨模块调用解析）
- 跨模块同名歧义/本模块同名 → 不改（安全）；root 不重命名；单模块无 import = identity

`checkImport`（替换 TypeChecker:286 空实现）：轻量校验重复 import + 与本模块顶层声明冲突 → `IMPORT_SYMBOL_CONFLICT`。

## 验证

- 全量 **680 测试 0 失败**
- `ModuleGraphLinkerTest` 6：identity / dotted alias call+trace / 冲突重命名 / 类型+Construct+PatCtor 跨模块改写 / Lambda+Match+If 嵌套 / cycle
- linker 不动 grammar（无 parity 影响）

## 说明

- **Truffle 端到端执行验证留 PR-3c**（aster-api 集成真实跑 GraalVM）。core 无 truffle 依赖，本步用 linked Core JSON 断言所有跨模块引用已正确改写。

🤖 Generated with [Claude Code](https://claude.com/claude-code)