### PR TITLE
fix(canonicalizer): don't strip single-letter identifier segments as articles

### DIFF
--- a/src/main/java/aster/core/canonicalizer/Canonicalizer.java
+++ b/src/main/java/aster/core/canonicalizer/Canonicalizer.java
@@ -347,7 +347,10 @@ public final class Canonicalizer {
         // 使用 Unicode 兼容的词边界：
         // (?<!\p{L}) - 前面不是字母（支持 Unicode 字母）
         // (?=\s|$|[\p{Punct}\u3001-\u303F\uFF00-\uFF65]) - 后面是空白、行尾、ASCII 标点或中日韩标点
-        String pattern = "(?<!\\p{L})(" + quotedArticles + ")(?=\\s|$|[\\p{Punct}\\u3001-\\u303F\\uFF00-\\uFF65])\\s?";
+        // (?<![\p{L}.]) - 前面不是字母也不是点（点排除模块路径 risk.A / 成员访问 A.a 里的标识符段，
+        //                 避免单字母大写标识符如 'A' 被 CASE_INSENSITIVE 误判为冠词 'a' 而吞掉）
+        // (?![\p{L}.])   - 后面不紧跟字母或点（同理排除 A.a 中的 A）
+        String pattern = "(?<![\\p{L}.])(" + quotedArticles + ")(?![\\p{L}.])(?=\\s|$|[\\p{Punct}\\u3001-\\u303F\\uFF00-\\uFF65])\\s?";
         return Pattern.compile(pattern,
                 Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE | Pattern.UNICODE_CHARACTER_CLASS);
     }


### PR DESCRIPTION
## 问题

模块路径 `risk.A`、成员访问 `A.a` 里的**单字母大写标识符段**被 CASE_INSENSITIVE 冠词正则误判为冠词 `a` 而吞掉：`risk.A`→`risk.`、`A.a`→`.`，导致跨模块 CNL 解析失败（ADR 0015 阶段3c 实测踩到，当时被迫用多字母模块名规避）。

## 修复

冠词移除正则加 dotted 上下文排除：
- `(?<![\p{L}.])` 前面不是字母也不是点（排除 `risk.A` 里 A 前的点）
- `(?![\p{L}.])` 后面不紧跟字母或点（排除 `A.a` 里 A 后的点）

真冠词 `a`/`an`/`the` 仍正常移除（前后是空白/标点，非 dotted 上下文）。

## 验证

- core 全量 **680 测试 0 失败**；zh/de Canonicalizer 无回归
- 测试在 aster-lang-en `EnUsCanonicalizerTest.ArticleRemovalTests`（单独 PR，因 en 测试依赖本 core 改动）：
  - `Use risk.A version 1 as Score.` 原样保留（不再变 `Use risk. version 1 as Score.`）
  - `Return A.a(amount).` 原样保留
  - 真冠词回归：`define the function to return a value` → `define function to return value`

🤖 Generated with [Claude Code](https://claude.com/claude-code)