### PR TITLE
feat(grammar): allow @entry on a standalone line (ADR 0015)

### DIFF
--- a/src/main/antlr/AsterParser.g4
+++ b/src/main/antlr/AsterParser.g4
@@ -83,7 +83,7 @@ topLevelDecl
  *     ...
  */
 funcDecl
-    : annotation* RULE nameIdent typeParamList? givenParamList? COMMA? (PRODUCE annotatedType?)? (DOT capabilityAnnotation? COLON NEWLINE block | COLON NEWLINE block | DOT)
+    : (annotation NEWLINE*)* RULE nameIdent typeParamList? givenParamList? COMMA? (PRODUCE annotatedType?)? (DOT capabilityAnnotation? COLON NEWLINE block | COLON NEWLINE block | DOT)
     ;
 
 /**

--- a/src/test/java/aster/core/parser/AstBuilderTest.java
+++ b/src/test/java/aster/core/parser/AstBuilderTest.java
@@ -210,6 +210,23 @@ class AstBuilderTest {
     }
 
     @Test
+    void testFuncWithStandaloneEntryAnnotationLine() {
+        // @entry 独立成行（注解与 Rule 之间有换行）——grammar (annotation NEWLINE*)* RULE 支持
+        String input = """
+            @entry
+            Rule main produce Text:
+              Return "ok".
+            """;
+
+        aster.core.ast.Module module = parseAndBuild(input);
+
+        Decl.Func func = (Decl.Func) module.decls().get(0);
+        assertEquals("main", func.name());
+        assertEquals(1, func.annotations().size());
+        assertEquals("entry", func.annotations().get(0).name());
+    }
+
+    @Test
     void testFuncWithMultipleAnnotations() {
         String input = """
             @entry @preview(source: "test") Rule main produce Text:


### PR DESCRIPTION
@entry 此前必须与 Rule 同行。本 PR 让 funcDecl 改为 `(annotation NEWLINE*)* RULE`，支持独立行 `@entry\nRule main`（更符合装饰器惯例），同行仍工作。

- core 680 测试无回归 + AstBuilderTest 独立行用例
- ts 引擎早已支持（consumeNewlines），aster-lang-ts 同步加 parity 测试
- grammar 改动触发 tier1-parity 双引擎对齐

🤖 Generated with [Claude Code](https://claude.com/claude-code)