### PR TITLE
feat(grammar): add logical and/or operators

### DIFF
--- a/src/main/antlr/AsterParser.g4
+++ b/src/main/antlr/AsterParser.g4
@@ -428,10 +428,22 @@ exprStmt
 
 /**
  * 表达式（多级优先级）
- * 使用优先级爬升技术：比较 < 加减 < 乘除 < 函数调用 < 基本表达式
+ * 优先级（低→高）：or < and < not < 比较 < 加减 < 乘除 < 函数调用 < 基本表达式
  */
 expr
-    : comparisonExpr
+    : orExpr
+    ;
+
+// 逻辑或（最低优先级，左结合）。and/or 在表达式上下文是逻辑运算符；
+// 在 givenParamList / fieldList / constructFields / typeList / waitStmt 等
+// 列表上下文，AND 由各自规则显式消费，不进入此表达式链。
+orExpr
+    : andExpr (OR andExpr)*
+    ;
+
+// 逻辑与（高于 or，低于 not / 比较，左结合）
+andExpr
+    : comparisonExpr (AND comparisonExpr)*
     ;
 
 // 比较表达式。除符号/多词比较词 token 外，`under` / `over` 作为**软关键字**

--- a/src/main/java/aster/core/parser/AstBuilder.java
+++ b/src/main/java/aster/core/parser/AstBuilder.java
@@ -928,6 +928,30 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
     // 表达式
     // ============================================================
 
+    // 逻辑或：andExpr (OR andExpr)* → 左结合的 Call{Name "or", [l, r]}
+    @Override
+    public Expr visitOrExpr(AsterParser.OrExprContext ctx) {
+        Expr left = (Expr) visit(ctx.andExpr(0));
+        for (int i = 1; i < ctx.andExpr().size(); i++) {
+            Expr right = (Expr) visit(ctx.andExpr(i));
+            Expr.Name op = new Expr.Name("or", spanFrom(ctx.OR(i - 1).getSymbol()));
+            left = new Expr.Call(op, List.of(left, right), spanFrom(ctx));
+        }
+        return left;
+    }
+
+    // 逻辑与：comparisonExpr (AND comparisonExpr)* → 左结合的 Call{Name "and", [l, r]}
+    @Override
+    public Expr visitAndExpr(AsterParser.AndExprContext ctx) {
+        Expr left = (Expr) visit(ctx.comparisonExpr(0));
+        for (int i = 1; i < ctx.comparisonExpr().size(); i++) {
+            Expr right = (Expr) visit(ctx.comparisonExpr(i));
+            Expr.Name op = new Expr.Name("and", spanFrom(ctx.AND(i - 1).getSymbol()));
+            left = new Expr.Call(op, List.of(left, right), spanFrom(ctx));
+        }
+        return left;
+    }
+
     @Override
     public Expr visitComparisonExpr(AsterParser.ComparisonExprContext ctx) {
         Expr left = (Expr) visit(ctx.additiveExpr(0));

--- a/src/test/java/aster/core/parser/AstBuilderTest.java
+++ b/src/test/java/aster/core/parser/AstBuilderTest.java
@@ -1043,4 +1043,72 @@ class AstBuilderTest {
         assertEquals(1, call.args().size());
         assertEquals("x", ((Expr.Name) call.args().get(0)).name());
     }
+
+    // ===== 逻辑运算符 and / or（低于比较，左结合）=====
+
+    private Expr.Call firstIfCond(String input) {
+        aster.core.ast.Module module = parseAndBuild(input);
+        Decl.Func f = (Decl.Func) module.decls().stream()
+            .filter(d -> d instanceof Decl.Func).findFirst().orElseThrow();
+        Stmt.If iff = (Stmt.If) f.body().statements().get(0);
+        return (Expr.Call) iff.cond();
+    }
+
+    @Test
+    void testLogicalAndLowersToAndCall() {
+        // a.age at least 18 and a.income at least 30000 → Call{Name "and", [cmp, cmp]}
+        Expr.Call cond = firstIfCond("""
+            Module t.
+            Define A has age as Int, income as Int.
+            Rule f given a as A, produce Bool:
+              If a.age at least 18 and a.income at least 30000
+                Return true.
+              Return false.
+            """);
+        assertEquals("and", ((Expr.Name) cond.target()).name());
+        assertEquals(2, cond.args().size());
+    }
+
+    @Test
+    void testLogicalOrLowersToOrCall() {
+        Expr.Call cond = firstIfCond("""
+            Module t.
+            Rule f given tier as Text, produce Bool:
+              If tier equals to "gold" or tier equals to "platinum"
+                Return true.
+              Return false.
+            """);
+        assertEquals("or", ((Expr.Name) cond.target()).name());
+        assertEquals(2, cond.args().size());
+    }
+
+    @Test
+    void testLogicalAndIsLeftAssociative() {
+        // a and b and c → ((a and b) and c)：顶层是 and，左 arg 又是 and
+        Expr.Call cond = firstIfCond("""
+            Module t.
+            Define A has age as Int, score as Int, income as Int.
+            Rule f given a as A, produce Bool:
+              If a.age at least 18 and a.score at least 650 and a.income at least 25000
+                Return true.
+              Return false.
+            """);
+        assertEquals("and", ((Expr.Name) cond.target()).name());
+        assertTrue(cond.args().get(0) instanceof Expr.Call inner
+            && ((Expr.Name) inner.target()).name().equals("and"));
+    }
+
+    @Test
+    void testConstructFieldAndNotConfusedWithLogicalAnd() {
+        // P with a set to 1 and b set to 2 → 2 个字段（and 是分隔符，非逻辑与）
+        aster.core.ast.Module module = parseAndBuild("""
+            Module t.
+            Define P has a as Int, b as Int.
+            Rule f produce P:
+              Return P with a set to 1 and b set to 2.
+            """);
+        Decl.Func f = (Decl.Func) module.decls().get(1);
+        Stmt.Return ret = (Stmt.Return) f.body().statements().get(0);
+        assertEquals(2, ((Expr.Construct) ret.expr()).fields().size());
+    }
 }


### PR DESCRIPTION
## 概要

为 Aster Lang 表达式补全逻辑 `and`/`or` 二元运算符，打通 grammar→AstBuilder→Core IR。

此前 Java 引擎**完全不支持**逻辑 and/or：`and`/`or` token 仅作 `givenParamList`/`fieldList`/`constructFields` 等列表分隔符，逻辑位置 parse 报错。导致文档站教的 `age at least 18 and income at least 30000` 这类复合条件在 Java 引擎下无法编译（TS 引擎 0.2.2 已支持，Truffle `Builtins` 也早已注册 `and`/`or`/`not`）。本 PR 补齐 Java 端缺口，实现双引擎对齐。

## 改动

- **AsterParser.g4**：表达式优先级阶梯插入 `expr → orExpr → andExpr → comparisonExpr`（or 最低，and 次之，紧于比较运算符）。重新生成无歧义警告。
- **AstBuilder**：`visitOrExpr`/`visitAndExpr` → `Call{Name "and"/"or", [left, right]}`，与既有 `visitComparisonExpr` 同模式，左结合。
- **AstBuilderTest**：+4 测（and/or lower 成对应 Call、左结合、construct 字段分隔符 `and` 不与逻辑 `and` 混淆）。

## 优先级

`and` 绑定紧于 `or`：`x or y and z` 解析为 `x or (y and z)`。

## 验证

- ✅ core **685 测试全绿**（含 4 个新增 logical 测试）
- ✅ `givenParamList`/`fieldList`/`constructFields` 的列表分隔符 `and` 不受影响（不走 expr 链）
- ✅ 下游 aster-api e2e（Truffle 真执行 `and`/`or` 复合条件，配套 PR）+ 双引擎 parity fixture（aster-lang-test 配套 PR）

## 发版

grammar 改动会触发下游 PR-blocking tier1-parity gate。**合并后需发版 core**，aster-api/truffle 消费新版方可端到端转绿（本地已 `publishToMavenLocal` 验证）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)