### PR TITLE
fix(grammar): allow and/or/not as qualified-name segments

### DIFF
--- a/src/main/antlr/AsterParser.g4
+++ b/src/main/antlr/AsterParser.g4
@@ -49,10 +49,18 @@ qualifiedName
 
 /**
  * 限定名称片段，允许普通标识符或类型标识符
+ * <p>
+ * 软关键字：AND/OR/NOT 在限定名（模块名 Module x.y.z. / Use x.y.z.）的段位置
+ * 当普通标识符用——段之间由 DOT 分隔，不与表达式里的逻辑运算符或列表分隔符冲突。
+ * 沿用 nameIdent 已有的 TYPE/VERSION 软关键字模式，避免改 lexer 引入全局风险。
+ * 解决 lexer 把 `boolean.and`/`boolean.or` 段误当 AND/OR token 而拒绝的问题。
  */
 qualifiedSegment
     : IDENT
     | TYPE_IDENT
+    | AND
+    | OR
+    | NOT
     ;
 
 /**

--- a/src/main/java/aster/core/parser/AstBuilder.java
+++ b/src/main/java/aster/core/parser/AstBuilder.java
@@ -87,12 +87,10 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
     @Override
     public String visitQualifiedName(AsterParser.QualifiedNameContext ctx) {
         return ctx.qualifiedSegment().stream()
-            .map(segment -> {
-                if (segment.IDENT() != null) {
-                    return segment.IDENT().getText();
-                }
-                return segment.TYPE_IDENT().getText();
-            })
+            // 段可能是 IDENT / TYPE_IDENT，也可能是软关键字 AND/OR/NOT
+            // （模块名/Use 路径里这些词当普通标识符用，见 grammar qualifiedSegment）。
+            // 直接取段文本，避免按 token 类型逐一判空导致 NPE。
+            .map(segment -> segment.getText())
             .collect(Collectors.joining("."));
     }
 

--- a/src/test/java/aster/core/parser/AstBuilderTest.java
+++ b/src/test/java/aster/core/parser/AstBuilderTest.java
@@ -1111,4 +1111,31 @@ class AstBuilderTest {
         Stmt.Return ret = (Stmt.Return) f.body().statements().get(0);
         assertEquals(2, ((Expr.Construct) ret.expr()).fields().size());
     }
+
+    @Test
+    void testModuleNameWithAndOrNotSegments() {
+        // 模块名段含软关键字 and/or/not（qualifiedSegment 允许），不被 lexer 当运算符吞掉
+        assertEquals("dual.engine.boolean.and",
+            parseAndBuild("Module dual.engine.boolean.and.\n\nRule f produce Bool:\n  Return true.\n").name());
+        assertEquals("dual.engine.boolean.or",
+            parseAndBuild("Module dual.engine.boolean.or.\n\nRule f produce Bool:\n  Return true.\n").name());
+        assertEquals("logic.not.helper",
+            parseAndBuild("Module logic.not.helper.\n\nRule f produce Bool:\n  Return true.\n").name());
+    }
+
+    @Test
+    void testUsePathWithAndOrSegments() {
+        // Use 路径段同样允许 and/or/not 软关键字（跨模块引用）
+        aster.core.ast.Module module = parseAndBuild("""
+            Module consumer.
+
+            Use risk.and.scoring version 1 as Score.
+
+            Rule f produce Bool:
+              Return true.
+            """);
+        Decl.Import imp = (Decl.Import) module.decls().stream()
+            .filter(d -> d instanceof Decl.Import).findFirst().orElseThrow();
+        assertEquals("risk.and.scoring", imp.path());
+    }
 }


### PR DESCRIPTION
## 概要

修复模块名/Use 路径段含 `and`/`or`/`not` 时被 lexer 当运算符 token 而 parse 失败的 bug。

```
Module x.boolean.and.       ❌ 此前：and 被当 AND token
Use risk.and.scoring ...     ❌ 同上
```

## 根因

ANTLR 最长匹配下 `AND`/`OR`/`NOT` token 与 IDENT 同长 → 取先定义的关键字 token。`qualifiedSegment` 只接受 `IDENT`/`TYPE_IDENT`，段为 AND/OR/NOT 时无规则匹配。

## 修复（软关键字模式，不改 lexer）

沿用 `nameIdent` 已有的 `TYPE`/`VERSION` 软关键字先例，在 **parser 层**让标识符位置容忍这些 token，避免改 lexer 引入全局风险：

- **AsterParser.g4**：`qualifiedSegment` 增加 `AND|OR|NOT` 备选。段间由 DOT 分隔，不与表达式逻辑运算符（andExpr/orExpr/NotExpr）或列表分隔符冲突。重新生成**无歧义警告**。
- **AstBuilder.visitQualifiedName**：段改用 `getText()` 取文本，兼容软关键字 token（此前按 `IDENT()`/`TYPE_IDENT()` 判空，段为 AND/OR/NOT 时 NPE）。
- **AstBuilderTest**：+2 测（模块名 `and`/`or`/`not` 段、Use 路径 `and` 段）。

## 验证

- ✅ core **687 测试全绿**，grammar 重新生成无歧义警告
- ✅ **tier1-parity --mode=parse 173/173**，--mode=ir 这批 boolean 样本 identical fingerprint（lowering NPE 消除）

## 关联

配套 aster-lang-test PR 把 4 个 boolean 样本从 tier2-divergent 提升进 tier1-parity（该 PR 依赖本修复）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)