### PR TITLE
fix(parser): qualified Map.* call target no longer dropped

### DIFF
--- a/src/main/java/aster/core/parser/AstBuilder.java
+++ b/src/main/java/aster/core/parser/AstBuilder.java
@@ -1082,7 +1082,13 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
     @Override
     public Expr visitPostfixExpr(AsterParser.PostfixExprContext ctx) {
         Expr current = (Expr) visit(ctx.primaryExpr());
-        boolean baseIsTypeIdent = ctx.primaryExpr() instanceof AsterParser.TypeIdentExprContext;
+        // `Map` has its own lexer token (MAP) so it parses as MapIdentExpr, not
+        // TypeIdentExpr — but for qualified stdlib calls like `Map.get(m, k)` it must
+        // behave like a type qualifier (yielding the call target `Map.get`), exactly
+        // as `List.get` does. Without this, the `Map` qualifier is dropped and the
+        // target collapses to a bare `get`, which fails to resolve.
+        boolean baseIsTypeIdent = ctx.primaryExpr() instanceof AsterParser.TypeIdentExprContext
+            || ctx.primaryExpr() instanceof AsterParser.MapIdentExprContext;
         List<MemberSegment> pendingMembers = new ArrayList<>();
 
         for (AsterParser.PostfixSuffixContext suffixCtx : ctx.postfixSuffix()) {


### PR DESCRIPTION
## What
`Map` has a dedicated lexer token (`MAP`), so it parses as `MapIdentExpr` rather than `TypeIdentExpr`. In `visitPostfixExpr` the qualified-name path only fired for `TypeIdentExpr`, so `Map.get(m, k)` lowered to a bare `get` call target that fails to resolve at runtime — whereas `List.get` works (`List` parses as `TYPE_IDENT`).

This treats `MapIdentExpr` as a type-qualifier base so `Map.get` lowers to the correct `Map.get` target.

## Verification
- `./gradlew build publishToMavenLocal` green (ANTLR regen + 502 tests)
- Downstream dual-engine eval parity: `map_ops` (Map.get) now identical across engines

Part of the stdlib-collections eval-parity cross-repo set (branch `feat/stdlib-collections-eval-parity` in core/truffle/ts/test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)