### PR TITLE
test(parity): emit full Core IR under -Dparity.ir.full (ADR 0016)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,7 +109,7 @@ tasks.test {
     // Codex review R-Phase-B-W3: forward EXACT keys (not a wildcard
     // `parity.*` prefix) so future tests can't accidentally collide
     // with the parity runner's property namespace.
-    listOf("parity.ir.input", "parity.ir.output").forEach { key ->
+    listOf("parity.ir.input", "parity.ir.output", "parity.ir.full").forEach { key ->
         val v = System.getProperty(key)
         if (v != null) systemProperty(key, v)
     }

--- a/src/test/java/aster/core/dualengine/CoreIrFingerprintCli.java
+++ b/src/test/java/aster/core/dualengine/CoreIrFingerprintCli.java
@@ -114,6 +114,12 @@ class CoreIrFingerprintCli {
                     JsonNode coreJson = MAPPER.valueToTree(coreModule);
                     record.put("ok", true);
                     record.set("fingerprint", fingerprint(coreJson));
+                    // ADR 0016 阶段1：-Dparity.ir.full=true 时附带完整 Core IR JSON，
+                    // 供 parity-tier1.mjs 的归一化字段级比较器消费（默认仍只发指纹，
+                    // 保持现有 IR-mode 行为不变）。
+                    if (Boolean.getBoolean("parity.ir.full")) {
+                        record.set("ir", coreJson);
+                    }
                 } catch (Throwable t) {
                     // A failure on one sample shouldn't abort the whole batch.
                     // The parity runner needs every sample's verdict so it can


### PR DESCRIPTION
## What
`CoreIrFingerprintCli` optionally attaches the complete lowered Core IR JSON (an `ir` field) when `-Dparity.ir.full=true`, alongside the existing fingerprint. Default behavior unchanged.

Consumed by aster-lang-test `parity-tier1.mjs --mode=ir --full` (ADR 0016) for field-level normalized IR diff. Branch-matched with aster-lang-test PR on `feat/ir-field-level-parity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)