### PR TITLE
chore(release): 1.0.1 — Hindi (hi-IN) builtin lexicon

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "cloud.aster-lang"
-version = "1.0.0"
+version = "1.0.1"
 
 publishing {
     publications {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.0")
+            from("cloud.aster-lang:aster-lang-platform:1.0.1")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.1")
+            from("cloud.aster-lang:aster-lang-platform:1.0.2")
         }
     }
 }


### PR DESCRIPTION
Version bump to **1.0.1** so the JVM ecosystem carries the Hindi (hi-IN) builtin lexicon + Canonicalizer danda normalization shipped in #20 (ADR 0017 Phase 2).

After merge, tag `v1.0.1` on main triggers the GH Packages publish of `cloud.aster-lang:aster-lang-core:1.0.1`. The `aster-lang-platform` catalog will then repoint `core` to 1.0.1 (separate PR), and aster-api consumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)