### PR TITLE
fix(core): ReDoS guard on lexicon regex, PII L2 sink enforcement, collision-safe module mangling

### DIFF
--- a/src/main/java/aster/core/canonicalizer/Canonicalizer.java
+++ b/src/main/java/aster/core/canonicalizer/Canonicalizer.java
@@ -6,6 +6,7 @@ import aster.core.lexicon.CanonicalizationConfig;
 import aster.core.lexicon.CompoundPattern;
 import aster.core.lexicon.Lexicon;
 import aster.core.lexicon.LexiconRegistry;
+import aster.core.lexicon.RegexGuard;
 import aster.core.lexicon.SemanticTokenKind;
 
 import java.util.ArrayList;
@@ -540,7 +541,8 @@ public final class Canonicalizer {
      */
     private String applyCustomRules(String s) {
         for (CanonicalizationConfig.CanonicalizationRule rule : config.customRules()) {
-            Pattern pattern = Pattern.compile(rule.pattern());
+            // customRules 来自不可信 lexicon 配置：编译期筛查 ReDoS 形状。
+            Pattern pattern = RegexGuard.compile(rule.pattern(), 0);
             List<Segment> segments = segmentString(s);
             StringBuilder result = new StringBuilder(s.length());
 
@@ -573,8 +575,8 @@ public final class Canonicalizer {
         }
 
         if (protectedRanges.isEmpty()) {
-            // 无保留词，直接替换
-            return rulePattern.matcher(text).replaceAll(replacement);
+            // 无保留词，直接替换（看门狗超时防 ReDoS）
+            return RegexGuard.replaceAllWithTimeout(rulePattern, text, replacement);
         }
 
         // 对非保留区域执行替换
@@ -584,7 +586,7 @@ public final class Canonicalizer {
             // 替换保留词前的片段
             if (pos < range[0]) {
                 String segment = text.substring(pos, range[0]);
-                result.append(rulePattern.matcher(segment).replaceAll(replacement));
+                result.append(RegexGuard.replaceAllWithTimeout(rulePattern, segment, replacement));
             }
             // 保留词原样保留
             result.append(text, range[0], range[1]);
@@ -593,7 +595,7 @@ public final class Canonicalizer {
         // 替换最后一个保留词后的片段
         if (pos < text.length()) {
             String segment = text.substring(pos);
-            result.append(rulePattern.matcher(segment).replaceAll(replacement));
+            result.append(RegexGuard.replaceAllWithTimeout(rulePattern, segment, replacement));
         }
         return result.toString();
     }

--- a/src/main/java/aster/core/canonicalizer/StringSegmenter.java
+++ b/src/main/java/aster/core/canonicalizer/StringSegmenter.java
@@ -1,5 +1,7 @@
 package aster.core.canonicalizer;
 
+import aster.core.lexicon.RegexGuard;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -95,11 +97,30 @@ public final class StringSegmenter {
      * @return 替换后的文本（字符串字面量内容不变）
      */
     public String replaceOutsideStrings(String source, Pattern pattern, String replacement) {
+        return replaceOutsideStrings(source, pattern, replacement, false);
+    }
+
+    /**
+     * 便捷方法：对源码的非字符串部分应用正则替换，可选 ReDoS 看门狗。
+     * <p>
+     * 当 {@code guarded} 为 {@code true} 时（用于来自不可信 lexicon 配置的正则），
+     * 每段替换经 {@link RegexGuard#replaceAllWithTimeout} 在看门狗超时内执行，
+     * 灾难性回溯会被中断并抛出 {@link RegexGuard.RegexTimeoutException}。
+     *
+     * @param source      源码文本
+     * @param pattern     正则表达式
+     * @param replacement 替换内容
+     * @param guarded     是否启用看门狗超时
+     * @return 替换后的文本（字符串字面量内容不变）
+     */
+    public String replaceOutsideStrings(String source, Pattern pattern, String replacement, boolean guarded) {
         List<Segment> segments = segment(source);
         StringBuilder result = new StringBuilder(source.length());
         for (Segment seg : segments) {
             if (seg.inString) {
                 result.append(seg.text);
+            } else if (guarded) {
+                result.append(RegexGuard.replaceAllWithTimeout(pattern, seg.text, replacement));
             } else {
                 result.append(pattern.matcher(seg.text).replaceAll(replacement));
             }

--- a/src/main/java/aster/core/canonicalizer/transformers/RegexTransformer.java
+++ b/src/main/java/aster/core/canonicalizer/transformers/RegexTransformer.java
@@ -3,6 +3,7 @@ package aster.core.canonicalizer.transformers;
 import aster.core.canonicalizer.StringSegmenter;
 import aster.core.canonicalizer.SyntaxTransformer;
 import aster.core.lexicon.CanonicalizationConfig;
+import aster.core.lexicon.RegexGuard;
 
 import java.util.regex.Pattern;
 
@@ -11,6 +12,9 @@ import java.util.regex.Pattern;
  * <p>
  * 从声明式配置（如 {@code customRules}）构造。
  * 仅在字符串字面量外部执行替换。
+ * <p>
+ * <b>安全</b>：模式来自不可信 lexicon 配置，构造期经 {@link RegexGuard#compile} 静态筛查
+ * （拒绝超长 / 嵌套量词 ReDoS 形状），匹配期经看门狗超时执行，避免灾难性回溯导致 DoS。
  */
 public final class RegexTransformer implements SyntaxTransformer {
 
@@ -20,13 +24,13 @@ public final class RegexTransformer implements SyntaxTransformer {
 
     public RegexTransformer(String name, String pattern, String replacement) {
         this.name = name;
-        this.pattern = Pattern.compile(pattern, Pattern.UNICODE_CHARACTER_CLASS);
+        this.pattern = RegexGuard.compile(pattern, Pattern.UNICODE_CHARACTER_CLASS);
         this.replacement = replacement;
     }
 
     @Override
     public String transform(String source, CanonicalizationConfig config, StringSegmenter segmenter) {
-        return segmenter.replaceOutsideStrings(source, pattern, replacement);
+        return segmenter.replaceOutsideStrings(source, pattern, replacement, true);
     }
 
     public String getName() {

--- a/src/main/java/aster/core/lexicon/LexiconRegistry.java
+++ b/src/main/java/aster/core/lexicon/LexiconRegistry.java
@@ -517,6 +517,16 @@ public final class LexiconRegistry {
             }
         }
 
+        // 7. 安全：筛查不可信 customRules 正则的 ReDoS 形状（纵深防御，register 时即拒绝）。
+        var canon = lexicon.getCanonicalization();
+        if (canon != null && canon.customRules() != null) {
+            for (var rule : canon.customRules()) {
+                for (String redosError : RegexGuard.screen(rule.pattern())) {
+                    errors.add("Unsafe regex in customRule '" + rule.name() + "': " + redosError);
+                }
+            }
+        }
+
         return new ValidationResult(errors.isEmpty(), errors, warnings);
     }
 

--- a/src/main/java/aster/core/lexicon/LexiconValidator.java
+++ b/src/main/java/aster/core/lexicon/LexiconValidator.java
@@ -76,10 +76,14 @@ public final class LexiconValidator {
         List<String> errors = new ArrayList<>(baseResult.errors());
         List<String> warnings = new ArrayList<>(baseResult.warnings());
 
-        // 额外校验：customRules 的正则可编译性
+        // 额外校验：customRules 的正则可编译性 + ReDoS 形状筛查
         CanonicalizationConfig config = lexicon.getCanonicalization();
         if (config.customRules() != null) {
             for (CanonicalizationConfig.CanonicalizationRule rule : config.customRules()) {
+                // 不可信正则：先做 ReDoS 静态筛查（超长 / 嵌套量词），再验证可编译性。
+                for (String redosError : RegexGuard.screen(rule.pattern())) {
+                    errors.add("Unsafe regex in customRule '" + rule.name() + "': " + redosError);
+                }
                 try {
                     Pattern.compile(rule.pattern());
                 } catch (PatternSyntaxException e) {

--- a/src/main/java/aster/core/lexicon/RegexGuard.java
+++ b/src/main/java/aster/core/lexicon/RegexGuard.java
@@ -1,0 +1,205 @@
+package aster.core.lexicon;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * 针对来自不可信 lexicon 配置（如 {@code customRules}）的正则表达式提供 ReDoS 防御。
+ * <p>
+ * 不可信 JSON 语言包可以携带任意正则，这些正则会在编译后对<b>整段源码</b>执行。
+ * 形如 {@code (a+)+} 的嵌套量词在不匹配的长输入上会触发灾难性回溯（catastrophic
+ * backtracking），导致拒绝服务。本类提供纵深防御：
+ * <ul>
+ *   <li><b>注册/校验期静态筛查</b> —— {@link #screen(String)} 拒绝超长正则以及明显的
+ *       嵌套量词 ReDoS 形状（{@code (...+)+}、{@code (...*)*}、{@code (...+)*} 等）。
+ *       这是一个保守的启发式：可能漏判某些刁钻的形状，但不会误伤常见的良性正则。</li>
+ *   <li><b>匹配期超时</b> —— {@link #matcherFor(Pattern, CharSequence)} 把输入包装成可被
+ *       中断的 {@link CharSequence}，{@link #replaceAllWithTimeout} 在独立线程上运行
+ *       正则并设置看门狗超时（{@link #DEFAULT_TIMEOUT_MS}），超时即抛出清晰的 lexicon 错误。</li>
+ * </ul>
+ */
+public final class RegexGuard {
+
+    private RegexGuard() {}
+
+    /** 不可信正则字符串的最大长度（字符数）。 */
+    public static final int MAX_PATTERN_LENGTH = 1000;
+
+    /** 单次匹配的看门狗超时（毫秒）。 */
+    public static final long DEFAULT_TIMEOUT_MS = 2000;
+
+    /**
+     * 嵌套量词 ReDoS 形状的保守启发式。
+     * <p>
+     * 匹配“一个被量词修饰的分组，整体又被量词修饰”的模式，即 {@code (...Q)Q}，
+     * 其中内层 {@code Q} 属于 {@code + * {n,}} 之一（带可选 {@code ?} 惰性标记），
+     * 外层 {@code Q} 属于 {@code + * {n,}}。这覆盖经典灾难性回溯：
+     * {@code (a+)+}、{@code (a*)*}、{@code (a+)*}、{@code (.*)+}、{@code (a{2,})+} 等。
+     * <p>
+     * 形状（去转义后）：{@code \( ... [+*] | \{\d+,\}  ... \) [+*] | \{\d+,\}}。
+     */
+    private static final Pattern NESTED_QUANTIFIER = Pattern.compile(
+        "\\((?:[^()\\\\]|\\\\.)*?(?:[+*]|\\{\\d+,\\d*})\\??\\)(?:[+*]|\\{\\d+,\\d*})"
+    );
+
+    /**
+     * 静态筛查一个不可信正则字符串。
+     *
+     * @param pattern 正则字符串
+     * @return 校验错误列表；为空表示通过筛查
+     */
+    public static List<String> screen(String pattern) {
+        List<String> errors = new ArrayList<>();
+        if (pattern == null) {
+            errors.add("regex pattern must not be null");
+            return errors;
+        }
+        if (pattern.length() > MAX_PATTERN_LENGTH) {
+            errors.add("regex pattern too long: " + pattern.length()
+                + " chars (max " + MAX_PATTERN_LENGTH + ")");
+        }
+        if (NESTED_QUANTIFIER.matcher(pattern).find()) {
+            errors.add("regex pattern has nested-quantifier ReDoS shape "
+                + "(e.g. (...+)+, (...*)*, (...+)*): " + pattern);
+        }
+        return errors;
+    }
+
+    /**
+     * 筛查并编译一个不可信正则。
+     *
+     * @param pattern 正则字符串
+     * @param flags   {@link Pattern} 标志位
+     * @return 编译后的 {@link Pattern}
+     * @throws IllegalArgumentException 如果筛查失败或正则语法非法
+     */
+    public static Pattern compile(String pattern, int flags) {
+        List<String> errors = screen(pattern);
+        if (!errors.isEmpty()) {
+            throw new IllegalArgumentException("Rejected unsafe lexicon regex: " + String.join("; ", errors));
+        }
+        try {
+            return Pattern.compile(pattern, flags);
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException("Invalid lexicon regex: " + e.getMessage(), e);
+        }
+    }
+
+    private static final AtomicLong THREAD_SEQ = new AtomicLong();
+
+    private static final ThreadFactory WATCHDOG_THREADS = runnable -> {
+        Thread t = new Thread(runnable, "aster-regex-watchdog-" + THREAD_SEQ.incrementAndGet());
+        t.setDaemon(true);
+        return t;
+    };
+
+    /**
+     * 在看门狗超时内对 {@code input} 的非字符串部分执行 {@code pattern} 的全量替换。
+     * <p>
+     * 输入被包装成可中断的 {@link CharSequence}：匹配运行在独立 daemon 线程上，
+     * 超时则中断该线程并抛错，避免灾难性回溯把编译线程挂死。
+     *
+     * @param pattern     已编译正则
+     * @param input       目标文本
+     * @param replacement 替换串
+     * @param timeoutMs   超时毫秒数
+     * @return 替换后的文本
+     * @throws RegexTimeoutException 超时
+     */
+    public static String replaceAllWithTimeout(Pattern pattern, String input, String replacement, long timeoutMs) {
+        ExecutorService executor = Executors.newSingleThreadExecutor(WATCHDOG_THREADS);
+        Future<String> future = executor.submit(() -> {
+            Matcher matcher = pattern.matcher(new InterruptibleCharSequence(input));
+            return matcher.replaceAll(replacement);
+        });
+        try {
+            return future.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            throw new RegexTimeoutException(
+                "Lexicon regex exceeded " + timeoutMs + "ms (possible ReDoS): /" + pattern.pattern() + "/", e);
+        } catch (InterruptedException e) {
+            future.cancel(true);
+            Thread.currentThread().interrupt();
+            throw new RegexTimeoutException("Interrupted while running lexicon regex: /" + pattern.pattern() + "/", e);
+        } catch (ExecutionException e) {
+            var cause = e.getCause();
+            if (cause instanceof RuntimeException re) {
+                throw re;
+            }
+            throw new IllegalStateException("Lexicon regex failed: /" + pattern.pattern() + "/", cause);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * 便捷重载，使用 {@link #DEFAULT_TIMEOUT_MS}。
+     */
+    public static String replaceAllWithTimeout(Pattern pattern, String input, String replacement) {
+        return replaceAllWithTimeout(pattern, input, replacement, DEFAULT_TIMEOUT_MS);
+    }
+
+    /**
+     * 在看门狗超时内创建一个可中断的 {@link Matcher}（用于只判定 {@code find()} 的场景）。
+     */
+    public static Matcher matcherFor(Pattern pattern, CharSequence input) {
+        return pattern.matcher(new InterruptibleCharSequence(input));
+    }
+
+    /** 超时抛出的运行期异常。 */
+    public static final class RegexTimeoutException extends RuntimeException {
+        public RegexTimeoutException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    /**
+     * 可被线程中断打断的 {@link CharSequence} 包装。
+     * <p>
+     * {@link Matcher} 在回溯过程中会频繁调用 {@link #charAt(int)}；当看门狗线程
+     * 取消任务（{@code interrupt()}）时，下一次 {@code charAt} 抛出
+     * {@link RuntimeException}，从而打破灾难性回溯循环。
+     */
+    private static final class InterruptibleCharSequence implements CharSequence {
+        private final CharSequence delegate;
+
+        InterruptibleCharSequence(CharSequence delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public char charAt(int index) {
+            if (Thread.currentThread().isInterrupted()) {
+                throw new RuntimeException("regex matching interrupted (watchdog timeout)");
+            }
+            return delegate.charAt(index);
+        }
+
+        @Override
+        public int length() {
+            return delegate.length();
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return new InterruptibleCharSequence(delegate.subSequence(start, end));
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+    }
+}

--- a/src/main/java/aster/core/lowering/CoreLowering.java
+++ b/src/main/java/aster/core/lowering/CoreLowering.java
@@ -4,6 +4,9 @@ import aster.core.ast.*;
 import aster.core.ir.CoreModel;
 import aster.core.typecheck.CapabilityKind;
 import aster.core.typecheck.checkers.CapabilityChecker;
+// TODO(#24): lowering 依赖 typecheck（CapabilityKind / CapabilityChecker）造成 lowering->typecheck
+//   的层级耦合。应将 lowering 与 typecheck 解耦（capability 元数据下沉到 IR 或独立模块），
+//   并把模块版本改为从 git tag 派生。此次 PR 不做该架构重构，仅留记号。
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/aster/core/module/ModuleGraphLinker.java
+++ b/src/main/java/aster/core/module/ModuleGraphLinker.java
@@ -75,6 +75,9 @@ public final class ModuleGraphLinker {
     Map<ModuleKey, Set<String>> topLevelNames
   ) {
     var result = new HashMap<ModuleKey, Map<String, String>>();
+    // 安全：不同模块绝不能产生相同的 mangle 前缀，否则跨模块符号会被静默混淆。
+    // 一旦碰撞，立刻 fail loud（而非生成错误的合并程序）。
+    assertNoManglePrefixCollisions(topLevelNames.keySet(), ModuleKey::mangle);
     for (var entry : topLevelNames.entrySet()) {
       var key = entry.getKey();
       if (key.equals(root)) {
@@ -88,6 +91,32 @@ public final class ModuleGraphLinker {
       result.put(key, Map.copyOf(rename));
     }
     return Map.copyOf(result);
+  }
+
+  /**
+   * 防御性断言：所有模块的 mangle 前缀必须两两不同。
+   * <p>
+   * {@link ModuleKey#mangle()} 已是无碰撞编码；本断言守护未来对 mangle 的回归
+   * （以及任何理论残余歧义），碰撞时 fail loud 而非生成错误的合并程序。
+   * 前缀函数可注入以便测试。
+   *
+   * @param keys     待检查的模块 key
+   * @param prefixFn 计算前缀的函数（生产代码用 {@link ModuleKey#mangle()}）
+   */
+  static void assertNoManglePrefixCollisions(
+    Collection<ModuleKey> keys,
+    java.util.function.Function<ModuleKey, String> prefixFn
+  ) {
+    var prefixOwners = new HashMap<String, ModuleKey>();
+    for (var key : keys) {
+      var prefix = prefixFn.apply(key);
+      var existing = prefixOwners.putIfAbsent(prefix, key);
+      if (existing != null && !existing.equals(key)) {
+        throw new IllegalStateException(
+          "Module mangle prefix collision: '" + existing + "' and '" + key
+            + "' both produce prefix '" + prefix + "'");
+      }
+    }
   }
 
   private Map<String, String> buildTraceNames(Map<ModuleKey, Map<String, String>> renameMaps) {

--- a/src/main/java/aster/core/module/ModuleKey.java
+++ b/src/main/java/aster/core/module/ModuleKey.java
@@ -15,9 +15,16 @@ public record ModuleKey(String moduleName, int version) {
   }
 
   /**
-   * 生成合并后顶层符号的前缀，例如 risk.Scoring v2 -> risk_Scoring_v2__。
+   * 生成合并后顶层符号的前缀，例如 {@code risk.Scoring v2 -> risk_Scoring_v2__}。
+   * <p>
+   * 编码必须无碰撞：朴素的 {@code name.replace('.', '_')} 会让 {@code a.b} 与
+   * {@code a_b} 折叠到同一前缀。这里先把已有的 {@code _} 转义为 {@code __}，再把
+   * {@code .} 编码为单个 {@code _}；因此 {@code _} 永远成对出现于“原始下划线”，
+   * 单个 {@code _} 永远来自“点”，二者不会混淆——
+   * {@code a.b -> a_b_v1__}，{@code a_b -> a__b_v1__}（不同前缀）。
    */
   public String mangle() {
-    return moduleName.replace('.', '_') + "_v" + version + "__";
+    String encoded = moduleName.replace("_", "__").replace('.', '_');
+    return encoded + "_v" + version + "__";
   }
 }

--- a/src/main/java/aster/core/typecheck/EffectConfig.java
+++ b/src/main/java/aster/core/typecheck/EffectConfig.java
@@ -3,6 +3,8 @@ package aster.core.typecheck;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -18,11 +20,13 @@ import java.util.stream.Stream;
  * 核心功能：
  * - JSON 配置加载：支持从 .aster/effects.json 加载配置
  * - 环境变量支持：ASTER_EFFECT_CONFIG 可自定义配置路径
- * - 静默降级：配置加载失败时自动使用默认配置
+ * - 可见降级：配置加载失败时记录 WARNING 日志后使用默认配置（不静默吞错）
  * - 细粒度分类：支持 io.http、io.sql、io.files、cpu、ai 等细分效果
  * - 单例模式：模块级缓存避免重复 I/O
  */
 public final class EffectConfig {
+
+  private static final Logger LOG = System.getLogger(EffectConfig.class.getName());
 
   // ========== 单例实例 ==========
 
@@ -234,7 +238,10 @@ public final class EffectConfig {
       // 合并用户配置与默认配置
       return mergeWithDefault(userConfig);
     } catch (IOException | IllegalArgumentException e) {
-      // 配置加载失败，静默降级到默认配置
+      // 配置加载失败：记录原因后降级到默认配置（effect 推断不属于安全边界，
+      // 不应 fail-closed；但失败必须可见，不能静默吞掉）。
+      LOG.log(Level.WARNING,
+        "Failed to load effect config from '" + configPath + "', falling back to defaults: " + e.getMessage(), e);
       return DEFAULT_CONFIG;
     }
   }

--- a/src/main/java/aster/core/typecheck/TypeChecker.java
+++ b/src/main/java/aster/core/typecheck/TypeChecker.java
@@ -462,22 +462,4 @@ public final class TypeChecker {
     }
   }
 
-  /**
-   * @deprecated 自 ADR-0009 (P0-1) 起，PII flow 分析永远启用。本函数仅保留为
-   *   no-op stub，计划在 aster-lang-core 0.3.0 移除。所有 caller 应当假定
-   *   PII 检查总是运行。
-   *
-   *   原渐进式 opt-in 策略（ENFORCE_PII / ASTER_ENFORCE_PII 环境变量）已是
-   *   security hazard：同一策略在不同 runtime 报告不同安全结论，违背 Aster
-   *   "PII as a first-class type" 承诺。
-   *
-   *   跨语言对齐：TS 端 aster-lang-ts 0.2.1 的 `shouldEnforcePii()` 同样
-   *   deprecated，预计 0.3.0 移除。
-   *
-   * @return always true
-   */
-  @Deprecated(since = "aster-lang-core 0.2.x (ADR-0009 P0-1)", forRemoval = true)
-  private boolean shouldEnforcePii() {
-    return true;
-  }
 }

--- a/src/main/java/aster/core/typecheck/pii/PiiTypeChecker.java
+++ b/src/main/java/aster/core/typecheck/pii/PiiTypeChecker.java
@@ -329,6 +329,7 @@ public final class PiiTypeChecker {
       }
       return;
     }
+    // L3 在任何 sink 都必须先经 redact/tokenize 脱敏（脱敏会把级别降到 L1），否则报错。
     if (meta.getLevel() == PiiMeta.Level.L3) {
       emitDiagnostic(ErrorCode.PII_SINK_UNSANITIZED, exprOrigin(argExpr), Map.<String, Object>of(
         "level", meta.getLevel().name(),
@@ -336,7 +337,9 @@ public final class PiiTypeChecker {
       ), meta.getLevel().name(), sink.label);
       return;
     }
-    if (sink.kind == SinkKind.CONSOLE && meta.getLevel() == PiiMeta.Level.L2) {
+    // L2 在任何 sink（CONSOLE / NETWORK / DATABASE / EMIT）都同样需要脱敏；
+    // 未脱敏的 L2 抵达 sink 一律按与 L3 相同的诊断风格报错。
+    if (meta.getLevel() == PiiMeta.Level.L2) {
       emitDiagnostic(ErrorCode.PII_SINK_UNSANITIZED, exprOrigin(argExpr), Map.<String, Object>of(
         "level", meta.getLevel().name(),
         "sinkKind", sink.label

--- a/src/test/java/aster/core/canonicalizer/transformers/RegexTransformerTest.java
+++ b/src/test/java/aster/core/canonicalizer/transformers/RegexTransformerTest.java
@@ -1,0 +1,31 @@
+package aster.core.canonicalizer.transformers;
+
+import aster.core.canonicalizer.StringSegmenter;
+import aster.core.lexicon.CanonicalizationConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * RegexTransformer 安全性测试：构造期拒绝 ReDoS 形状；正常规则仍可用。
+ */
+class RegexTransformerTest {
+
+  @Test
+  void rejectsCatastrophicPatternAtConstruction() {
+    assertThatThrownBy(() -> new RegexTransformer("evil", "(a+)+$", "X"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("ReDoS");
+  }
+
+  @Test
+  void normalRuleStillTransforms() {
+    var transformer = new RegexTransformer("umlaut", "ue", "ü");
+    var segmenter = new StringSegmenter("\"", "\"");
+    var config = CanonicalizationConfig.defaults();
+    // 字符串字面量外替换，字符串内保持原样。
+    assertThat(transformer.transform("blue \"glue\"", config, segmenter))
+      .isEqualTo("blü \"glue\"");
+  }
+}

--- a/src/test/java/aster/core/lexicon/RegexGuardTest.java
+++ b/src/test/java/aster/core/lexicon/RegexGuardTest.java
@@ -1,0 +1,79 @@
+package aster.core.lexicon;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * ReDoS 防御单元测试。
+ */
+class RegexGuardTest {
+
+  @Test
+  void screenRejectsNestedQuantifierShapes() {
+    assertThat(RegexGuard.screen("(a+)+")).isNotEmpty();
+    assertThat(RegexGuard.screen("(a*)*")).isNotEmpty();
+    assertThat(RegexGuard.screen("(a+)*")).isNotEmpty();
+    assertThat(RegexGuard.screen("(.*)+")).isNotEmpty();
+    assertThat(RegexGuard.screen("(a{2,})+")).isNotEmpty();
+    assertThat(RegexGuard.screen("(a+)+$")).isNotEmpty();
+  }
+
+  @Test
+  void screenAcceptsNormalPatterns() {
+    assertThat(RegexGuard.screen("\\bfoo\\b")).isEmpty();
+    assertThat(RegexGuard.screen("ue")).isEmpty();
+    assertThat(RegexGuard.screen("(foo|bar)")).isEmpty();
+    assertThat(RegexGuard.screen("a+b*")).isEmpty();
+    assertThat(RegexGuard.screen("[a-z]{2,4}")).isEmpty();
+  }
+
+  @Test
+  void screenRejectsOverlongPatterns() {
+    String huge = "a".repeat(RegexGuard.MAX_PATTERN_LENGTH + 1);
+    assertThat(RegexGuard.screen(huge))
+      .anyMatch(e -> e.contains("too long"));
+  }
+
+  @Test
+  void compileRejectsCatastrophicPattern() {
+    assertThatThrownBy(() -> RegexGuard.compile("(a+)+$", 0))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("ReDoS");
+  }
+
+  @Test
+  void compileAcceptsNormalPattern() {
+    Pattern p = RegexGuard.compile("ue", 0);
+    assertThat(p.matcher("blue").replaceAll("ü")).isEqualTo("blü");
+  }
+
+  /**
+   * 灾难性回溯：{@code (.*a){20}$} 对一串不以 {@code a} 结尾的输入会指数级回溯
+   * （JDK 25 实测 n=30 约 70s）。该形状用精确计数 {@code {20}} 绕过了静态筛查的
+   * “开放量词”启发式，正好验证<b>匹配期看门狗</b>这一层纵深防御能 fail fast。
+   * 测试本身设硬上限 10s，看门狗 1.5s 内应中断。
+   */
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void matchTimeoutFailsFastOnCatastrophicInput() {
+    Pattern evil = Pattern.compile("(.*a){20}$"); // 直接编译，模拟绕过筛查
+    String input = "a".repeat(30) + "!";          // 长且不匹配 -> 灾难性回溯
+    assertThatThrownBy(() -> RegexGuard.replaceAllWithTimeout(evil, input, "X", 1500))
+      .isInstanceOf(RegexGuard.RegexTimeoutException.class)
+      .hasMessageContaining("ReDoS");
+  }
+
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  void matchWithTimeoutSucceedsForNormalInput() {
+    Pattern p = Pattern.compile("ue");
+    assertThat(RegexGuard.replaceAllWithTimeout(p, "blue glue", "ü", 1500))
+      .isEqualTo("blü glü");
+  }
+}

--- a/src/test/java/aster/core/module/ModuleGraphLinkerTest.java
+++ b/src/test/java/aster/core/module/ModuleGraphLinkerTest.java
@@ -130,6 +130,66 @@ class ModuleGraphLinkerTest {
   }
 
   @Test
+  void mangleIsCollisionFreeBetweenDotAndUnderscore() {
+    // 回归 #24：朴素的 name.replace('.', '_') 会让 a.b 与 a_b 折叠到同一前缀。
+    var dot = new ModuleKey("a.b", 1).mangle();
+    var underscore = new ModuleKey("a_b", 1).mangle();
+    assertNotEquals(dot, underscore);
+    assertEquals("a_b_v1__", dot);
+    assertEquals("a__b_v1__", underscore);
+  }
+
+  @Test
+  void linksDotAndUnderscoreModulesToDistinctSymbols() {
+    // a.b 和 a_b 各导出同名符号 f；旧 mangle 会把两者静默重写成同一名字。
+    var rootKey = new ModuleKey("app", 1);
+    var dotKey = new ModuleKey("a.b", 1);
+    var underscoreKey = new ModuleKey("a_b", 1);
+    var root = module("app", List.of(
+      importDecl("a.b", 1, "D"),
+      importDecl("a_b", 1, "U"),
+      func("main", ret(call("D.f")))
+    ));
+    var dotMod = module("a.b", List.of(func("f", ret(intE(1)))));
+    var underscoreMod = module("a_b", List.of(func("f", ret(intE(2)))));
+    var graph = new ModuleGraph(
+      rootKey,
+      Map.of(rootKey, root, dotKey, dotMod, underscoreKey, underscoreMod),
+      List.of(
+        new ModuleGraph.ImportEdge(rootKey, "D", dotKey),
+        new ModuleGraph.ImportEdge(rootKey, "U", underscoreKey)
+      )
+    );
+
+    var linked = new ModuleGraphLinker().link(graph);
+
+    var names = linked.merged().decls.stream()
+      .filter(CoreModel.Func.class::isInstance)
+      .map(CoreModel.Func.class::cast)
+      .map(f -> f.name)
+      .toList();
+    assertTrue(names.contains("a_b_v1__f"), names.toString());
+    assertTrue(names.contains("a__b_v1__f"), names.toString());
+  }
+
+  @Test
+  void collisionGuardRejectsCollidingPrefixes() {
+    // 注入一个会制造碰撞的前缀函数，验证守护断言确实 fail loud。
+    var a = new ModuleKey("a.b", 1);
+    var b = new ModuleKey("a_b", 1);
+    var ex = assertThrows(IllegalStateException.class, () ->
+      ModuleGraphLinker.assertNoManglePrefixCollisions(List.of(a, b), key -> "SAME_PREFIX_"));
+    assertTrue(ex.getMessage().contains("collision"), ex.getMessage());
+  }
+
+  @Test
+  void collisionGuardAcceptsDistinctPrefixes() {
+    var a = new ModuleKey("a.b", 1);
+    var b = new ModuleKey("a_b", 1);
+    ModuleGraphLinker.assertNoManglePrefixCollisions(List.of(a, b), ModuleKey::mangle);
+  }
+
+  @Test
   void detectsImportCycles() {
     var a = new ModuleKey("a", 1);
     var b = new ModuleKey("b", 1);

--- a/src/test/java/aster/core/typecheck/PiiTypeCheckTest.java
+++ b/src/test/java/aster/core/typecheck/PiiTypeCheckTest.java
@@ -210,6 +210,100 @@ class PiiTypeCheckTest {
     assertTrue(hasCode(diagnostics, ErrorCode.PII_ARG_VIOLATION));
   }
 
+  @Test
+  void testL2ToHttpSink_shouldError() {
+    // Http.* 把 sink 参数定为第 2 个（body），第 1 个是 URL。
+    var fn = func(
+      "post_email",
+      List.of(piiParam("email", "L2", "email")),
+      textType(),
+      List.of(returnStmt(callExpr("Http.post", stringLiteral("https://x"), nameExpr("email")))),
+      List.of("io")
+    );
+    var diagnostics = checker.checkModule(List.of(fn));
+    var diag = findDiagnostic(diagnostics, ErrorCode.PII_SINK_UNSANITIZED);
+    assertNotNull(diag);
+    assertEquals("L2", diag.data().get("level"));
+  }
+
+  @Test
+  void testL2ToSqlSink_shouldError() {
+    var fn = func(
+      "store_email",
+      List.of(piiParam("email", "L2", "email")),
+      textType(),
+      List.of(returnStmt(callExpr("Sql.insert", nameExpr("email")))),
+      List.of("io")
+    );
+    var diagnostics = checker.checkModule(List.of(fn));
+    var diag = findDiagnostic(diagnostics, ErrorCode.PII_SINK_UNSANITIZED);
+    assertNotNull(diag);
+    assertEquals("L2", diag.data().get("level"));
+  }
+
+  @Test
+  void testL2ToEmitSink_shouldError() {
+    var fn = func(
+      "emit_email",
+      List.of(piiParam("email", "L2", "email")),
+      textType(),
+      List.of(returnStmt(callExpr("emit", nameExpr("email")))),
+      List.of("io")
+    );
+    var diagnostics = checker.checkModule(List.of(fn));
+    var diag = findDiagnostic(diagnostics, ErrorCode.PII_SINK_UNSANITIZED);
+    assertNotNull(diag);
+    assertEquals("L2", diag.data().get("level"));
+  }
+
+  @Test
+  void testL2SanitizedToHttpSink_shouldAllow() {
+    // redact 把 L2 降级为 L1，因此抵达 sink 时无需再报错。
+    var fn = func(
+      "post_redacted_email",
+      List.of(piiParam("email", "L2", "email")),
+      textType(),
+      List.of(
+        letStmt("safe", callExpr("redact", nameExpr("email"))),
+        returnStmt(callExpr("Http.post", stringLiteral("https://x"), nameExpr("safe")))
+      ),
+      List.of("io")
+    );
+    var diagnostics = checker.checkModule(List.of(fn));
+    assertFalse(hasCode(diagnostics, ErrorCode.PII_SINK_UNSANITIZED));
+  }
+
+  @Test
+  void testL2SanitizedToSqlSink_shouldAllow() {
+    var fn = func(
+      "store_tokenized_email",
+      List.of(piiParam("email", "L2", "email")),
+      textType(),
+      List.of(
+        letStmt("safe", callExpr("tokenize", nameExpr("email"))),
+        returnStmt(callExpr("Sql.insert", nameExpr("safe")))
+      ),
+      List.of("io")
+    );
+    var diagnostics = checker.checkModule(List.of(fn));
+    assertFalse(hasCode(diagnostics, ErrorCode.PII_SINK_UNSANITIZED));
+  }
+
+  @Test
+  void testL2ToConsoleSink_unchangedStillErrors() {
+    var fn = func(
+      "print_email",
+      List.of(piiParam("email", "L2", "email")),
+      textType(),
+      List.of(returnStmt(callExpr("IO.print", nameExpr("email")))),
+      List.of("io")
+    );
+    var diagnostics = checker.checkModule(List.of(fn));
+    var diag = findDiagnostic(diagnostics, ErrorCode.PII_SINK_UNSANITIZED);
+    assertNotNull(diag);
+    assertEquals("L2", diag.data().get("level"));
+  }
+
   private boolean hasCode(List<Diagnostic> diagnostics, ErrorCode code) {
     return diagnostics.stream().anyMatch(diag -> diag.code() == code);
   }

--- a/src/test/java/aster/core/typecheck/capability/ManifestReaderTest.java
+++ b/src/test/java/aster/core/typecheck/capability/ManifestReaderTest.java
@@ -1,0 +1,45 @@
+package aster.core.typecheck.capability;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * ManifestReader 失败即关闭（fail-closed）测试。
+ * <p>
+ * 当 manifest 路径被显式指定但不可读 / 内容非法时，必须抛错而非静默放行——
+ * 否则能力/effect 边界会被悄悄绕过。
+ */
+class ManifestReaderTest {
+
+  @Test
+  void nullPathThrows() {
+    assertThrows(IllegalArgumentException.class, () -> ManifestReader.read(null));
+  }
+
+  @Test
+  void missingFileThrowsFailClosed() {
+    var missing = Path.of("does-not-exist-" + System.nanoTime() + ".json");
+    assertThrows(IllegalArgumentException.class, () -> ManifestReader.read(missing));
+  }
+
+  @Test
+  void invalidJsonThrowsFailClosed(@TempDir Path dir) throws IOException {
+    var path = dir.resolve("broken.json");
+    Files.writeString(path, "{ this is not valid json ");
+    // IOException -> IllegalStateException（fail-closed），不会返回空配置静默放行。
+    assertThrows(IllegalStateException.class, () -> ManifestReader.read(path));
+  }
+
+  @Test
+  void unknownCapabilityThrowsFailClosed(@TempDir Path dir) throws IOException {
+    var path = dir.resolve("bad-cap.json");
+    Files.writeString(path, "{\"capabilities\":{\"allow\":[\"NotARealCapability\"]}}");
+    assertThrows(IllegalArgumentException.class, () -> ManifestReader.read(path));
+  }
+}


### PR DESCRIPTION
From the ecosystem review (#24). **Review-only — security-sensitive.**

- **ReDoS guard** (HIGH): new `RegexGuard` with (a) static `screen()` rejecting >1000-char and nested-quantifier patterns, and (b) `replaceAllWithTimeout()` running on a daemon thread over an `InterruptibleCharSequence` with a 2s watchdog (`RegexTimeoutException`). Wired into `RegexTransformer`, `Canonicalizer.applyCustomRules`, `LexiconValidator`, and `LexiconRegistry` (registration-time screen). Verified: `(.*a){20}$` on long input fails fast in ~1.7s (vs ~70s unguarded on JDK 25).
- **PII L2 sink enforcement** (HIGH): `checkSinkAllowed` now flags unsanitized L2 at NETWORK/DATABASE/EMIT (mirroring L3); `redact`/`tokenize` downgrade to L1 so sanitized data passes.
- **Module mangling collisions** (HIGH): `ModuleKey.mangle()` escapes `_`→`__` before `.`→`_` (so `a.b` ≠ `a_b`); `ModuleGraphLinker.assertNoManglePrefixCollisions` throws on duplicate prefixes.
- **Fail-closed config** (MEDIUM): confirmed `ManifestReader`/`loadManifestFromEnv` re-throw on missing/invalid manifest (+test); `EffectConfig` now logs a WARNING before defaulting instead of silently swallowing.
- **Dead `shouldEnforcePii()` stub** removed (LOW).

Deferred (noted, `// TODO(#24)` left at `CoreLowering.java`): the lowering→typecheck `CapabilityKind`/`CapabilityChecker` coupling refactor; version-from-tag.

**Tests:** 5 new/updated classes, 39/39 pass standalone on JDK 25 (catastrophic-pattern watchdog, L2 sink matrix, mangling collisions, fail-closed manifest). Full gradle `test` couldn't run in-sandbox (`aster-lang-test:1.0.2` 403s without CI creds) — main sources compile clean; **CI is authoritative**.

For CI review: the static nested-quantifier screen intentionally doesn't catch exact-count `{n}` nesting (e.g. `(.*a){20}`) — that's covered by the match-time watchdog by design; a one-line tweak can extend the static screen if preferred.

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0178JewiMVqy1SMfVqfKbDom)_