### PR TITLE
refactor(core): extract capability types to neutral package; release tag↔version guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # 校验推送的 v* tag（去掉前导 v）与 build.gradle.kts 中的 version 一致，
+      # 不一致即提前失败，避免 v1.0.3 tag 却发布出 1.0.2 的版本漂移（#26）。
+      # 镜像 aster-lang-test release-maven.yml 的守卫模式；保持静态 version，
+      # 不引入动态 version 派生（后者会破坏本地构建的稳定性）。
+      - name: Verify tag matches build.gradle.kts version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' build.gradle.kts | head -n1)
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Error: Tag version ($TAG_VERSION) does not match build.gradle.kts version ($PKG_VERSION)"
+            exit 1
+          fi
+
       # 共享版本目录（aster-lang-platform，ADR 0012）—— core settings 依赖它。
       - uses: actions/checkout@v6
         with:

--- a/src/main/java/aster/core/capability/CapabilityInference.java
+++ b/src/main/java/aster/core/capability/CapabilityInference.java
@@ -1,0 +1,86 @@
+package aster.core.capability;
+
+import aster.core.ir.CoreModel;
+import aster.core.ir.visitor.DefaultCoreVisitor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Capability 推断工具（中立模块）。
+ * <p>
+ * 该类不依赖任何具体编译阶段（typecheck / lowering），仅基于 Core IR 推断
+ * 调用名称对应的资源能力，供 lowering（phase 4）与 typecheck（phase 3）共同复用，
+ * 避免 lowering -&gt; typecheck 的层级耦合。
+ */
+public final class CapabilityInference {
+
+  private static final Map<CapabilityKind, List<String>> CAPABILITY_PREFIXES = Map.ofEntries(
+    Map.entry(CapabilityKind.HTTP, List.of("Http.")),
+    Map.entry(CapabilityKind.SQL, List.of("Db.", "Sql.")),
+    Map.entry(CapabilityKind.TIME, List.of("Time.", "Clock.")),
+    Map.entry(CapabilityKind.FILES, List.of("Files.", "Fs.")),
+    Map.entry(CapabilityKind.SECRETS, List.of("Secrets.")),
+    Map.entry(CapabilityKind.AI_MODEL, List.of("Ai.")),
+    Map.entry(CapabilityKind.PAYMENT, List.of("Payment.")),
+    Map.entry(CapabilityKind.INVENTORY, List.of("Inventory."))
+  );
+
+  private CapabilityInference() {
+  }
+
+  /**
+   * 推断调用名称对应的 capability。
+   */
+  public static Optional<CapabilityKind> inferCapabilityFromName(String name) {
+    if (name == null || name.isBlank()) {
+      return Optional.empty();
+    }
+    for (var entry : CAPABILITY_PREFIXES.entrySet()) {
+      for (var prefix : entry.getValue()) {
+        if (name.startsWith(prefix)) {
+          return Optional.of(entry.getKey());
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * 收集代码块中的 capability 使用情况。
+   *
+   * @return capability -&gt; 调用列表
+   */
+  public static Map<CapabilityKind, List<String>> collectCapabilities(CoreModel.Block body) {
+    if (body == null) {
+      return Collections.emptyMap();
+    }
+    var capabilities = new EnumMap<CapabilityKind, List<String>>(CapabilityKind.class);
+    new CapabilityCollector(capabilities).visitBlock(body, null);
+    return capabilities;
+  }
+
+  private static final class CapabilityCollector extends DefaultCoreVisitor<Void> {
+
+    private final Map<CapabilityKind, List<String>> capabilities;
+
+    CapabilityCollector(Map<CapabilityKind, List<String>> capabilities) {
+      this.capabilities = capabilities;
+    }
+
+    @Override
+    public Void visitExpression(CoreModel.Expr expr, Void ctx) {
+      if (expr instanceof CoreModel.Call call && call.target instanceof CoreModel.Name name) {
+        inferCapabilityFromName(name.name).ifPresent(cap -> {
+          var entries = capabilities.computeIfAbsent(cap, ignored -> new ArrayList<>());
+          entries.add(name.name);
+        });
+      }
+      return super.visitExpression(expr, ctx);
+    }
+  }
+}

--- a/src/main/java/aster/core/capability/CapabilityKind.java
+++ b/src/main/java/aster/core/capability/CapabilityKind.java
@@ -1,4 +1,4 @@
-package aster.core.typecheck;
+package aster.core.capability;
 
 import java.util.Locale;
 import java.util.Optional;

--- a/src/main/java/aster/core/ir/visitor/CoreVisitor.java
+++ b/src/main/java/aster/core/ir/visitor/CoreVisitor.java
@@ -1,4 +1,4 @@
-package aster.core.typecheck.visitor;
+package aster.core.ir.visitor;
 
 import aster.core.ir.CoreModel;
 

--- a/src/main/java/aster/core/ir/visitor/DefaultCoreVisitor.java
+++ b/src/main/java/aster/core/ir/visitor/DefaultCoreVisitor.java
@@ -1,4 +1,4 @@
-package aster.core.typecheck.visitor;
+package aster.core.ir.visitor;
 
 import aster.core.ir.CoreModel;
 

--- a/src/main/java/aster/core/lowering/CoreLowering.java
+++ b/src/main/java/aster/core/lowering/CoreLowering.java
@@ -1,12 +1,9 @@
 package aster.core.lowering;
 
 import aster.core.ast.*;
+import aster.core.capability.CapabilityInference;
+import aster.core.capability.CapabilityKind;
 import aster.core.ir.CoreModel;
-import aster.core.typecheck.CapabilityKind;
-import aster.core.typecheck.checkers.CapabilityChecker;
-// TODO(#24): lowering 依赖 typecheck（CapabilityKind / CapabilityChecker）造成 lowering->typecheck
-//   的层级耦合。应将 lowering 与 typecheck 解耦（capability 元数据下沉到 IR 或独立模块），
-//   并把模块版本改为从 git tag 派生。此次 PR 不做该架构重构，仅留记号。
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -224,11 +221,10 @@ public final class CoreLowering {
   private CoreModel.Workflow lowerWorkflow(Stmt.Workflow workflow) {
     CoreModel.Workflow out = new CoreModel.Workflow();
     out.steps = new ArrayList<>();
-    var capabilityChecker = new CapabilityChecker();
     String previousStep = null;
     if (workflow.steps() != null) {
       for (Stmt.WorkflowStep step : workflow.steps()) {
-        CoreModel.Step lowered = lowerWorkflowStep(step, previousStep, capabilityChecker);
+        CoreModel.Step lowered = lowerWorkflowStep(step, previousStep);
         out.steps.add(lowered);
         previousStep = step.name();
       }
@@ -251,8 +247,7 @@ public final class CoreLowering {
 
   private CoreModel.Step lowerWorkflowStep(
       Stmt.WorkflowStep step,
-      String previousStep,
-      CapabilityChecker capabilityChecker
+      String previousStep
   ) {
     CoreModel.Step lowered = new CoreModel.Step();
     lowered.name = step.name();
@@ -265,20 +260,19 @@ public final class CoreLowering {
     } else {
       lowered.dependencies = new ArrayList<>();
     }
-    lowered.effectCaps = collectStepCapabilities(capabilityChecker, lowered.body, lowered.compensate);
+    lowered.effectCaps = collectStepCapabilities(lowered.body, lowered.compensate);
     lowered.origin = spanToOrigin(step.span());
     return lowered;
   }
 
   private List<String> collectStepCapabilities(
-      CapabilityChecker capabilityChecker,
       CoreModel.Block body,
       CoreModel.Block compensate
   ) {
     var merged = new LinkedHashSet<String>();
-    mergeCapabilityMap(capabilityChecker.collectCapabilities(body), merged);
+    mergeCapabilityMap(CapabilityInference.collectCapabilities(body), merged);
     if (compensate != null) {
-      mergeCapabilityMap(capabilityChecker.collectCapabilities(compensate), merged);
+      mergeCapabilityMap(CapabilityInference.collectCapabilities(compensate), merged);
     }
     return new ArrayList<>(merged);
   }

--- a/src/main/java/aster/core/typecheck/capability/ManifestConfig.java
+++ b/src/main/java/aster/core/typecheck/capability/ManifestConfig.java
@@ -1,6 +1,6 @@
 package aster.core.typecheck.capability;
 
-import aster.core.typecheck.CapabilityKind;
+import aster.core.capability.CapabilityKind;
 
 import java.util.Collections;
 import java.util.EnumSet;

--- a/src/main/java/aster/core/typecheck/capability/ManifestReader.java
+++ b/src/main/java/aster/core/typecheck/capability/ManifestReader.java
@@ -1,6 +1,6 @@
 package aster.core.typecheck.capability;
 
-import aster.core.typecheck.CapabilityKind;
+import aster.core.capability.CapabilityKind;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/src/main/java/aster/core/typecheck/checkers/CapabilityChecker.java
+++ b/src/main/java/aster/core/typecheck/checkers/CapabilityChecker.java
@@ -1,16 +1,15 @@
 package aster.core.typecheck.checkers;
 
+import aster.core.capability.CapabilityInference;
+import aster.core.capability.CapabilityKind;
 import aster.core.ir.CoreModel;
-import aster.core.typecheck.CapabilityKind;
+import aster.core.ir.visitor.DefaultCoreVisitor;
 import aster.core.typecheck.ErrorCode;
 import aster.core.typecheck.capability.ManifestConfig;
 import aster.core.typecheck.model.Diagnostic;
-import aster.core.typecheck.visitor.DefaultCoreVisitor;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -27,17 +26,6 @@ import java.util.Set;
  */
 public final class CapabilityChecker {
 
-  private static final Map<CapabilityKind, List<String>> CAPABILITY_PREFIXES = Map.ofEntries(
-    Map.entry(CapabilityKind.HTTP, List.of("Http.")),
-    Map.entry(CapabilityKind.SQL, List.of("Db.", "Sql.")),
-    Map.entry(CapabilityKind.TIME, List.of("Time.", "Clock.")),
-    Map.entry(CapabilityKind.FILES, List.of("Files.", "Fs.")),
-    Map.entry(CapabilityKind.SECRETS, List.of("Secrets.")),
-    Map.entry(CapabilityKind.AI_MODEL, List.of("Ai.")),
-    Map.entry(CapabilityKind.PAYMENT, List.of("Payment.")),
-    Map.entry(CapabilityKind.INVENTORY, List.of("Inventory."))
-  );
-
   private final List<Diagnostic> diagnostics = new ArrayList<>();
   private ManifestConfig manifest;
 
@@ -47,33 +35,22 @@ public final class CapabilityChecker {
 
   /**
    * 推断调用名称对应的 capability。
+   *
+   * <p>实际逻辑已下沉至中立模块 {@link CapabilityInference}，此处保留委托方法以维持现有调用点。
    */
   public static Optional<CapabilityKind> inferCapabilityFromName(String name) {
-    if (name == null || name.isBlank()) {
-      return Optional.empty();
-    }
-    for (var entry : CAPABILITY_PREFIXES.entrySet()) {
-      for (var prefix : entry.getValue()) {
-        if (name.startsWith(prefix)) {
-          return Optional.of(entry.getKey());
-        }
-      }
-    }
-    return Optional.empty();
+    return CapabilityInference.inferCapabilityFromName(name);
   }
 
   /**
    * 收集代码块中的 capability 使用情况。
    *
+   * <p>实际逻辑已下沉至中立模块 {@link CapabilityInference}，此处保留委托方法以维持现有调用点。
+   *
    * @return capability -> 调用列表
    */
   public Map<CapabilityKind, List<String>> collectCapabilities(CoreModel.Block body) {
-    if (body == null) {
-      return Collections.emptyMap();
-    }
-    var capabilities = new EnumMap<CapabilityKind, List<String>>(CapabilityKind.class);
-    new CapabilityCollector(capabilities).visitBlock(body, null);
-    return capabilities;
+    return CapabilityInference.collectCapabilities(body);
   }
 
   /**
@@ -381,26 +358,6 @@ public final class CapabilityChecker {
       Optional.ofNullable(code.help()),
       data == null ? Map.of() : Map.copyOf(data)
     ));
-  }
-
-  private static final class CapabilityCollector extends DefaultCoreVisitor<Void> {
-
-    private final Map<CapabilityKind, List<String>> capabilities;
-
-    CapabilityCollector(Map<CapabilityKind, List<String>> capabilities) {
-      this.capabilities = capabilities;
-    }
-
-    @Override
-    public Void visitExpression(CoreModel.Expr expr, Void ctx) {
-      if (expr instanceof CoreModel.Call call && call.target instanceof CoreModel.Name name) {
-        inferCapabilityFromName(name.name).ifPresent(cap -> {
-          var entries = capabilities.computeIfAbsent(cap, ignored -> new ArrayList<>());
-          entries.add(name.name);
-        });
-      }
-      return super.visitExpression(expr, ctx);
-    }
   }
 
   private void checkManifestConstraints(CoreModel.Func func) {

--- a/src/test/java/aster/core/capability/CapabilityInferenceTest.java
+++ b/src/test/java/aster/core/capability/CapabilityInferenceTest.java
@@ -1,0 +1,65 @@
+package aster.core.capability;
+
+import aster.core.ir.CoreModel;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 守护中立 capability 模块（#26）。
+ * <p>
+ * {@link CapabilityInference} 是 lowering（phase 4）与 typecheck（phase 3）共享的
+ * capability 推断来源，从 typecheck 下沉至此以解除 lowering -&gt; typecheck 的层级耦合。
+ * 该模块仅依赖 IR，本测试直接覆盖其推断逻辑，确保下沉后行为不变。
+ */
+class CapabilityInferenceTest {
+
+  @Test
+  void inferCapabilityFromNameMatchesKnownPrefix() {
+    assertEquals(CapabilityKind.HTTP, CapabilityInference.inferCapabilityFromName("Http.get").orElseThrow());
+    assertEquals(CapabilityKind.SQL, CapabilityInference.inferCapabilityFromName("Db.query").orElseThrow());
+    assertEquals(CapabilityKind.SQL, CapabilityInference.inferCapabilityFromName("Sql.exec").orElseThrow());
+  }
+
+  @Test
+  void inferCapabilityFromNameUnknownReturnsEmpty() {
+    assertTrue(CapabilityInference.inferCapabilityFromName("Custom.call").isEmpty());
+    assertTrue(CapabilityInference.inferCapabilityFromName(null).isEmpty());
+    assertTrue(CapabilityInference.inferCapabilityFromName("  ").isEmpty());
+  }
+
+  @Test
+  void collectCapabilitiesAggregatesCallsAcrossNestedBlocks() {
+    var caps = CapabilityInference.collectCapabilities(
+      blockWithStatements(returnCall("Http.get"), returnCall("Db.query"))
+    );
+
+    assertEquals(List.of("Http.get"), caps.get(CapabilityKind.HTTP));
+    assertEquals(List.of("Db.query"), caps.get(CapabilityKind.SQL));
+  }
+
+  @Test
+  void collectCapabilitiesNullBodyReturnsEmpty() {
+    assertTrue(CapabilityInference.collectCapabilities(null).isEmpty());
+  }
+
+  private CoreModel.Block blockWithStatements(CoreModel.Stmt... statements) {
+    var block = new CoreModel.Block();
+    block.statements = List.of(statements);
+    return block;
+  }
+
+  private CoreModel.Return returnCall(String targetName) {
+    var name = new CoreModel.Name();
+    name.name = targetName;
+    var call = new CoreModel.Call();
+    call.target = name;
+    call.args = List.of();
+    var ret = new CoreModel.Return();
+    ret.expr = call;
+    return ret;
+  }
+}

--- a/src/test/java/aster/core/typecheck/checkers/CapabilityCheckerTest.java
+++ b/src/test/java/aster/core/typecheck/checkers/CapabilityCheckerTest.java
@@ -1,7 +1,7 @@
 package aster.core.typecheck.checkers;
 
+import aster.core.capability.CapabilityKind;
 import aster.core.ir.CoreModel;
-import aster.core.typecheck.CapabilityKind;
 import aster.core.typecheck.ErrorCode;
 import aster.core.typecheck.capability.ManifestConfig;
 import aster.core.typecheck.capability.ManifestReader;


### PR DESCRIPTION
Follow-up to the review (#24 → #26). **Review-only.** Behavior-preserving refactor; affected-package tests pass (JDK 25). Full suite needs the lang-pack SPI artifacts the release workflow publishes — CI authoritative.

**1. Decouple lowering → typecheck.** Removed the phase-4→phase-3 dependency:
- `CapabilityKind` moved `aster.core.typecheck` → **`aster.core.capability`** (neutral; both phases depend on it).
- Extracted **`aster.core.capability.CapabilityInference`** (`inferCapabilityFromName`, `collectCapabilities`, `CAPABILITY_PREFIXES`) out of `CapabilityChecker`; depends only on IR.
- Moved the generic IR visitor `CoreVisitor`/`DefaultCoreVisitor` `aster.core.typecheck.visitor` → **`aster.core.ir.visitor`** (pure IR traversal) so the neutral module needs nothing from typecheck.
- `CapabilityChecker` stays in typecheck and now delegates to `CapabilityInference` (zero call-site churn). `CoreLowering` drops the `CapabilityChecker` dependency and calls `CapabilityInference` directly — **no `typecheck` import remains** (verified by grep); the old `// TODO(#24)` removed.
- +`CapabilityInferenceTest` guarding the neutral seam.

**2. Version-from-tag guard.** Added an early tag↔`build.gradle.kts` version assertion to `release.yml` (mirrors aster-lang-test's pattern), kept the static version to avoid destabilizing local builds (rationale in commit).

Refs #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0178JewiMVqy1SMfVqfKbDom)_