### PR TITLE
fix(lexicon): retry SPI discovery so all bundled lexicons load deterministically

### DIFF
--- a/.claude/review-report.md
+++ b/.claude/review-report.md
@@ -1,0 +1,72 @@
+# 代码审查报告 — LexiconRegistry SPI 加载竞态修复（多副本 lexicon 不一致）
+
+**审查时间**: 2026-06-20
+**审查人**: Codex（生成者=Claude，交叉审查，无自审）
+**被审查任务**: 修复 aster-api 多副本 /api/v1/lexicons 随机丢 locale（前端"刷新随机 on/off"根因）
+
+---
+
+## 执行摘要
+
+**综合评分**: 92/100（第二轮，修复后）
+**审查建议**: 通过
+**品味评分**: 好品味（重试控制流与共享诊断映射解耦，iterator 失败信号本轮局部化）
+
+第一轮 78/100 **退回**（抓出 1 致命 + 2 真问题）；按建议重构后第二轮 92/100 通过。
+
+---
+
+## 根因（生产实测）
+
+aster-api K3S 6 副本，逐 pod /api/v1/lexicons：3/6 副本各丢**不同的一个** locale（zh/de/hi）→
+前端忠实渲染命中 pod → 语言开关"刷新随机 on/off"。en-US 永远在（core 内嵌默认）；zh/de/hi
+走 SPI 语言包 jar。`LexiconRegistry.discoverPluginsDetailed` 用 ServiceLoader lazy 迭代，旧容错
+= best-effort + 连续 2 次失败 abort：多副本并行启动 + 堆压力（maxHeap=384MB）下 lazy iter.next()
+偶发 ServiceConfigurationError → 静默丢插件，无重试、无完整性校验。
+
+---
+
+## 第一轮抓出的 3 个问题（已全部修复）
+
+1. **【致命】带 provider hint 的 iterator 失败不重试**：旧 retry 判定依赖失败 key 的
+   `startsWith("spi-iter#")`，但 `extractProviderHint` 成功时 key=provider class —— 而生产**最常见**
+   的 "Provider &lt;fqcn&gt; could not be instantiated" 正带 provider class → 漏判 → **不重试** →
+   根因没修。**修**：iterator catch 现**无条件** `++iterFailures`，provider hint 只影响诊断 key。
+2. **【并发】重试控制流读/removeIf 共享 discoveryFailures**：与 hot-plug 并发写竞争 + stale key 污染。
+   **修**：新增 private record `DiscoveryPass(newlyRegistered, iteratorFailures)`，`discoverPlugins`
+   重试判定用**本轮局部** `iteratorFailures`，**不再**碰共享 map。public `discoverPluginsDetailed`
+   签名不变（委托 private `discoverPluginsPass`）。
+3. **【测试】缺 provider-hint 瞬时失败覆盖**：**补** `testTransientSpiFailureWithProviderHintRecoveredByRetry`
+   （首轮 service 文件插不存在的 provider class → iter.next() 抛带 hint 的错 → 第二轮恢复，断言
+   zh-CN 加齐；旧逻辑此测试必失败）。
+
+## 设计要点
+- iterator 级失败（hasNext/next 抛错=瞬时类加载/解析）→ 计入 iterFailures → 重试。
+- provider 级失败（iter.next 成功后的 ABI/validate/register 失败=确定性）→ 不计入 → 不重试。
+- 重试上限 MAX_DISCOVERY_PASSES=3 + 单轮 maxIterFailures=8（防真卡死）→ 有界终止。
+- 构造器加 logStartupLexiconSummary（多副本诊断，坏副本此前连日志都没有）。
+
+---
+
+## 五层法（第二轮）
+- 第一层 数据结构：✅ entries.putIfAbsent 幂等；DiscoveryPass 本轮局部信号。
+- 第二层 特殊情况：✅ iterator-vs-provider 失败分类正确（瞬时重试 / 确定性 skip）。
+- 第三层 复杂度：✅ public/private 拆分干净，hot-plug 行为不变。
+- 第四层 破坏性：✅ public API 签名不变；读路径 availableIds/get 未动。
+- 第五层 可行性：✅ 真修根因（带 hint 瞬时失败也重试），有界终止。
+
+---
+
+## 致命问题
+无（第一轮的致命问题已修）。
+
+## 剩余非阻断（已知，未改）
+- 无 provider hint 的瞬时失败恢复后，匿名 spi-iter# 诊断可能残留触发 summary WARN（不影响控制流）。
+- deterministic provider instantiation failure 在 iter.next() 时也会重试最多 3 轮（成本有界，可接受）。
+
+---
+
+## 验证
+core 全 **1220 测试 0 fail**；LexiconRegistryTest **36 测试**（含 2 个新重试测试：无 hint + 带 hint）全绿。
+
+**结论**: 可以合入。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,16 @@ jobs:
           path: aster-lang-locales
           token: ${{ secrets.CROSS_REPO_TOKEN }}
 
+      # 共享测试 corpus（cloud.aster-lang:aster-lang-test）。core 的
+      # testImplementation(asterLibs.test) 依赖它；GH Packages 未必有当前版本，
+      # 故 sibling-checkout 后 publishToMavenLocal（与下方 parity job 同范式）。
+      # 缺这步会让 :testCompileClasspath 解析 aster-lang-test:<ver> 失败。
+      - uses: ./.github/actions/checkout-sibling
+        with:
+          repository: aster-cloud/aster-lang-test
+          path: aster-lang-test
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
+
       - uses: actions/setup-java@v5
         with:
           java-version: '25'
@@ -55,6 +65,11 @@ jobs:
         run: |
           ln -sfn "$PWD" aster-lang-core
           cd aster-lang-locales && ./gradlew publishToMavenLocal -x test
+
+      # Phase 2b: 发布测试 corpus 到 Maven Local（core test 的 testImplementation 依赖）。
+      - name: Publish test corpus to Maven Local
+        working-directory: aster-lang-test/packages/jvm
+        run: ./gradlew publishToMavenLocal -x test
 
       # Phase 3: 运行 core 完整构建（含测试）
       - name: Test

--- a/src/main/java/aster/core/lexicon/LexiconRegistry.java
+++ b/src/main/java/aster/core/lexicon/LexiconRegistry.java
@@ -124,6 +124,21 @@ public final class LexiconRegistry {
         // 其他语言包通过 SPI 机制按需注册（META-INF/services/aster.core.lexicon.LexiconPlugin）。
         // 若 en-US plugin 也在 classpath，discoverPlugins() 会因 ID 已注册而跳过，避免双注册。
         discoverPlugins();
+        // 完整性日志：明确打印启动后最终注册的 lexicon ids，便于多副本部署排查"某副本少一门
+        // 语言"（此前坏副本连日志都没有）。仍有 discoveryFailures 残留则一并 WARN。
+        logStartupLexiconSummary();
+    }
+
+    /** 启动 SPI 发现后打印最终 lexicon 清单 + 残留失败（多副本一致性诊断）。 */
+    private void logStartupLexiconSummary() {
+        java.util.List<String> ids = new java.util.ArrayList<>(availableIds());
+        java.util.Collections.sort(ids);
+        LOGGER.info(() -> "Lexicon registry ready: available=" + ids);
+        if (!discoveryFailures.isEmpty()) {
+            LOGGER.warning(() -> "Lexicon SPI discovery left "
+                + discoveryFailures.size() + " unresolved entries after retries: "
+                + discoveryFailures);
+        }
     }
 
     /**
@@ -599,21 +614,54 @@ public final class LexiconRegistry {
         return discoverPlugins(Thread.currentThread().getContextClassLoader());
     }
 
+    /** discoverPlugins 启动重试的最大轮数（首轮 + 重试）。 */
+    private static final int MAX_DISCOVERY_PASSES = 3;
+
     /**
      * 通过 SPI 在指定 {@link ClassLoader} 上发现并注册语言包插件。
      * <p>
      * 显式传 loader 让 hot-plug 路径无需污染调用线程的 contextClassLoader。
      * 调用者负责在加载阶段保留 loader 引用（避免被 GC 收走、jar 类被卸载）。
      * <p>
-     * 容错策略：单个 service entry 抛错（Quarkus jar 缺失会包成 RuntimeException）
-     * 时跳过该 entry；连续两次失败就放弃本次发现，避免 lazy iterator 卡死。
+     * 容错策略（R-multi-replica）：bundled SPI 语言包是确定性依赖，启动时偶发的
+     * {@link ServiceConfigurationError}（多副本并行启动 + 堆压力下的类加载竞态）是**瞬时**的。
+     * 因此 discover **重试**：每轮用**全新** {@link ServiceLoader}（不复用可能卡死的 lazy
+     * iterator）重扫，{@link #entries} 的 putIfAbsent 天然幂等，只补缺失的。重试判定用**本轮
+     * 局部**的 iterator 级失败数（{@link DiscoveryPass#iteratorFailures}，与共享诊断映射
+     * {@link #discoveryFailures} 解耦——后者并发 hot-plug 也会写，不可作控制流）：本轮有 iterator
+     * 级瞬时失败且未达上限（{@link #MAX_DISCOVERY_PASSES}）就再扫一轮，0 失败即停。这样把
+     * "best-effort 静默丢插件" 改为"最终一致加载全部 bundled 语言包"，消除跨副本
+     * /api/v1/lexicons 不一致。
      *
      * @param loader 用于 SPI 扫描的 classloader。{@code null} 表示用 system loader
-     * @return 成功加载的插件数量
+     * @return 成功加载的插件数量（累计本次调用各轮新注册）
      */
     public int discoverPlugins(ClassLoader loader) {
-        return discoverPluginsDetailed(loader).size();
+        Set<String> allNewlyRegistered = new HashSet<>();
+        for (int pass = 1; pass <= MAX_DISCOVERY_PASSES; pass++) {
+            // 重试判定用**本轮局部** iterator 级失败数（DiscoveryPass.iteratorFailures），
+            // **不**读共享 discoveryFailures 映射——后者既是诊断又是并发 hot-plug 写入的，
+            // 用它做控制流会被 stale key / 并发写入污染（Codex 审查）。也**不**依赖失败 key
+            // 的 "spi-iter#" 前缀：带 provider hint 的瞬时 ServiceConfigurationError（生产
+            // 最常见的类加载竞态）key=provider class，但它仍是 iterator 级瞬时失败、**应重试**。
+            DiscoveryPass result = discoverPluginsPass(loader);
+            allNewlyRegistered.addAll(result.newlyRegistered());
+            // iterator 级失败（瞬时类加载/解析）才重试；确定性 ABI/validate 失败不计入
+            // iteratorFailures（它们在 provider 解析成功之后发生，是真该 skip 的，见 pass 内）。
+            if (result.iteratorFailures() == 0) {
+                break;
+            }
+            if (pass < MAX_DISCOVERY_PASSES) {
+                LOGGER.warning("Lexicon SPI discovery pass " + pass + " had "
+                    + result.iteratorFailures() + " iterator-level failure(s); "
+                    + "retrying with a fresh ServiceLoader.");
+            }
+        }
+        return allNewlyRegistered.size();
     }
+
+    /** 一轮 SPI 发现的结果：本轮新注册的 id + iterator 级瞬时失败次数（重试判定用）。 */
+    private record DiscoveryPass(Set<String> newlyRegistered, int iteratorFailures) {}
 
     /**
      * R4：discoverPlugins 的"详细"变体——返回**本次调用真正新注册**的 lexicon
@@ -627,28 +675,45 @@ public final class LexiconRegistry {
      * 知道"新 loader 真正提供了哪些 lexicon"以便跟踪并在删除时清理。
      */
     public Set<String> discoverPluginsDetailed(ClassLoader loader) {
+        return discoverPluginsPass(loader).newlyRegistered();
+    }
+
+    /**
+     * 单轮 SPI 发现的内部实现，返回 {@link DiscoveryPass}（新注册 id + iterator 级瞬时失败数）。
+     * iterator 级失败数供 {@link #discoverPlugins} 决定是否重试——这是**本轮局部信号**，
+     * 与共享 {@link #discoveryFailures} 诊断映射解耦（后者并发 hot-plug 也会写，不可作控制流）。
+     */
+    private DiscoveryPass discoverPluginsPass(ClassLoader loader) {
         Set<String> newlyRegistered = new HashSet<>();
         int skipped = 0;
         Iterator<LexiconPlugin> iter = ServiceLoader.load(LexiconPlugin.class, loader).iterator();
-        int consecutiveFailures = 0;
+        // 单轮内 lazy iterator 失败的总上限：防真卡死的 iterator 无限循环，但**不**因瞬时失败
+        // （类加载竞态）就放弃后续 provider。瞬时失败靠 discoverPlugins() 的重试包装补齐
+        // （每轮 new ServiceLoader）。MAX 远超 bundled 插件数，仅作真卡死止损阀。
+        int iterFailures = 0;
+        final int maxIterFailures = 8;
         while (true) {
             LexiconPlugin plugin;
             try {
                 if (!iter.hasNext()) break;
                 plugin = iter.next();
-                consecutiveFailures = 0;
             } catch (ServiceConfigurationError | RuntimeException e) {
+                // **iterator 级失败 = 瞬时**（hasNext/next 抛错：缺类、解析竞态、provider 实例化
+                // 失败）。无论能否提取 provider hint，都计入 iterFailures 触发重试——生产最常见
+                // 的 "Provider <fqcn> could not be instantiated" 带 provider class，仍是瞬时的。
+                ++iterFailures;
                 String providerHint = extractProviderHint(e);
                 String key = providerHint != null
                     ? providerHint
-                    : "spi-iter#" + System.currentTimeMillis() + "-" + consecutiveFailures;
+                    : "spi-iter#" + System.currentTimeMillis() + "-" + iterFailures;
                 String msg = e.getClass().getSimpleName() + ": " + e.getMessage();
                 discoveryFailures.put(key, msg);
                 LOGGER.log(java.util.logging.Level.WARNING,
                     "Skipping unresolved LexiconPlugin entry [" + key + "]: " + msg, e);
-                if (++consecutiveFailures >= 2) {
-                    LOGGER.warning("Two consecutive plugin iterator failures — aborting SPI discovery. "
-                        + "Backbone en-US remains available; affected locales will fall back via FallbackLexicon.");
+                if (iterFailures >= maxIterFailures) {
+                    LOGGER.warning("SPI iterator failed " + maxIterFailures + " times this pass — "
+                        + "aborting this discovery pass (likely a genuinely stuck lazy iterator). "
+                        + "discoverPlugins() retry will re-scan with a fresh ServiceLoader.");
                     break;
                 }
                 continue;
@@ -713,7 +778,7 @@ public final class LexiconRegistry {
             LOGGER.info(() -> "Lexicon ABI summary: loaded=" + finalLoaded
                 + " skipped=" + finalSkipped + " (incompatible)");
         }
-        return newlyRegistered;
+        return new DiscoveryPass(newlyRegistered, iterFailures);
     }
 
     /**

--- a/src/test/java/aster/core/lexicon/LexiconRegistryTest.java
+++ b/src/test/java/aster/core/lexicon/LexiconRegistryTest.java
@@ -658,4 +658,105 @@ class LexiconRegistryTest {
             }
         }
     }
+
+    /**
+     * R-multi-replica：模拟多副本启动时的**瞬时 SPI 失败**——首轮 getResources 抛 IOException
+     * （ServiceLoader 扫不到 provider → 该轮丢插件），后续轮恢复。验证 discoverPlugins 的重试
+     * 包装最终把全部 bundled lexicon 加齐（消除"某副本少一门语言"的跨副本不一致）。
+     *
+     * <p>背景：生产 6 副本各丢不同的一个 locale（zh/de/hi），因 ServiceLoader lazy 迭代在类
+     * 加载竞态下偶发失败，旧实现 best-effort 静默丢弃。新实现重试直到完整。
+     */
+    @Test
+    void testTransientSpiFailureRecoveredByRetry() {
+        ClassLoader real = LexiconPlugin.class.getClassLoader();
+        final String svc = "META-INF/services/aster.core.lexicon.LexiconPlugin";
+
+        // 把 zh-CN 物理移除，模拟"本副本尚未加载 zh"。
+        registry.unregister("zh-CN");
+        assertFalse(registry.has("zh-CN"), "前置：zh-CN 已移除");
+
+        // 首轮对 LexiconPlugin service 资源抛 IOException（瞬时），之后放行到真实 loader。
+        java.util.concurrent.atomic.AtomicInteger svcCalls = new java.util.concurrent.atomic.AtomicInteger();
+        ClassLoader flaky = new ClassLoader(real) {
+            @Override
+            public java.util.Enumeration<java.net.URL> getResources(String name) throws java.io.IOException {
+                if (svc.equals(name) && svcCalls.getAndIncrement() == 0) {
+                    // 首次扫描 LexiconPlugin service 文件 → 瞬时失败（类加载竞态的等价物）。
+                    throw new java.io.IOException("simulated transient SPI resource failure");
+                }
+                return super.getResources(name);
+            }
+        };
+
+        try {
+            // discoverPlugins 内部重试：第 1 轮 getResources 抛 IOException（ServiceLoader 该轮
+            // 报 ServiceConfigurationError / 扫不到），第 2 轮恢复 → zh-CN 最终加齐。
+            int loaded = registry.discoverPlugins(flaky);
+            assertTrue(svcCalls.get() >= 2,
+                "应至少触发 2 次 getResources（首轮失败 + 重试），实际=" + svcCalls.get());
+            assertTrue(registry.has("zh-CN"),
+                "重试后 zh-CN 应已加齐（瞬时失败不应导致永久丢失）；loaded=" + loaded);
+        } finally {
+            if (!registry.has("zh-CN")) {
+                registry.discoverPlugins(LexiconPlugin.class.getClassLoader());
+            }
+        }
+    }
+
+    /**
+     * R-multi-replica（Codex 审查补充）：模拟**带 provider class** 的瞬时
+     * ServiceConfigurationError —— 生产最常见的类加载竞态 "Provider &lt;fqcn&gt; could not be
+     * instantiated / not found"。首轮 service 文件多一行**不存在的 provider 类**，使
+     * iter.next() 抛 ServiceConfigurationError（带 provider hint，key=该 class 名），第二轮
+     * 该坏行消失 → 恢复。验证：**iterator 级失败无论是否带 provider hint 都触发重试**
+     * （此前的 bug：带 hint 时 key 非 "spi-iter#" 前缀 → 漏判 → 不重试）。
+     */
+    @Test
+    void testTransientSpiFailureWithProviderHintRecoveredByRetry() throws Exception {
+        ClassLoader real = LexiconPlugin.class.getClassLoader();
+        final String svc = "META-INF/services/aster.core.lexicon.LexiconPlugin";
+
+        registry.unregister("zh-CN");
+        assertFalse(registry.has("zh-CN"), "前置：zh-CN 已移除");
+
+        // 把首轮要"注入坏行"的临时 service 文件写到 temp dir，URL 指向它。
+        java.nio.file.Path tmpDir = java.nio.file.Files.createTempDirectory("flaky-spi");
+        java.nio.file.Path svcFile = tmpDir.resolve("svc-bad.txt");
+        // 不存在的 provider 类 → ServiceLoader.iterator().next() 抛
+        // ServiceConfigurationError: Provider aster.bogus.DoesNotExistPlugin not found（带 hint）。
+        java.nio.file.Files.writeString(svcFile, "aster.bogus.DoesNotExistPlugin\n");
+        java.net.URL badUrl = svcFile.toUri().toURL();
+
+        java.util.concurrent.atomic.AtomicInteger svcCalls = new java.util.concurrent.atomic.AtomicInteger();
+        ClassLoader flaky = new ClassLoader(real) {
+            @Override
+            public java.util.Enumeration<java.net.URL> getResources(String name) throws java.io.IOException {
+                java.util.List<java.net.URL> urls = java.util.Collections.list(super.getResources(name));
+                // 仅**首轮**在真实 service 资源**前面**插入坏 URL，让 ServiceLoader 先迭代到坏
+                // 行抛错（带 provider hint），后续轮干净。
+                if (svc.equals(name) && svcCalls.getAndIncrement() == 0) {
+                    java.util.List<java.net.URL> withBad = new java.util.ArrayList<>();
+                    withBad.add(badUrl);
+                    withBad.addAll(urls);
+                    return java.util.Collections.enumeration(withBad);
+                }
+                return java.util.Collections.enumeration(urls);
+            }
+        };
+
+        try {
+            int loaded = registry.discoverPlugins(flaky);
+            assertTrue(svcCalls.get() >= 2,
+                "带 provider-hint 的瞬时失败也应触发重试（≥2 次扫描），实际=" + svcCalls.get());
+            assertTrue(registry.has("zh-CN"),
+                "重试后 zh-CN 应加齐——带 provider hint 的 iterator 失败也必须重试；loaded=" + loaded);
+        } finally {
+            java.nio.file.Files.deleteIfExists(svcFile);
+            java.nio.file.Files.deleteIfExists(tmpDir);
+            if (!registry.has("zh-CN")) {
+                registry.discoverPlugins(LexiconPlugin.class.getClassLoader());
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 目的

修生产 bug：`aster-lang.cloud/admin` 的 Platform language availability 开关**刷新随机 on/off**。

**根因**：aster-api K3S **6 副本**，逐 pod 实测 `/api/v1/lexicons`，**3/6 副本各丢不同的一个 locale**（zh/de/hi）。前端忠实渲染命中 pod 的返回 → 随机 on/off。`en-US` 永远在（core 内嵌默认）；`zh/de/hi` 走 SPI 语言包 jar。

`discoverPluginsDetailed` 用 `ServiceLoader` lazy 迭代，旧容错 = best-effort + 连续 2 次失败 abort。多副本并行启动 + 堆压力下 `iter.next()` 偶发 `ServiceConfigurationError`（类加载竞态）→ **静默丢插件，无重试**。

## 修复
- `discoverPlugins` 加**重试**（`MAX_DISCOVERY_PASSES=3`，每轮全新 `ServiceLoader`，`entries.putIfAbsent` 幂等只补缺失）。重试判定用**本轮局部** iterator 失败数（新 `record DiscoveryPass`），与共享 `discoveryFailures` 解耦。
- 去掉"连续 2 次失败 abort"，改单轮 `maxIterFailures=8` 止损 + iterator 失败**无条件**计数（含带 provider hint 的失败——旧逻辑漏判）。
- 构造器加 `logStartupLexiconSummary`。
- 单测：无 hint + 带 hint 两种瞬时失败各验重试后加齐。

## Codex 交叉审查
78/100 退回（抓出致命：带 provider-hint 瞬时失败不重试）→ 重构 → 92/100 通过。

## 验证
core 全 **1220 测试 0 fail**；`LexiconRegistryTest` 36（含 2 新测试）全绿。aster-api composite includeBuild core，部署自动拿到。

🤖 Generated with [Claude Code](https://claude.com/claude-code)