### PR TITLE
feat(lexicon): expose disabledIds() snapshot for cross-replica availability reconcile

### DIFF
--- a/src/main/java/aster/core/lexicon/LexiconRegistry.java
+++ b/src/main/java/aster/core/lexicon/LexiconRegistry.java
@@ -955,6 +955,22 @@ public final class LexiconRegistry {
     }
 
     /**
+     * 返回当前**软下线**（desiredDisabled）的 lexicon 归一化 ID 只读快照。
+     *
+     * <p>用途：跨副本可用性对账需要把“本副本实际下线集”与持久真相源（如 Redis SET）做差分，
+     * 从而恢复漏掉的 enable。直接读注册表是**唯一可靠的本地下线视图**——调用方自行跟踪“已应用
+     * 下线”易在 origin 路径漏记（本地 disable 后 self-broadcast 的 markUnavailable 返回 false）。
+     *
+     * <p>en-US backbone 永不会进入 desiredDisabled（{@link #markUnavailable} 守护），故不会出现在
+     * 此集合。返回防御性拷贝，调用方修改不影响内部状态。
+     *
+     * @return 归一化的已下线 ID 集合快照（可能为空）
+     */
+    public Set<String> disabledIds() {
+        return new HashSet<>(desiredDisabled);
+    }
+
+    /**
      * 异步通知所有监听器当前可用集合。
      * <p>
      * 实现选择：内联调用而非另起线程池。理由：

--- a/src/test/java/aster/core/lexicon/LexiconRegistryTest.java
+++ b/src/test/java/aster/core/lexicon/LexiconRegistryTest.java
@@ -222,6 +222,46 @@ class LexiconRegistryTest {
     }
 
     @Test
+    void testDisabledIdsReflectsDesiredDisabled() {
+        try {
+            assertFalse(registry.disabledIds().contains("zh-cn"),
+                "未下线时 disabledIds() 不含 zh-CN");
+
+            registry.markUnavailable("zh-CN");
+            // disabledIds() 返回归一化 ID（小写），跨副本对账据此与持久集差分。
+            assertTrue(registry.disabledIds().contains("zh-cn"),
+                "下线后 disabledIds() 应含归一化的 zh-cn");
+
+            registry.markAvailable("zh-CN");
+            assertFalse(registry.disabledIds().contains("zh-cn"),
+                "恢复后 disabledIds() 不再含 zh-cn");
+        } finally {
+            registry.markAvailable("zh-CN");
+        }
+    }
+
+    @Test
+    void testDisabledIdsNeverContainsEnUsBackbone() {
+        // en-US backbone 永不可下线（markUnavailable 守护）→ disabledIds() 必不含它。
+        registry.markUnavailable("en-US");
+        assertFalse(registry.disabledIds().contains("en-us"),
+            "en-US backbone 不可下线，disabledIds() 必不含");
+    }
+
+    @Test
+    void testDisabledIdsSnapshotIsDefensiveCopy() {
+        try {
+            registry.markUnavailable("zh-CN");
+            java.util.Set<String> snapshot = registry.disabledIds();
+            snapshot.clear(); // 修改快照不应影响注册表内部状态
+            assertFalse(registry.has("zh-CN"),
+                "清空 disabledIds() 返回的快照不应让 zh-CN 重新可用（防御性拷贝）");
+        } finally {
+            registry.markAvailable("zh-CN");
+        }
+    }
+
+    @Test
     void testDesiredDisabledPersistsAcrossRegisterCycle() {
         // M8 回归：在已注册的 zh-CN 上 markUnavailable 后，
         // 一次 hypothetical re-register 不应清除 desired-disabled 状态。


### PR DESCRIPTION
## 背景

aster-api 跑 K3S **6 副本**（ArgoCD）。admin 在 aster-lang.cloud/admin 软下线/恢复一门语言时，请求经负载均衡只命中**单个副本**，底层 `LexiconRegistry.markUnavailable/markAvailable` 改的是**该副本的内存 `desiredDisabled` 集**——其余 5 副本不知道 → `/api/v1/lexicons` 各副本返回不同 → 前端语言开关**"刷新随机 on/off"**（生产 bug）。

aster-api 侧用 **Redis SET 作持久真相源 + pub/sub 广播**实现跨副本同步。但 Redis pub/sub 是 best-effort，**丢消息是正常语义**（订阅断开、pod 卡顿、启动窗口）。活副本漏一条 enable 广播会**永久停在旧内存状态**，故 aster-api 需周期**对账**：把"本副本实际下线集"与 Redis SET 差分，恢复漏掉的 enable。

## 改动

新增 `public Set<String> disabledIds()`——返回 `desiredDisabled` 的**归一化防御性拷贝**（en-US backbone 永不在内，由 `markUnavailable` 守护）。

**为什么必须读注册表真值、而非让 aster-api 自行跟踪"已应用下线"**：origin pod（处理 admin disable 的那个）本地直接 `markUnavailable` 返回 true，随后 self-broadcast 的 disable 事件 `markUnavailable` 返回 false → 自跟踪集会**漏记**该 id → 该 pod 漏掉别处的 enable 时对账无法恢复。直接读注册表是唯一无漏记的本地下线视图。

## 测试

3 个单测（`LexiconRegistryTest`）：反映 `desiredDisabled` / 不含 en-US backbone / 返回防御性拷贝。`LexiconRegistryTest` 全绿。

## 风险

纯**新增只读方法**，无 API 破坏性、无 grammar/lexicon-data 变更（不触双引擎 parity）。aster-api 经 composite `includeBuild` 按源码消费此方法（无需 core 发版）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)