### PR TITLE
feat(grammar): expression-level if (ADR 0019 G2b)

### DIFF
--- a/src/main/antlr/AsterParser.g4
+++ b/src/main/antlr/AsterParser.g4
@@ -529,8 +529,17 @@ exprStmt
  * 表达式（多级优先级）
  * 优先级（低→高）：or < and < not < 比较 < 加减 < 乘除 < 函数调用 < 基本表达式
  */
+// ADR 0019 G2b：表达式级 if（`if cond then a else b`）作为完整表达式。锚在 expr 顶层
+// 而非进运算符优先级链：if-expr 是自带边界的完整表达式（then/else 划定子表达式范围），
+// 不参与 +/*/比较 的结合，从根本上避开 dangling-else 与运算符优先级歧义。else 必需
+// （表达式两个方向都必须有值）。thenExpr/elseExpr 递归用 expr → 支持嵌套 if-expr。
 expr
-    : orExpr
+    : ifExpr
+    | orExpr
+    ;
+
+ifExpr
+    : IF cond=orExpr inlineThen thenE=expr inlineElseSep elseE=expr
     ;
 
 // 逻辑或（最低优先级，左结合）。and/or 在表达式上下文是逻辑运算符；

--- a/src/main/java/aster/core/ast/Expr.java
+++ b/src/main/java/aster/core/ast/Expr.java
@@ -31,12 +31,13 @@ import java.util.List;
     @JsonSubTypes.Type(value = Expr.None.class, name = "None"),
     @JsonSubTypes.Type(value = Expr.ListLiteral.class, name = "ListLiteral"),
     @JsonSubTypes.Type(value = Expr.Lambda.class, name = "Lambda"),
-    @JsonSubTypes.Type(value = Expr.Await.class, name = "Await")
+    @JsonSubTypes.Type(value = Expr.Await.class, name = "Await"),
+    @JsonSubTypes.Type(value = Expr.IfExpr.class, name = "IfExpr")
 })
 public sealed interface Expr extends AstNode
     permits Expr.Name, Expr.Bool, Expr.Int, Expr.Long, Expr.Double, Expr.String, Expr.Null,
             Expr.Call, Expr.Construct, Expr.Ok, Expr.Err, Expr.Some, Expr.None, Expr.ListLiteral,
-            Expr.Lambda, Expr.Await {
+            Expr.Lambda, Expr.Await, Expr.IfExpr {
 
     /**
      * Name 名称表达式（变量引用或函数名）
@@ -320,6 +321,31 @@ public sealed interface Expr extends AstNode
         @Override
         public java.lang.String kind() {
             return "Await";
+        }
+    }
+
+    /**
+     * IfExpr 表达式级条件（ADR 0019 G2b）：{@code if cond then thenExpr else elseExpr}。
+     *
+     * <p>与语句级 {@link Stmt.If} 区别：这是**表达式**，三个分支都是 {@link Expr}（非块），
+     * 求值产出一个值，可作子表达式 / Return 值 / Let 绑定右侧。else 分支**必需**
+     * （表达式必须在两个方向都有值，否则类型不完整——与语句级 if 的 else 可选不同）。
+     *
+     * @param cond     条件表达式（须为 Bool）
+     * @param thenExpr 条件为真时求值的表达式
+     * @param elseExpr 条件为假时求值的表达式
+     * @param span     源码位置信息
+     */
+    @JsonTypeName("IfExpr")
+    record IfExpr(
+        @JsonProperty("cond") Expr cond,
+        @JsonProperty("thenExpr") Expr thenExpr,
+        @JsonProperty("elseExpr") Expr elseExpr,
+        @JsonProperty("span") Span span
+    ) implements Expr {
+        @Override
+        public java.lang.String kind() {
+            return "IfExpr";
         }
     }
 }

--- a/src/main/java/aster/core/ir/CoreModel.java
+++ b/src/main/java/aster/core/ir/CoreModel.java
@@ -426,9 +426,10 @@ public final class CoreModel {
     @JsonSubTypes.Type(value = Construct.class, name = "Construct"),
     @JsonSubTypes.Type(value = Call.class, name = "Call"),
     @JsonSubTypes.Type(value = Lambda.class, name = "Lambda"),
-    @JsonSubTypes.Type(value = Await.class, name = "Await")
+    @JsonSubTypes.Type(value = Await.class, name = "Await"),
+    @JsonSubTypes.Type(value = IfE.class, name = "IfExpr")
   })
-  public sealed interface Expr permits Name, Bool, IntE, LongE, DoubleE, StringE, NullE, Ok, Err, Some, NoneE, Construct, Call, Lambda, Await {}
+  public sealed interface Expr permits Name, Bool, IntE, LongE, DoubleE, StringE, NullE, Ok, Err, Some, NoneE, Construct, Call, Lambda, Await, IfE {}
 
   @JsonTypeName("Name")
   public static final class Name implements Expr {
@@ -529,6 +530,19 @@ public final class CoreModel {
   @JsonTypeName("Await")
   public static final class Await implements Expr {
     public Expr expr;       // 异步表达式（等待其完成）
+    public Origin origin;
+  }
+
+  /**
+   * IfE 表达式级条件（ADR 0019 G2b）：{@code if cond then thenE else elseE}，求值产出一个值。
+   * 与语句级 {@link If} 区别：三分支都是 {@link Expr}（非块），且 else 必需。
+   * kind 序列化为 "IfExpr"（与前端 AST + TS Core IR 对齐，双引擎 IR-parity 契约）。
+   */
+  @JsonTypeName("IfExpr")
+  public static final class IfE implements Expr {
+    public Expr cond;       // 条件（Bool）
+    public Expr thenE;      // 真分支表达式
+    public Expr elseE;      // 假分支表达式
     public Origin origin;
   }
 }

--- a/src/main/java/aster/core/ir/visitor/DefaultCoreVisitor.java
+++ b/src/main/java/aster/core/ir/visitor/DefaultCoreVisitor.java
@@ -243,6 +243,14 @@ public class DefaultCoreVisitor<Ctx> implements CoreVisitor<Ctx, Void> {
 
       // Lambda
       case CoreModel.Lambda lambda -> visitLambdaImpl(lambda, ctx);
+
+      // ADR 0019 G2b：表达式级 if —— 遍历三个子表达式（cond/then/else）。
+      case CoreModel.IfE ifx -> {
+        visitExpressionChild(ifx.cond, ctx);
+        visitExpressionChild(ifx.thenE, ctx);
+        visitExpressionChild(ifx.elseE, ctx);
+        yield null;
+      }
     };
   }
 

--- a/src/main/java/aster/core/lowering/CoreLowering.java
+++ b/src/main/java/aster/core/lowering/CoreLowering.java
@@ -426,6 +426,15 @@ public final class CoreLowering {
         out.origin = spanToOrigin(await.span());
         yield out;
       }
+      case Expr.IfExpr ifx -> {
+        // ADR 0019 G2b：表达式级 if 降为 Core IR IfE（保表达式语义，不展开成语句）。
+        CoreModel.IfE out = new CoreModel.IfE();
+        out.cond = lowerExpr(ifx.cond());
+        out.thenE = lowerExpr(ifx.thenExpr());
+        out.elseE = lowerExpr(ifx.elseExpr());
+        out.origin = spanToOrigin(ifx.span());
+        yield out;
+      }
       case Expr.ListLiteral list -> {
         CoreModel.Construct out = new CoreModel.Construct();
         out.typeName = "List";

--- a/src/main/java/aster/core/module/ModuleGraphLinker.java
+++ b/src/main/java/aster/core/module/ModuleGraphLinker.java
@@ -378,6 +378,12 @@ public final class ModuleGraphLinker {
           // captures 是局部闭包变量名，不参与顶层符号重命名。
         });
         case CoreModel.Await await -> rewriteExpr(await.expr);
+        case CoreModel.IfE ifx -> {
+          // ADR 0019 G2b：表达式级 if 的三个子表达式都可能含跨模块符号引用。
+          rewriteExpr(ifx.cond);
+          rewriteExpr(ifx.thenE);
+          rewriteExpr(ifx.elseE);
+        }
       }
     }
 

--- a/src/main/java/aster/core/parser/AstBuilder.java
+++ b/src/main/java/aster/core/parser/AstBuilder.java
@@ -998,6 +998,26 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
     // 表达式
     // ============================================================
 
+    // expr : ifExpr | orExpr —— 分派到对应子节点。默认 visitChildren 在多 alt 下不可靠，
+    // 显式取存在的那个分支。
+    @Override
+    public Expr visitExpr(AsterParser.ExprContext ctx) {
+        if (ctx.ifExpr() != null) {
+            return (Expr) visit(ctx.ifExpr());
+        }
+        return (Expr) visit(ctx.orExpr());
+    }
+
+    // ADR 0019 G2b：表达式级 if —— `IF cond=orExpr inlineThen thenE=expr inlineElseSep elseE=expr`
+    // → Expr.IfExpr{cond, thenExpr, elseExpr}。thenE/elseE 是 expr → 天然支持嵌套 if-expr。
+    @Override
+    public Expr visitIfExpr(AsterParser.IfExprContext ctx) {
+        Expr cond = (Expr) visit(ctx.cond);
+        Expr thenE = (Expr) visit(ctx.thenE);
+        Expr elseE = (Expr) visit(ctx.elseE);
+        return new Expr.IfExpr(cond, thenE, elseE, spanFrom(ctx));
+    }
+
     // 逻辑或：andExpr (OR andExpr)* → 左结合的 Call{Name "or", [l, r]}
     @Override
     public Expr visitOrExpr(AsterParser.OrExprContext ctx) {

--- a/src/main/java/aster/core/typecheck/TypeSystem.java
+++ b/src/main/java/aster/core/typecheck/TypeSystem.java
@@ -534,6 +534,9 @@ public final class TypeSystem {
         yield funcType;
       }
       case CoreModel.Construct ctor -> createTypeName(ctor.typeName);
+      // ADR 0019 G2b：表达式级 if 的静态类型 = then 分支类型（两分支类型一致由
+      // BaseTypeChecker.checkIfExpr 校验；此处取 then 作代表，null 时降级 unknown）。
+      case CoreModel.IfE ifx -> inferStaticType(ifx.thenE);
       default -> null;
     };
   }

--- a/src/main/java/aster/core/typecheck/checkers/BaseTypeChecker.java
+++ b/src/main/java/aster/core/typecheck/checkers/BaseTypeChecker.java
@@ -114,7 +114,35 @@ public final class BaseTypeChecker {
 
       // Await
       case CoreModel.Await await -> checkAwait(await, ctx);
+
+      // ADR 0019 G2b：表达式级 if —— cond 须 Bool，类型 = 两分支统一后的类型。
+      case CoreModel.IfE ifx -> checkIfExpr(ifx, ctx);
     };
+  }
+
+  /**
+   * 表达式级 if 类型推断（ADR 0019 G2b）：cond 须 Bool；类型 = then/else 两分支的统一类型。
+   * 与语句级 {@link #checkIf} 区别：else 必需（表达式两方向都要有值），故总是比较两分支。
+   * 分支类型不一致 → IF_BRANCH_MISMATCH（与语句级同一错误码），返回 then 分支类型继续推断。
+   */
+  private Type checkIfExpr(CoreModel.IfE ifx, VisitorContext ctx) {
+    var condType = typeOfExpr(ifx.cond, ctx);
+    if (!TypeSystem.equals(condType, createTypeName("Bool"), false)) {
+      diagnostics.typeMismatch(createTypeName("Bool"), condType, Optional.ofNullable(ifx.origin));
+    }
+    var thenType = typeOfExpr(ifx.thenE, ctx);
+    var elseType = typeOfExpr(ifx.elseE, ctx);
+    if (!TypeSystem.equals(thenType, elseType, false)) {
+      diagnostics.error(
+        ErrorCode.IF_BRANCH_MISMATCH,
+        Optional.ofNullable(ifx.origin),
+        Map.of(
+          "then", TypeSystem.format(thenType),
+          "else", TypeSystem.format(elseType)
+        )
+      );
+    }
+    return thenType;
   }
 
   // ========== 语句类型检查 ==========

--- a/src/main/java/aster/core/typecheck/checkers/EffectChecker.java
+++ b/src/main/java/aster/core/typecheck/checkers/EffectChecker.java
@@ -120,6 +120,12 @@ public final class EffectChecker {
         }
         yield maxEffect;
       }
+      // ADR 0019 G2b：表达式级 if 的效果 = 三个子表达式效果的并（否则分支里的
+      // io/async 调用会被 default→PURE 漏掉，导致效果分析失真）。
+      case CoreModel.IfE ifx -> join(
+        inferEffect(ifx.cond, ctx),
+        join(inferEffect(ifx.thenE, ctx), inferEffect(ifx.elseE, ctx))
+      );
       // 字面量和名称引用都是纯的
       default -> Effect.PURE;
     };

--- a/src/main/java/aster/core/typecheck/pii/PiiTypeChecker.java
+++ b/src/main/java/aster/core/typecheck/pii/PiiTypeChecker.java
@@ -238,6 +238,14 @@ public final class PiiTypeChecker {
       traverseBlock(lambda.body, lambdaEnv, lambdaCtx);
       return null;
     }
+    if (expr instanceof CoreModel.IfE ifx) {
+      // ADR 0019 G2b：表达式级 if —— cond/then/else 都要走 sink 检查（分支里可能有 sink
+      // 调用），结果 PII = 两分支 PII 的并（值可能来自任一分支）。
+      inferExprPii(ifx.cond, env, ctx);
+      var thenMeta = inferExprPii(ifx.thenE, env, ctx);
+      var elseMeta = inferExprPii(ifx.elseE, env, ctx);
+      return mergePiiMeta(thenMeta, elseMeta);
+    }
     return null;
   }
 
@@ -540,6 +548,7 @@ public final class PiiTypeChecker {
     if (expr instanceof CoreModel.Call call) return call.origin;
     if (expr instanceof CoreModel.Lambda lambda) return lambda.origin;
     if (expr instanceof CoreModel.Await await) return await.origin;
+    if (expr instanceof CoreModel.IfE ifx) return ifx.origin; // ADR 0019 G2b
     return null;
   }
 

--- a/src/test/java/aster/core/ast/CoreIrSchemaAbiTest.java
+++ b/src/test/java/aster/core/ast/CoreIrSchemaAbiTest.java
@@ -42,6 +42,8 @@ class CoreIrSchemaAbiTest {
         "Name", "Call", "Construct", "Lambda", "Await",
         "Int", "Long", "Double", "Bool", "String", "Null",
         "Ok", "Err", "Some", "None", "ListLiteral",
+        "IfExpr", // ADR 0019 G2b：表达式级 if（只增不删）
+
         // 语句 Stmt（注意 Workflow 的 kind() 返回小写 "workflow"）
         "Let", "Return", "If", "Match", "Set", "Start", "Wait", "Block", "Define", "workflow",
         // 类型 Type


### PR DESCRIPTION
ADR 0019 **G2b**：表达式级 if（`return if c then a else b`、`let x be if c then a else b`、嵌套 else-if 链、作子表达式）。新增 **Core IR `IfExpr` 节点**（用户选的最干净路线，非 IIFE 降糖）。

## 语法
`expr : ifExpr | orExpr`；`ifExpr : IF cond=orExpr THEN thenE=expr ELSE elseE=expr`。锚在 expr 顶层不进运算符优先级链（避 dangling-else + 优先级歧义）；**else 必需**；cond=orExpr（避 `if if` 歧义）；then/else=expr 支持嵌套。与 G2a 语句级 inline-if 在 statement 位置无歧义。ANTLR 重生成无冲突警告。

## 改动（穷尽覆盖所有 Expr 遍历点）
AST(Expr.IfExpr + AstBuilder) / Core IR(CoreModel.IfE + DefaultCoreVisitor) / Lowering / ModuleGraphLinker / Typecheck(checkIfExpr：cond 须 Bool + 两分支统一) / TypeSystem / EffectChecker(三子并避 default→PURE) / PiiTypeChecker(inferExprPii + exprOrigin) / CoreIrSchemaAbiTest golden。

## 验证
真引擎 eval `if score>90 then "A" else if score>70 then "B" else "C"` → 95→A,80→B,50→C。core 1223 测试全绿。与 TS/Truffle **双引擎 eval 逐字节一致**（parity fixture：aster-lang-test#feat/g2b-if-expression，parse 213/213）。Codex 审查 7.5→修订（抓出 TS 侧 PII/emitter 遗漏，已全修）。

依赖同名分支：aster-lang-ts / aster-lang-truffle / aster-lang-test 同名 `feat/g2b-if-expression`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)