### PR TITLE
fix(parser): 已声明记录类型的位置式构造改为编译期报错

### DIFF
--- a/src/main/java/aster/core/parser/AstBuilder.java
+++ b/src/main/java/aster/core/parser/AstBuilder.java
@@ -31,6 +31,12 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
     );
 
     private final Set<String> declaredTypeNames = new HashSet<>();
+    /**
+     * 可【构造】的类型名（Data/Enum 记录类型），不含 type alias。
+     * 仅用于「位置式构造禁止」检查——type alias 别名标量（如 Int），本就不该用
+     * {@code with..set to} 构造，故不纳入；与 aster-lang-ts 行为对齐。
+     */
+    private final Set<String> declaredRecordTypeNames = new HashSet<>();
 
     private record TypeWithAnnotations(Type type, List<Annotation> annotations) {}
 
@@ -47,6 +53,7 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
         }
 
         declaredTypeNames.clear();
+        declaredRecordTypeNames.clear();
         List<AsterParser.TopLevelDeclContext> declContexts = ctx.topLevelDecl();
         if (declContexts == null) {
             declContexts = List.of();
@@ -59,13 +66,16 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
                 TerminalNode typeName = declCtx.dataDecl().TYPE_IDENT();
                 if (typeName != null) {
                     declaredTypeNames.add(typeName.getText());
+                    declaredRecordTypeNames.add(typeName.getText());  // 可构造
                 }
             } else if (declCtx.enumDecl() != null) {
                 TerminalNode typeName = declCtx.enumDecl().TYPE_IDENT();
                 if (typeName != null) {
                     declaredTypeNames.add(typeName.getText());
+                    declaredRecordTypeNames.add(typeName.getText());  // 可构造
                 }
             } else if (declCtx.typeDecl() != null) {
+                // type alias 别名标量，不可构造 → 只进 declaredTypeNames，不进 record 集
                 AsterParser.TypeDeclContext typeDeclCtx = declCtx.typeDecl();
                 // ADR 0019 G1：类型别名名也可为软关键字（小写结构词）。与 visitTypeDecl
                 // 的取名分支保持一致，避免 declaredTypeNames 预扫描漏登记。
@@ -1562,6 +1572,18 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
     private Expr createCallExpression(Expr target, List<Expr> args, Span span) {
         if (target instanceof Expr.Name name) {
             String funcName = name.name();
+            // 位置式 `TypeName(args)` 对【已声明类型】不是合法语法——结构体构造必须用命名字段
+            // `TypeName with field set to expr and ...`。原先位置式被静默降级成函数调用，
+            // 后续才在执行期暴露为「未定义函数」；在此于构建期就报错并给出正确写法。
+            // 此检查置于 Ok/Err/Some/None 内置变体之前：若用户声明了同名记录类型（如 Define Ok），
+            // 以用户声明优先报错，与 TS 引擎行为一致（declaredRecordTypes 优先），保证 parity。
+            // 仅对【记录类型】报错，不含 type alias（别名标量本就不可构造）。
+            if (declaredRecordTypeNames.contains(funcName)) {
+                throw new IllegalStateException(
+                    "Cannot construct '" + funcName + "' with positional arguments. "
+                    + "Use named fields instead: '" + funcName
+                    + " with <field> set to <value> and ...'");
+            }
             switch (funcName) {
                 case "Ok" -> {
                     if (args.size() == 1) {

--- a/src/test/java/aster/core/parser/StructPositionalConstructionTest.java
+++ b/src/test/java/aster/core/parser/StructPositionalConstructionTest.java
@@ -1,0 +1,70 @@
+package aster.core.parser;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 回归测试：对已声明类型用位置式 {@code TypeName(args)} 构造，应在构建期报错并提示
+ * 用命名字段 {@code TypeName with field set to ...}，而非静默降级成函数调用。
+ * <p>
+ * 历史 bug：位置式被当作普通 Call，编译期不报错，直到执行期才暴露为「未定义函数」。
+ */
+class StructPositionalConstructionTest {
+
+    private aster.core.ast.Module pb(String input) {
+        var lexer = new AsterCustomLexer(org.antlr.v4.runtime.CharStreams.fromString(input));
+        var tokens = new org.antlr.v4.runtime.CommonTokenStream(lexer);
+        var parser = new AsterParser(tokens);
+        var ctx = parser.module();
+        return new AstBuilder().visitModule(ctx);
+    }
+
+    @Test
+    void positionalConstructOfDeclaredTypeErrors() {
+        String src = "Module a.b.\nDefine Box has v, w.\nRule f given x, produce:\n  Return Box(5, 6).\n";
+        var ex = assertThrows(IllegalStateException.class, () -> pb(src));
+        assertTrue(ex.getMessage().contains("Box"), "应提及类型名: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("set to"),
+            "应提示用命名字段 with..set to: " + ex.getMessage());
+    }
+
+    @Test
+    void namedFieldConstructWorks() {
+        String src = "Module a.b.\nDefine Box has v, w.\nRule f given x, produce:\n"
+            + "  Return Box with v set to 5 and w set to 6.\n";
+        assertDoesNotThrow(() -> pb(src));
+    }
+
+    @Test
+    void okBuiltinStillCallable() {
+        // Ok 是内置变体构造，不是已声明类型，位置式仍合法
+        String src = "Module a.b.\nRule f given x, produce:\n  Return Ok(x).\n";
+        assertDoesNotThrow(() -> pb(src));
+    }
+
+    @Test
+    void ordinaryFunctionCallStillWorks() {
+        // 普通函数调用（非类型名）不受影响
+        String src = "Module a.b.\nRule g given y, produce:\n  Return y.\n"
+            + "Rule f given x, produce:\n  Return g(x).\n";
+        assertDoesNotThrow(() -> pb(src));
+    }
+
+    @Test
+    void forwardReferencePositionalAlsoErrors() {
+        // Box 在 Define 之前被位置式构造——预扫描确保也报错（与 TS 引擎 parity）
+        String src = "Module a.b.\nRule f given x, produce:\n  Return Box(5, 6).\n"
+            + "Define Box has v, w.\n";
+        assertThrows(IllegalStateException.class, () -> pb(src));
+    }
+
+    @Test
+    void typeAliasIsNotTreatedAsConstructible() {
+        // type alias 别名标量(Score=Int)不是可构造记录类型，Score(5) 不应触发构造报错
+        // （与 TS parity；alias 不进 record 集）
+        String src = "Module a.b.\nRule f given x, produce:\n  Return Score(5).\n"
+            + "Type Score as Int.\n";
+        assertDoesNotThrow(() -> pb(src));
+    }
+}


### PR DESCRIPTION
## Bug

对已声明的记录类型（`Define...has` / `Define...as one of`）用位置式 `TypeName(args)` 构造，原先被静默降级成普通函数调用 Call，**编译期不报错**，直到执行期才暴露为「未定义函数」。正确语法是命名字段 `TypeName with field set to expr and ...`。

写迁移指南实证保险理赔规则时发现（位置式 `Adjudication("DECLINED", ...)` 编译过、运行时炸）。

## 修复

`createCallExpression` 在 Ok/Err/Some/None 内置变体之前检查 `declaredRecordTypeNames`——若是已声明记录类型，构建期即报错并给出正确写法。

要点（与 aster-lang-ts PR 配对，双引擎 parity）：
- **仅记录类型报错，type alias 不报错**：预扫描区分 `declaredTypeNames`（含 alias，供类型解析）vs `declaredRecordTypeNames`（仅 dataDecl/enumDecl，供构造禁止）。alias 别名标量本就不可构造。
- 检查置于内置变体 switch 之前：用户声明同名类型（`Define Ok`）优先报错
- Java 本就预扫描全部顶层声明 → 前向引用（`Define` 在后）也被拦

## 验证

6-case parity matrix 与 aster-lang-ts 逐一对拍全 PASS：record-forward 报错 / alias-forward 放行 / named-construct / Ok-shadow 报错 / plain-Ok / func-call。

回归测试 `StructPositionalConstructionTest`（6 例）。**core 全量 `./gradlew test` 绿**。

Codex 交叉审查（三轮，9/100→…→9/10 通过）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)