### PR TITLE
fix(parser): zh OF 家族关键词当标识符不再破坏解析（token 级位置消歧）

### DIFF
--- a/src/main/antlr/AsterLexer.g4
+++ b/src/main/antlr/AsterLexer.g4
@@ -183,9 +183,13 @@ PERFORMS: 'performs';
 // ============================================================
 
 // 类型标识符（Uppercase 开头，支持 Latin Extended 和 CJK 等 Unicode 字符）
+// 私有区标记  起头：Canonicalizer 把"非英文关键词当标识符"候选词包成
+// 原值 单 token（避免多词展开撑破标识符位置），由 AsterCustomLexer 按
+// 位置决定还原成标识符或展开成关键词（见该类）。
 TYPE_IDENT: [A-Z] IdentContinue*
           | LatinExtUpperChar IdentContinue*
           | CjkChar IdentContinue*
+          | KwIdentMarkerOpen IdentContinue*
           ;
 
 // 普通标识符（lowercase 或 _ 开头，支持 Latin Extended 和 CJK 等 Unicode 字符）
@@ -193,8 +197,14 @@ IDENT: [a-z_] IdentContinue*
      | LatinExtLowerChar IdentContinue*
      ;
 
-// 标识符续字符片段（字母、数字、下划线、Latin Extended、CJK 字符）
-fragment IdentContinue: [a-zA-Z0-9_] | LatinExtChar | CjkChar;
+// 私有区标记起止字符（U+E000 / U+E001），仅用于 Canonicalizer↔AsterCustomLexer 内部协议。
+fragment KwIdentMarkerOpen: '\uE000';
+fragment KwIdentMarkerClose: '\uE001';
+fragment KwIdentMarkerSep: '\uE002';
+fragment KwIdentMarkerSpace: '\uE003';
+
+// 标识符续字符片段（字母、数字、下划线、Latin Extended、CJK 字符、私有区标记）
+fragment IdentContinue: [a-zA-Z0-9_] | LatinExtChar | CjkChar | KwIdentMarkerOpen | KwIdentMarkerClose | KwIdentMarkerSep | KwIdentMarkerSpace;
 
 // Latin Extended 字符（德语 ü/ö/ä/ß、法语 é/è/ê 等）
 fragment LatinExtChar: [\u00C0-\u00FF]     // Latin-1 Supplement (À-ÿ)

--- a/src/main/java/aster/core/canonicalizer/Canonicalizer.java
+++ b/src/main/java/aster/core/canonicalizer/Canonicalizer.java
@@ -94,6 +94,75 @@ public final class Canonicalizer {
     private final List<Map.Entry<Pattern, String>> compiledCustomRules;
 
     /**
+     * "关键词当标识符"协议标记（私有区 U+E000 / U+E001）。
+     * <p>
+     * 非英文（zh）词法包下,【单源词→多英文词】的关键词(如 `结果`→`result of`)当用户标识符
+     * 时,多词展开会撑破标识符位置(`result of`=两 token)破坏解析。Canonicalizer 把这些源词
+     * 包成 {@code 原值} 单 token(不展开),由 AsterCustomLexer 按位置决定:标识符
+     * 位置剥标记还原成源词,关键词位置展开成英文关键词。保证 AST 标识符名=源词,与 TS 引擎
+     * 的 originalValue 还原机制 parity。
+     */
+    public static final char KW_IDENT_MARKER_OPEN = '\uE000';
+    public static final char KW_IDENT_MARKER_CLOSE = '\uE001';
+    /** \u6807\u8BB0\u5185\u5206\u9694\u3010\u6E90\u8BCD\u3011\u4E0E\u3010\u82F1\u6587\u5C55\u5F00\u5F62\u3011\u7684\u79C1\u6709\u533A\u5206\u9694\u7B26\uFF08U+E002\uFF09\u3002 */
+    public static final char KW_IDENT_MARKER_SEP = '\uE002';
+    /** \u6807\u8BB0\u5185\u82F1\u6587\u5C55\u5F00\u5F62\u91CC\u3010\u7A7A\u683C\u3011\u7684\u79C1\u6709\u533A\u5360\u4F4D\u7B26\uFF08U+E003\uFF09\uFF0C\u907F\u514D\u6807\u8BB0 token \u542B\u7A7A\u683C\u88AB\u62C6\u3002 */
+    public static final char KW_IDENT_MARKER_SPACE = '\uE003';
+
+    /**
+     * \u628A\u6E90\u8BCD + \u82F1\u6587\u5C55\u5F00\u5F62\u5305\u6210\u81EA\u5305\u542B\u7684\u5355 token \u6807\u8BB0\uFF1A{@code <OPEN>\u6E90\u8BCD<SEP>\u82F1\u6587\u5C55\u5F00<CLOSE>}\u3002
+     * \u82F1\u6587\u5C55\u5F00\u5F62\u91CC\u7684\u7A7A\u683C\u7528 SPACE \u5360\u4F4D\u7B26\u66FF\u6362\uFF0C\u4F7F\u6574\u4F53\u6210\u4E3A\u4E0D\u542B\u7A7A\u683C\u7684\u5355 token\u3002
+     */
+    public static String wrapKeywordIdent(String source, String englishExpansion) {
+        String enc = englishExpansion.replace(' ', KW_IDENT_MARKER_SPACE);
+        return KW_IDENT_MARKER_OPEN + source + KW_IDENT_MARKER_SEP + enc + KW_IDENT_MARKER_CLOSE;
+    }
+
+    /**
+     * 可包裹的 OF 家族关键词（{@code wrapExpr: IDENT OF expr} 文法）。这些关键词的英文形首词
+     * 是普通 IDENT（result/option/ok/err/some），与用户标识符真撞名,故包裹保护。其余"单源词→
+     * 多英文词"关键词(为以下之一/结果为/执行/对每个/等候/最多尝试)在固定语法位置或被文本级
+     * transformer 消费,不包裹。
+     */
+    private static final java.util.Set<SemanticTokenKind> WRAPPABLE_OF_FAMILY = java.util.Set.of(
+        SemanticTokenKind.RESULT_OF,
+        SemanticTokenKind.OPTION_OF,
+        SemanticTokenKind.OK_OF,
+        SemanticTokenKind.ERR_OF,
+        SemanticTokenKind.SOME_OF
+    );
+
+    /** 判断 token 文本是否是包裹的"关键词当标识符"标记。 */
+    public static boolean isWrappedKeywordIdent(String text) {
+        return text != null && text.length() >= 2
+            && text.charAt(0) == KW_IDENT_MARKER_OPEN
+            && text.charAt(text.length() - 1) == KW_IDENT_MARKER_CLOSE;
+    }
+
+    /** 从标记还原【源词】（标识符位置用）。返回 null 表示非标记。 */
+    public static String unwrapSource(String text) {
+        if (!isWrappedKeywordIdent(text)) {
+            return null;
+        }
+        int sep = text.indexOf(KW_IDENT_MARKER_SEP);
+        int end = sep >= 0 ? sep : text.length() - 1;
+        return text.substring(1, end);
+    }
+
+    /** 从标记还原【英文展开形】（关键词位置用，空格已解码）。返回 null 表示非标记。 */
+    public static String unwrapEnglish(String text) {
+        if (!isWrappedKeywordIdent(text)) {
+            return null;
+        }
+        int sep = text.indexOf(KW_IDENT_MARKER_SEP);
+        if (sep < 0) {
+            return null;
+        }
+        String enc = text.substring(sep + 1, text.length() - 1);
+        return enc.replace(KW_IDENT_MARKER_SPACE, ' ');
+    }
+
+    /**
      * 空白规范化所需的正则表达式
      */
     private static final Pattern SPACE_RUN_RE = Pattern.compile("[ \\t]+");
@@ -365,9 +434,22 @@ public final class Canonicalizer {
 
             String targetKeyword = targetLexicon.getKeywords().get(kind);
             if (targetKeyword != null && !sourceKeyword.equals(targetKeyword)) {
-                // 对关键词应用 customRules 变换，使翻译表匹配 customRules 处理后的文本
-                // 例如：德语 "gib zurueck" 经 customRules 后变为 "gib zurück"
-                translationMap.put(applyCustomRulesToKey(sourceKeyword), targetKeyword);
+                String srcCanon = applyCustomRulesToKey(sourceKeyword);
+                // "关键词当标识符"保护：单源词(无空格)翻成多英文词(含空格)的关键词,当用户标识符
+                // 时多词展开(`result of`=两 token)会撑破标识符位置。改为映射到自包含标记
+                // {@code 源词英文展开} 单 token,由 AsterCustomLexer 按位置还原(标识符)
+                // 或展开(关键词)。
+                // ★只包裹 OF 家族(wrapExpr `IDENT OF expr`):首词是普通 IDENT,与用户标识符真撞名。
+                //   结构短语(为以下之一/结果为/执行/对每个/等候/最多尝试)不包裹——它们在固定语法
+                //   位置或被文本级 transformer(如 ResultIsTransformer)消费,包裹会破坏其关键词用法。
+                if (WRAPPABLE_OF_FAMILY.contains(kind)
+                        && !srcCanon.trim().contains(" ") && targetKeyword.trim().contains(" ")) {
+                    translationMap.put(srcCanon, wrapKeywordIdent(sourceKeyword, targetKeyword));
+                } else {
+                    // 对关键词应用 customRules 变换，使翻译表匹配 customRules 处理后的文本
+                    // 例如：德语 "gib zurueck" 经 customRules 后变为 "gib zurück"
+                    translationMap.put(srcCanon, targetKeyword);
+                }
             }
         }
 

--- a/src/main/java/aster/core/parser/AsterCustomLexer.java
+++ b/src/main/java/aster/core/parser/AsterCustomLexer.java
@@ -2,8 +2,11 @@ package aster.core.parser;
 
 import org.antlr.v4.runtime.*;
 
+import aster.core.canonicalizer.Canonicalizer;
+
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Set;
 
 /**
  * 自定义 Lexer 类，扩展 ANTLR4 生成的 AsterLexer，添加缩进敏感语法支持。
@@ -53,6 +56,36 @@ public class AsterCustomLexer extends AsterLexer {
      */
     private boolean checkIndent = false;
 
+    /**
+     * 上一个返回的【有意义】token 的小写文本（跳过 INDENT/DEDENT/NEWLINE），
+     * 用于"关键词当标识符"标记的位置判定（前驱是否为结构关键词）。
+     */
+    private String prevMeaningfulLower = null;
+
+    /**
+     * 是否正处于【标识符声明列表】内（见过结构关键词,经逗号/and 延续,直到 `.`/`:`/换行结束）。
+     * 用于字段/参数列表里逗号后的标记 token（`年龄，结果`）仍判为标识符位置。
+     */
+    private boolean inIdentifierList = false;
+
+    /**
+     * 引出【标识符位置】的英文结构关键词（翻译后形式），前驱是它们则当前标记 token 是标识符。
+     * 含逗号/and（字段/参数列表延续，由 prevMeaningful 间接覆盖）。
+     */
+    // 引出【标识符声明位置】的结构关键词(其紧后是用户命名:类型/字段/参数/变量名)。
+    // 只保留【后继判定不足以消歧】的真声明头。注意:
+    //  - 不含 `as`/`produce`:引出【类型】,OF 家族在该位置是类型构造关键词,不能当标识符。
+    //  - 不含 `set`/`and`:construct 字段名在 set 之前;`and` 只是列表延续。
+    //  - 不含 `has`/`with`:它们也是函数调用后缀(`f with 成功值 x`),全局进列表会把调用参数里
+    //    的 OF 家族构造器误当标识符。改靠【后继 token 判定】消歧:
+    //      has 结果 .        → 后继是 `.` → 字段名(还原)
+    //      has 结果 as Text. → 后继是 `as` → 字段名(还原)
+    //      with 结果 set to  → 后继是 `set` → 构造字段名(还原)
+    //      f with 成功值 x   → 后继是 `x`(表达式起点) → 构造器(展开)
+    private static final Set<String> IDENTIFIER_INTRODUCERS = Set.of(
+        "define", "rule", "given", "let"
+    );
+
     public AsterCustomLexer(CharStream input) {
         super(input);
         indentStack.push(0); // 初始缩进为 0
@@ -62,7 +95,9 @@ public class AsterCustomLexer extends AsterLexer {
     public Token nextToken() {
         // 如果 pending 队列不为空，优先返回队列中的 token
         if (!pending.isEmpty()) {
-            return pending.poll();
+            Token p = pending.poll();
+            recordMeaningful(p);  // 展开 token 也须更新前驱状态,否则后续标记位置判定错位
+            return p;
         }
 
         // 如果需要检查缩进，先检查再返回下一个 token
@@ -70,12 +105,38 @@ public class AsterCustomLexer extends AsterLexer {
             checkIndent = false;
             handleIndentation();
             if (!pending.isEmpty()) {
-                return pending.poll();
+                Token p = pending.poll();
+                recordMeaningful(p);
+                return p;
             }
         }
 
-        // 获取下一个 token（从基类 AsterLexer）
-        Token t = super.nextToken();
+        // 获取下一个 token：优先消费 peek 缓存的（避免 OF 家族构造器判定时预读丢 token），
+        // 先返回预读保留的隐藏 token（注释 trivia），再返回真实 token，否则从基类取。
+        Token t;
+        if (!bufferedHidden.isEmpty()) {
+            return bufferedHidden.poll();  // 隐藏 token 直接返回,不参与标记/缩进/前驱逻辑
+        } else if (bufferedNext != null) {
+            t = bufferedNext;
+            bufferedNext = null;
+        } else {
+            t = super.nextToken();
+        }
+
+        // "关键词当标识符"标记 token：按位置还原成标识符或展开成英文关键词。
+        if (t.getType() != Token.EOF && Canonicalizer.isWrappedKeywordIdent(t.getText())) {
+            Token resolved = resolveWrappedKeywordIdent(t);
+            // resolveWrappedKeywordIdent 可能把展开 token 入 pending，这里返回首个
+            if (resolved != null) {
+                recordMeaningful(resolved);
+                return resolved;
+            }
+            if (!pending.isEmpty()) {
+                Token first = pending.poll();
+                recordMeaningful(first);
+                return first;
+            }
+        }
 
         // 如果遇到 EOF，生成所有剩余的 DEDENT token
         if (t.getType() == Token.EOF) {
@@ -107,7 +168,163 @@ public class AsterCustomLexer extends AsterLexer {
             return t;
         }
 
+        recordMeaningful(t);
         return t;
+    }
+
+    /**
+     * 记录上一个有意义 token 的小写文本（用于标记位置判定）。
+     * 跳过 NEWLINE/INDENT/DEDENT/EOF/隐藏通道——它们不影响"前驱是否结构关键词"判定。
+     */
+    private void recordMeaningful(Token t) {
+        int type = t.getType();
+        if (type == NEWLINE || type == AsterParser.INDENT || type == AsterParser.DEDENT
+                || type == Token.EOF || t.getChannel() == Token.HIDDEN_CHANNEL) {
+            return;
+        }
+        String txt = t.getText();
+        prevMeaningfulLower = txt == null ? null : txt.toLowerCase(java.util.Locale.ROOT);
+
+        // 维护"标识符声明列表"状态：结构关键词进入；`.`/`:`/`(`/`as`/`produce` 等结束；
+        // 其余（字段名/逗号/and）延续。`as`/`produce` 之后是【类型】(OF 家族在该位置是
+        // 类型构造关键词,非标识符),故退出列表。
+        if (prevMeaningfulLower != null && IDENTIFIER_INTRODUCERS.contains(prevMeaningfulLower)) {
+            inIdentifierList = true;
+        } else if (type == AsterParser.DOT || type == AsterParser.COLON
+                || type == AsterParser.LPAREN || type == AsterParser.RPAREN
+                || type == AsterParser.AS || type == AsterParser.BE || type == AsterParser.TO_WORD
+                || (prevMeaningfulLower != null && prevMeaningfulLower.equals("produce"))) {
+            // 语句/类型/调用/值边界 → 列表结束。
+            // BE(`Let x be <expr>`)/TO_WORD(`F set to <expr>`)之后是表达式值,
+            // 其中 OF 家族是构造器关键词,不能当标识符 → 退出列表。
+            inIdentifierList = false;
+        }
+        // 其余 token（字段名 IDENT、逗号、and）保持 inIdentifierList 不变，使
+        // `包含 年龄，结果` 里逗号后的 结果 仍判为标识符位置。
+    }
+
+    /**
+     * 解析"关键词当标识符"标记 token：按位置决定还原成标识符还是展开成英文关键词。
+     * <ul>
+     *   <li>标识符位置（前驱是结构关键词，或处于标识符声明列表内）→ 单 IDENT，文本=源词。</li>
+     *   <li>关键词位置 → 展开成英文关键词的各 token，逐个入 pending。</li>
+     * </ul>
+     * 返回直接返回的 token（标识符情形），或 null（已把展开 token 入 pending）。
+     */
+    private Token resolveWrappedKeywordIdent(Token t) {
+        String text = t.getText();
+        String source = Canonicalizer.unwrapSource(text);
+        String english = Canonicalizer.unwrapEnglish(text);
+        if (source == null || english == null) {
+            // 防御：格式异常时按英文展开（保持可解析）
+            english = source != null ? source : text;
+            source = null;
+        }
+
+        boolean afterIntroducer =
+            prevMeaningfulLower != null && IDENTIFIER_INTRODUCERS.contains(prevMeaningfulLower);
+        boolean inListContinuation = inIdentifierList;
+
+        // 判定标识符 vs 关键词(OF 家族 `IDENT OF expr` 构造器):
+        // - 前驱是结构关键词,或处于标识符声明列表内 → 声明位置,当标识符。
+        // - 否则看【后继 token】:OF 家族关键词形需要 expr 操作数(`成功值 x`),若后继能起一个
+        //   表达式 → 当关键词(展开);若后继是句末符/逗号/右括号/换行/EOF → 当标识符(变量引用等)。
+        // 不用全局"已声明名"集合(会污染后续同形关键词,破坏 parity)。
+        boolean asIdentifier;
+        if (source != null && (afterIntroducer || inListContinuation)) {
+            asIdentifier = true;
+        } else if (source != null) {
+            Token nextReal = peekNextRealToken();
+            asIdentifier = !startsExpression(nextReal);
+        } else {
+            asIdentifier = false;
+        }
+
+        if (asIdentifier) {
+            // 单 IDENT/TYPE_IDENT，文本=源词（与 TS 引擎标识符名一致）
+            int kind = isUppercaseStart(source) ? AsterParser.TYPE_IDENT : AsterParser.IDENT;
+            CommonToken id = new CommonToken(kind, source);
+            id.setLine(t.getLine());
+            id.setCharPositionInLine(t.getCharPositionInLine());
+            return id;
+        }
+
+        // 关键词位置：把英文展开形重新词法化成 token 入 pending。
+        expandEnglishToPending(english, t);
+        return null;
+    }
+
+    /** 预读的下一个真实 token（被 peekNextRealToken 缓存,nextToken 顶部优先消费）。 */
+    private Token bufferedNext = null;
+    /** 预读时遇到的 HIDDEN 通道 token（注释），保留以便按序返回,不丢 trivia。 */
+    private final Deque<Token> bufferedHidden = new ArrayDeque<>();
+
+    /**
+     * 预读下一个【真实】token（跳过但保留 HIDDEN 通道）并缓存,供 OF 家族构造器判定使用。
+     * 预读到的真实/隐藏 token 均缓存,由 nextToken 在 super.nextToken 之前按序优先返回,
+     * 既不丢真实语法 token,也不丢注释 trivia。
+     */
+    private Token peekNextRealToken() {
+        if (bufferedNext == null) {
+            Token n = super.nextToken();
+            while (n.getChannel() == Token.HIDDEN_CHANNEL && n.getType() != Token.EOF) {
+                bufferedHidden.add(n);  // 保留隐藏 token,稍后按序返回
+                n = super.nextToken();
+            }
+            bufferedNext = n;
+        }
+        return bufferedNext;
+    }
+
+    /**
+     * 判断 token 能否起一个表达式(OF 家族构造器的操作数)。
+     * 覆盖 primaryExpr/unaryExpr/ifExpr/lambdaExpr 的起点:标识符、字面量(含 null/bool)、
+     * 括号/列表、以及在表达式位置当软关键词的结构词(if/not/function/Map/let/match/... )。
+     */
+    private static boolean startsExpression(Token t) {
+        if (t == null) {
+            return false;
+        }
+        int type = t.getType();
+        return type == AsterParser.IDENT || type == AsterParser.TYPE_IDENT
+            || type == AsterParser.INT_LITERAL || type == AsterParser.FLOAT_LITERAL
+            || type == AsterParser.LONG_LITERAL || type == AsterParser.STRING_LITERAL
+            || type == AsterParser.BOOL_LITERAL || type == AsterParser.NULL_LITERAL
+            || type == AsterParser.LPAREN || type == AsterParser.LBRACKET
+            || type == AsterParser.FUNCTION || type == AsterParser.MAP
+            || type == AsterParser.IF || type == AsterParser.NOT
+            // 结构软关键词在表达式位置可当变量名/方法名(structKeywordName)
+            || type == AsterParser.LET || type == AsterParser.MATCH
+            || type == AsterParser.RETURN || type == AsterParser.RULE
+            || type == AsterParser.DEFINE || type == AsterParser.WHEN
+            || type == AsterParser.START || type == AsterParser.WAIT
+            || type == AsterParser.ELSE || type == AsterParser.THEN;
+    }
+
+    /** 把英文展开形（如 "result of"）重新词法化成 token，全部入 pending。 */
+    private void expandEnglishToPending(String english, Token at) {
+        AsterCustomLexer sub = new AsterCustomLexer(CharStreams.fromString(english));
+        Token st;
+        while ((st = sub.nextToken()).getType() != Token.EOF) {
+            int type = st.getType();
+            if (type == NEWLINE || type == AsterParser.INDENT || type == AsterParser.DEDENT) {
+                continue;
+            }
+            CommonToken ct = new CommonToken(type, st.getText());
+            ct.setLine(at.getLine());
+            ct.setCharPositionInLine(at.getCharPositionInLine());
+            pending.add(ct);
+        }
+    }
+
+    /** 判断源词首字符是否大写（决定 IDENT vs TYPE_IDENT；CJK 等无大小写归 TYPE_IDENT，与 ANTLR 规则一致）。 */
+    private static boolean isUppercaseStart(String s) {
+        if (s.isEmpty()) {
+            return false;
+        }
+        char c = s.charAt(0);
+        // ASCII 小写或下划线 → IDENT；其余（大写、CJK 等）→ TYPE_IDENT（同 AsterLexer.g4）
+        return !((c >= 'a' && c <= 'z') || c == '_');
     }
 
     /**

--- a/src/test/java/aster/core/canonicalizer/KeywordAsIdentifierTest.java
+++ b/src/test/java/aster/core/canonicalizer/KeywordAsIdentifierTest.java
@@ -1,0 +1,155 @@
+package aster.core.canonicalizer;
+
+import aster.core.lexicon.LexiconRegistry;
+import aster.core.parser.AsterCustomLexer;
+import aster.core.parser.AsterLexer;
+import aster.core.parser.AsterParser;
+import org.antlr.v4.runtime.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 回归测试：非英文（zh）词法包下，用户标识符与"单源词→多英文词"的 CNL 关键词同形时，
+ * 应在标识符位置当标识符（名=源词，与 TS 引擎 parity），在关键词位置仍当关键词。
+ * <p>
+ * 历史 bug：zh `结果`(RESULT_OF) 当字段名 → 翻译层展开成 `result of` 两 token → 撑破
+ * 标识符位置解析失败。修复：Canonicalizer 把这些源词包成自包含标记单 token，
+ * AsterCustomLexer 按位置还原（标识符）或展开（关键词）。
+ */
+class KeywordAsIdentifierTest {
+
+    private boolean parses(String src) {
+        var canon = new Canonicalizer(LexiconRegistry.getInstance().getOrThrow("zh-CN"), null);
+        String en = canon.canonicalize(src);
+        final boolean[] err = {false};
+        try {
+            var lexer = new AsterCustomLexer(CharStreams.fromString(en));
+            var tokens = new CommonTokenStream(lexer);
+            tokens.fill();
+            tokens.seek(0);
+            var parser = new AsterParser(tokens);
+            parser.removeErrorListeners();
+            parser.addErrorListener(new BaseErrorListener() {
+                @Override
+                public void syntaxError(Recognizer<?, ?> r, Object s, int l, int c, String m, RecognitionException e) {
+                    err[0] = true;
+                }
+            });
+            parser.module();
+        } catch (Exception e) {
+            err[0] = true;
+        }
+        return !err[0];
+    }
+
+    @Test
+    void resultOfKeywordAsFieldName() {
+        // 结果 = RESULT_OF 关键词，当字段名应解析成功
+        assertTrue(parses("模块 a.b。\n定义 盒子 包含 结果。\n"), "结果 当字段名");
+    }
+
+    @Test
+    void keywordIdentInFieldList() {
+        // 字段列表中逗号前后均可用关键词当字段名
+        assertTrue(parses("模块 a.b。\n定义 盒子 包含 年龄，结果。\n"), "年龄,结果");
+        assertTrue(parses("模块 a.b。\n定义 盒子 包含 结果，年龄。\n"), "结果,年龄");
+        assertTrue(parses("模块 a.b。\n定义 盒子 包含 年龄，结果，金额。\n"), "年龄,结果,金额");
+    }
+
+    @Test
+    void keywordIdentAsParamAndVar() {
+        assertTrue(parses("模块 a.b。\n规则 f 给定 结果 产出：\n  返回 结果。\n"), "结果 当参数名");
+        assertTrue(parses("模块 a.b。\n规则 f 给定 x，结果 产出：\n  返回 结果。\n"), "结果 参数列表");
+        assertTrue(parses("模块 a.b。\n规则 f 给定 x 产出：\n  令 结果 定义为 x。\n  返回 结果。\n"), "结果 当变量名+引用");
+    }
+
+    @Test
+    void keywordIdentAsTypeName() {
+        assertTrue(parses("模块 a.b。\n定义 结果 包含 值。\n"), "结果 当类型名");
+    }
+
+    @Test
+    void constructorKeywordWorksBothWays() {
+        // 成功值 = OK_OF 是真构造器：既能当字段名（标识符）又能当构造器（关键词）
+        assertTrue(parses("模块 a.b。\n定义 盒子 包含 成功值。\n"), "成功值 当字段名");
+        assertTrue(parses("模块 a.b。\n规则 f 给定 x 产出：\n  返回 成功值 x。\n"), "成功值 x 构造器");
+    }
+
+    @Test
+    void identifierNameEqualsSourceWord() {
+        // parity 硬约束：标识符名 = 源词 `结果`（与 TS 引擎一致），且无标记残留
+        var canon = new Canonicalizer(LexiconRegistry.getInstance().getOrThrow("zh-CN"), null);
+        String en = canon.canonicalize("模块 a.b。 定义 盒子 包含 结果。");
+        var lexer = new AsterCustomLexer(CharStreams.fromString(en));
+        var tokens = new CommonTokenStream(lexer);
+        tokens.fill();
+        boolean found = false;
+        for (var tok : tokens.getTokens()) {
+            if ("结果".equals(tok.getText())) {
+                found = true;
+            }
+            assertFalse(tok.getText().indexOf(Canonicalizer.KW_IDENT_MARKER_OPEN) >= 0,
+                "不应有标记残留: " + tok.getText());
+        }
+        assertTrue(found, "字段名 token 应为源词 结果");
+    }
+
+    @Test
+    void normalFieldsUnaffected() {
+        assertTrue(parses("模块 a.b。\n定义 盒子 包含 年龄，金额。\n"), "普通字段不受影响");
+    }
+
+    @Test
+    void ofFamilyInTypePositionStaysKeyword() {
+        // 类型注解位置(作为 结果 文本 = as result-of Text):结果 是类型构造关键词,非标识符
+        assertTrue(parses("模块 a.b。\n定义 盒子 包含 字段 作为 结果 文本。\n"), "结果 在类型注解位置");
+    }
+
+    @Test
+    void constructorWithNullOperand() {
+        // 成功值 空值 (ok of null):null 是合法表达式操作数,成功值 应当关键词展开
+        assertTrue(parses("模块 a.b。\n规则 f 给定 x 产出：\n  返回 成功值 空值。\n"), "成功值 空值");
+    }
+
+    @Test
+    void variableReferenceRestored() {
+        // 变量引用 `返回 结果`(结果 是先前 Let/参数声明):后继是句末符 → 还原成标识符
+        assertTrue(parses("模块 a.b。\n规则 f 给定 结果 产出：\n  返回 结果。\n"), "参数 结果 引用");
+        assertTrue(parses("模块 a.b。\n规则 f 给定 x 产出：\n  令 结果 定义为 x。\n  返回 结果。\n"), "变量 结果 引用");
+    }
+
+    @Test
+    void enumAndReturnShorthandUnaffected() {
+        // 结构短语(为以下之一/结果为)不被包裹,其 enum/return-shorthand 关键词用法不受影响
+        assertTrue(parses("模块 a.b。\n定义 状态 为以下之一 甲，乙。\n"), "为以下之一 enum");
+        assertTrue(parses("模块 a.b。\n规则 f 给定 x 产出：\n  结果为 x。\n"), "结果为 return shorthand");
+    }
+
+    @Test
+    void ofFamilyInValueRhsStaysKeyword() {
+        // 表达式右值位置(Let be / set to 之后)OF 家族是构造器关键词,不能被"声明列表"泄漏误当标识符
+        assertTrue(parses("模块 a.b。\n规则 f 给定 x 产出：\n  令 y 定义为 成功值 x。\n  返回 y。\n"),
+            "Let y be 成功值 x 构造器");
+    }
+
+    @Test
+    void ofFamilyAsFunctionName() {
+        // OF 家族当函数名(规则 结果 ...)应还原成标识符,名=源词(与 TS parity)
+        assertTrue(parses("模块 a.b。\n规则 结果 给定 x 产出：\n  返回 x。\n"), "结果 当函数名");
+    }
+
+    @Test
+    void structuralPhraseAsFieldRejected() {
+        // 结构短语当字段名两引擎都拒绝(仅 OF 家族还原,保持 parity)
+        assertFalse(parses("模块 a.b。\n定义 盒子 包含 为以下之一。\n"), "为以下之一 当字段名应拒绝");
+    }
+
+    @Test
+    void withAsCallSuffixStaysKeyword() {
+        // with(包含) 也是函数调用后缀(`g 包含 成功值 x`),其参数位置的 OF 家族是构造器关键词,
+        // 不能被误当声明字段名 → 靠后继(x 是表达式起点)判定为关键词展开
+        assertTrue(parses("模块 a.b。\n规则 g 给定 a 产出：\n  返回 a。\n\n"
+            + "规则 f 给定 x 产出：\n  返回 g 包含 成功值 x。\n"), "g 包含 成功值 x");
+    }
+}


### PR DESCRIPTION
## Bug

非英文（zh）词法包下，用户标识符与某 CNL 关键词的词同形时被翻译层翻译破坏解析。zh `结果`=RESULT_OF 当字段名 → 翻译层展开成 `result of` 两 token → 撑破标识符位置 → `Expected '.'`。

**范围**：只 zh 受影响（de 关键词单词不展开；EN 靠 `nameIdent` 软关键词容忍），且只【单源词→多英文词】的 **OF 家族**（`result/option/ok/err/some of`，`wrapExpr: IDENT OF expr` 文法，首词是普通 IDENT 真撞名）。

## 机制（与 aster-lang-ts originalValue 还原 parity，AST 标识符名 = 源词）

- **AsterLexer.g4**：IdentContinue 加私有区标记字符 U+E000~E003，让标记包裹的词 lex 成单 token
- **Canonicalizer**：OF 家族不翻成 `result of`，而包成自包含单 token 标记 `<源词><SEP><英文展开>`（`WRAPPABLE_OF_FAMILY` 白名单；结构短语如 `as one of`/`the result is` **不包裹**——它们被 transformer 消费或在固定语法位置）
- **AsterCustomLexer**（override nextToken）：标记 token 按位置还原成单 IDENT（名=源词）或展开成英文关键词。位置判定：声明头前驱 `{define,rule,given,let}` 或【后继 token】——OF 家族构造器需 expr 操作数，后继能起表达式 → 关键词展开，否则（句末/逗号/`as`/`set`）→ 标识符

## 覆盖

全标识符位置（字段/列表/参数/变量/类型/函数名）+ 引用 + 构造器 + 类型注解位置 + null 操作数；不破坏 enum / return-shorthand / with-call-suffix。回归测试 `KeywordAsIdentifierTest` 16 例。

## 验证

- **core 全量 `./gradlew test` 绿**；**tier1-parity 213/213 pass 0 divergent**
- 两引擎对同样 zh 关键词-标识符场景结果一致

**Codex 交叉审查四轮**（58→72→78→86→**94 通过**），逐轮抓出 parity/grammar 位置边界（结构短语 transformer 破坏 / declaredWrappedNames 全局污染 / 类型注解位置 / null 操作数 / with-call-suffix）。

配套 PR：aster-lang-ts 同名分支（须一起合，否则破 parity）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)