### PR TITLE
feat(lexicon): keyword alias mechanism (ADR 0022 Plan D)

### DIFF
--- a/src/main/java/aster/core/canonicalizer/Canonicalizer.java
+++ b/src/main/java/aster/core/canonicalizer/Canonicalizer.java
@@ -379,6 +379,14 @@ public final class Canonicalizer {
                 translationMap.put(applyCustomRulesToKey(sourceKeyword), symbol);
             }
 
+            // 运算符别名也翻成同一符号（ADR 0022，识别侧）。别名与规范拼写共享输出符号，
+            // 故 IR 不受影响。含已有运算符子串的多词别名靠最长匹配整体消费。
+            for (String alias : sourceLexicon.getAliases().getOrDefault(kind, List.of())) {
+                if (alias != null && !alias.isBlank() && !alias.equals(symbol)) {
+                    translationMap.putIfAbsent(applyCustomRulesToKey(alias), symbol);
+                }
+            }
+
             // 如果源语言不是英语，也需要添加英语关键词到符号的映射
             // 因为规范化后可能保留英语运算符关键词，需要再翻译为符号
             if (!"en-US".equals(sourceLexicon.getId())) {
@@ -389,8 +397,24 @@ public final class Canonicalizer {
             }
         }
 
-        // 2. 如果是英语词法表，只需要运算符符号翻译，不需要关键词翻译
+        // 2. 英语词法表：非运算符别名（如 FUNC_TO 的 "Policy"、IF 的 "Whenever"）需翻成
+        //    各自的英语规范关键词，否则 grammar 不认。运算符别名已在 §1 处理。
         if ("en-US".equals(sourceLexicon.getId())) {
+            for (Map.Entry<SemanticTokenKind, List<String>> e : sourceLexicon.getAliases().entrySet()) {
+                SemanticTokenKind kind = e.getKey();
+                if (OPERATOR_SYMBOL_MAP.containsKey(kind)) {
+                    continue; // 运算符别名已映射到符号
+                }
+                String canonical = sourceLexicon.getKeywords().get(kind);
+                if (canonical == null) {
+                    continue;
+                }
+                for (String alias : e.getValue()) {
+                    if (alias != null && !alias.isBlank() && !alias.equals(canonical)) {
+                        translationMap.putIfAbsent(applyCustomRulesToKey(alias), canonical);
+                    }
+                }
+            }
             return translationMap;
         }
 
@@ -449,6 +473,17 @@ public final class Canonicalizer {
                     // 对关键词应用 customRules 变换，使翻译表匹配 customRules 处理后的文本
                     // 例如：德语 "gib zurueck" 经 customRules 后变为 "gib zurück"
                     translationMap.put(srcCanon, targetKeyword);
+                }
+            }
+
+            // 该 kind 的源语言别名也翻成同一英语规范关键词（ADR 0022，识别侧）。
+            // 别名经校验保证不与标识符/其它关键词同形，故沿用与规范拼写相同的输出，
+            // 不做 OF 家族包裹（别名候选已排除会撑破标识符位置的形态）。
+            if (targetKeyword != null) {
+                for (String alias : sourceLexicon.getAliases().getOrDefault(kind, List.of())) {
+                    if (alias != null && !alias.isBlank()) {
+                        translationMap.putIfAbsent(applyCustomRulesToKey(alias), targetKeyword);
+                    }
                 }
             }
         }

--- a/src/main/java/aster/core/lexicon/DynamicLexicon.java
+++ b/src/main/java/aster/core/lexicon/DynamicLexicon.java
@@ -32,6 +32,7 @@ public final class DynamicLexicon implements Lexicon {
     private final String name;
     private final Direction direction;
     private final Map<SemanticTokenKind, String> keywords;
+    private final Map<SemanticTokenKind, List<String>> aliases;
     private final PunctuationConfig punctuation;
     private final CanonicalizationConfig canonicalization;
     private final ErrorMessages messages;
@@ -41,6 +42,7 @@ public final class DynamicLexicon implements Lexicon {
             String name,
             Direction direction,
             Map<SemanticTokenKind, String> keywords,
+            Map<SemanticTokenKind, List<String>> aliases,
             PunctuationConfig punctuation,
             CanonicalizationConfig canonicalization,
             ErrorMessages messages
@@ -49,6 +51,16 @@ public final class DynamicLexicon implements Lexicon {
         this.name = name;
         this.direction = direction;
         this.keywords = Map.copyOf(keywords);
+        // 深拷贝为不可变（ADR 0022）。别名缺省为空 Map，向后兼容。
+        Map<SemanticTokenKind, List<String>> aliasCopy = new EnumMap<>(SemanticTokenKind.class);
+        if (aliases != null) {
+            for (Map.Entry<SemanticTokenKind, List<String>> e : aliases.entrySet()) {
+                if (e.getValue() != null && !e.getValue().isEmpty()) {
+                    aliasCopy.put(e.getKey(), List.copyOf(e.getValue()));
+                }
+            }
+        }
+        this.aliases = Map.copyOf(aliasCopy);
         this.punctuation = punctuation;
         this.canonicalization = canonicalization;
         this.messages = messages;
@@ -104,6 +116,9 @@ public final class DynamicLexicon implements Lexicon {
         // keywords
         Map<SemanticTokenKind, String> keywords = parseKeywords(requireNode(root, "keywords"));
 
+        // aliases（可选，ADR 0022）：kind -> [别名, ...]。缺省为空。
+        Map<SemanticTokenKind, List<String>> aliases = parseAliases(root.path("aliases"));
+
         // punctuation
         PunctuationConfig punctuation = parsePunctuation(requireNode(root, "punctuation"));
 
@@ -113,7 +128,7 @@ public final class DynamicLexicon implements Lexicon {
         // messages
         ErrorMessages messages = parseMessages(root.path("messages"));
 
-        return new DynamicLexicon(id, name, direction, keywords, punctuation, canonicalization, messages);
+        return new DynamicLexicon(id, name, direction, keywords, aliases, punctuation, canonicalization, messages);
     }
 
     // ============================================================
@@ -133,6 +148,41 @@ public final class DynamicLexicon implements Lexicon {
             }
         }
         return keywords;
+    }
+
+    /**
+     * 解析别名映射（ADR 0022）：{@code { "FUNC_TO": ["Policy", ...], ... }}。
+     * 缺省/空节点返回空 Map。未知 kind 静默忽略（前向兼容）。
+     */
+    private static Map<SemanticTokenKind, List<String>> parseAliases(JsonNode node) {
+        Map<SemanticTokenKind, List<String>> aliases = new EnumMap<>(SemanticTokenKind.class);
+        if (node == null || !node.isObject()) {
+            return aliases;
+        }
+        Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> entry = fields.next();
+            try {
+                SemanticTokenKind kind = SemanticTokenKind.valueOf(entry.getKey());
+                JsonNode arr = entry.getValue();
+                if (!arr.isArray()) {
+                    continue;
+                }
+                List<String> list = new ArrayList<>();
+                for (JsonNode a : arr) {
+                    String s = a.asText();
+                    if (s != null && !s.isBlank()) {
+                        list.add(s);
+                    }
+                }
+                if (!list.isEmpty()) {
+                    aliases.put(kind, list);
+                }
+            } catch (IllegalArgumentException e) {
+                // 忽略未知 token（前向兼容）
+            }
+        }
+        return aliases;
     }
 
     private static PunctuationConfig parsePunctuation(JsonNode node) {
@@ -367,6 +417,11 @@ public final class DynamicLexicon implements Lexicon {
     @Override
     public Map<SemanticTokenKind, String> getKeywords() {
         return keywords;
+    }
+
+    @Override
+    public Map<SemanticTokenKind, List<String>> getAliases() {
+        return aliases;
     }
 
     @Override

--- a/src/main/java/aster/core/lexicon/FallbackLexicon.java
+++ b/src/main/java/aster/core/lexicon/FallbackLexicon.java
@@ -2,6 +2,7 @@ package aster.core.lexicon;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -82,6 +83,16 @@ public final class FallbackLexicon implements Lexicon {
     @Override
     public Map<SemanticTokenKind, String> getKeywords() {
         return mergedKeywords;
+    }
+
+    /**
+     * 别名完全透传 target（ADR 0022）。别名是语言强相关的识别侧扩展——把 en-US 的别名
+     * （如 "Policy"）混进 zh-CN 文档的识别集没有意义且可能误伤，故与 punctuation /
+     * canonicalization 同策略：只用 target 的，不做 fallback 合并。
+     */
+    @Override
+    public Map<SemanticTokenKind, List<String>> getAliases() {
+        return target.getAliases();
     }
 
     @Override

--- a/src/main/java/aster/core/lexicon/Lexicon.java
+++ b/src/main/java/aster/core/lexicon/Lexicon.java
@@ -47,9 +47,24 @@ public interface Lexicon {
     Direction getDirection();
 
     /**
-     * 获取关键词映射：SemanticTokenKind -> 该语言的关键词字符串
+     * 获取关键词映射：SemanticTokenKind -> 该语言的关键词字符串（规范拼写，唯一）
      */
     Map<SemanticTokenKind, String> getKeywords();
+
+    /**
+     * 获取关键词别名映射：SemanticTokenKind -> 该语义的别名拼写列表。
+     *
+     * <p>ADR 0022：别名只存在于「识别侧」（输入），规范拼写（{@link #getKeywords()}）
+     * 是唯一的「产出侧」（输出）。Canonicalizer 把别名归一成规范拼写后再进入下游，
+     * 因此别名不影响 Core IR —— 用别名与规范拼写编写的同一逻辑产出字节一致的 IR。
+     *
+     * <p>默认返回空 Map，表示无别名，行为与历史完全一致（向后兼容）。
+     *
+     * @return kind -> 别名列表（识别侧）
+     */
+    default Map<SemanticTokenKind, List<String>> getAliases() {
+        return Map.of();
+    }
 
     /**
      * 获取标点符号配置
@@ -81,6 +96,16 @@ public interface Lexicon {
             // 使用 Locale.ROOT 避免土耳其语等特殊区域设置导致的大小写转换问题
             index.put(entry.getValue().toLowerCase(Locale.ROOT), entry.getKey());
         }
+        // 别名也进索引（识别侧多对一）。规范拼写优先：别名不覆盖已存在的规范 key。
+        // 校验阶段（LexiconValidator）已保证别名不遮蔽任何规范拼写，故此处 putIfAbsent
+        // 仅作纵深防御。
+        for (Map.Entry<SemanticTokenKind, List<String>> entry : getAliases().entrySet()) {
+            for (String alias : entry.getValue()) {
+                if (alias != null && !alias.isBlank()) {
+                    index.putIfAbsent(alias.toLowerCase(Locale.ROOT), entry.getKey());
+                }
+            }
+        }
         return index;
     }
 
@@ -99,6 +124,21 @@ public interface Lexicon {
 
             if (isMultiWord || hasMarker) {
                 multiWord.add(keyword);
+            }
+        }
+
+        // 多词别名也纳入最长匹配集，否则像 "multiplied by" 这类含空格别名会被按单词拆开，
+        // 子词（如 by）无法被识别为同一关键词（ADR 0022 §5.4）。
+        for (List<String> aliases : getAliases().values()) {
+            for (String alias : aliases) {
+                if (alias == null || alias.isBlank()) {
+                    continue;
+                }
+                boolean isMultiWord = alias.contains(" ");
+                boolean hasMarker = punct.hasMarkers() && alias.contains(punct.markerOpen());
+                if (isMultiWord || hasMarker) {
+                    multiWord.add(alias);
+                }
             }
         }
 
@@ -121,6 +161,14 @@ public interface Lexicon {
                 return Optional.of(entry.getKey());
             }
         }
+        // 识别侧也认别名（ADR 0022）。
+        for (Map.Entry<SemanticTokenKind, List<String>> entry : getAliases().entrySet()) {
+            for (String alias : entry.getValue()) {
+                if (alias != null && alias.toLowerCase(Locale.ROOT).equals(lower)) {
+                    return Optional.of(entry.getKey());
+                }
+            }
+        }
         return Optional.empty();
     }
 
@@ -133,8 +181,15 @@ public interface Lexicon {
     default boolean isKeyword(String word) {
         // 使用 Locale.ROOT 避免土耳其语等特殊区域设置导致的大小写转换问题
         String lower = word.toLowerCase(Locale.ROOT);
-        return getKeywords().values().stream()
+        boolean canonical = getKeywords().values().stream()
             .anyMatch(kw -> kw.toLowerCase(Locale.ROOT).equals(lower));
+        if (canonical) {
+            return true;
+        }
+        // 别名也算关键词（识别侧，ADR 0022）。
+        return getAliases().values().stream()
+            .flatMap(List::stream)
+            .anyMatch(a -> a != null && a.toLowerCase(Locale.ROOT).equals(lower));
     }
 
     /**

--- a/src/main/java/aster/core/lexicon/LexiconExporter.java
+++ b/src/main/java/aster/core/lexicon/LexiconExporter.java
@@ -135,6 +135,25 @@ public final class LexiconExporter {
             }
         }
 
+        // aliases（ADR 0022）：kind -> [别名,...]，仅导出非空项。按枚举顺序，
+        // 供 TS 引擎 / cloud 前端消费。无别名的 lexicon 不产出该段（向后兼容）。
+        Map<SemanticTokenKind, List<String>> aliasMap = lexicon.getAliases();
+        if (aliasMap != null && !aliasMap.isEmpty()) {
+            ObjectNode aliases = mapper.createObjectNode();
+            for (SemanticTokenKind kind : SemanticTokenKind.values()) {
+                List<String> list = aliasMap.get(kind);
+                if (list != null && !list.isEmpty()) {
+                    ArrayNode arr = aliases.putArray(kind.name());
+                    for (String a : list) {
+                        arr.add(a);
+                    }
+                }
+            }
+            if (!aliases.isEmpty()) {
+                node.set("aliases", aliases);
+            }
+        }
+
         // punctuation
         node.set("punctuation", serializePunctuation(lexicon.getPunctuation()));
 

--- a/src/main/java/aster/core/lexicon/LexiconValidator.java
+++ b/src/main/java/aster/core/lexicon/LexiconValidator.java
@@ -4,7 +4,10 @@ import aster.core.canonicalizer.TransformerRegistry;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -98,6 +101,36 @@ public final class LexiconValidator {
         if (actual < expected) {
             warnings.add("Lexicon has " + actual + " keywords, expected " + expected
                     + " (missing " + (expected - actual) + ")");
+        }
+
+        // ADR 0022：别名不得遮蔽任何规范拼写或其它 kind 的别名。别名经规范化（lowercase）
+        // 后若与任一规范拼写撞 → error（会让识别歧义/抢占规范词）；与其它别名撞 → error。
+        // 这把"别名零损"的前提固化为注册时的硬校验。
+        Map<String, SemanticTokenKind> canonByLower = new HashMap<>();
+        for (Map.Entry<SemanticTokenKind, String> e : lexicon.getKeywords().entrySet()) {
+            if (e.getValue() != null && !e.getValue().isBlank()) {
+                canonByLower.put(e.getValue().toLowerCase(Locale.ROOT), e.getKey());
+            }
+        }
+        Map<String, SemanticTokenKind> aliasByLower = new HashMap<>();
+        for (Map.Entry<SemanticTokenKind, List<String>> e : lexicon.getAliases().entrySet()) {
+            for (String alias : e.getValue()) {
+                if (alias == null || alias.isBlank()) {
+                    errors.add("Empty alias for " + e.getKey());
+                    continue;
+                }
+                String lower = alias.toLowerCase(Locale.ROOT);
+                SemanticTokenKind clashCanon = canonByLower.get(lower);
+                if (clashCanon != null) {
+                    errors.add("Alias '" + alias + "' for " + e.getKey()
+                            + " shadows canonical keyword of " + clashCanon);
+                }
+                SemanticTokenKind clashAlias = aliasByLower.putIfAbsent(lower, e.getKey());
+                if (clashAlias != null) {
+                    errors.add("Alias '" + alias + "' is defined for both "
+                            + clashAlias + " and " + e.getKey());
+                }
+            }
         }
 
         return new LexiconRegistry.ValidationResult(errors.isEmpty(), errors, warnings);

--- a/src/main/resources/builtin/en-US.json
+++ b/src/main/resources/builtin/en-US.json
@@ -84,14 +84,6 @@
     "MATCHING": "matching",
     "PATTERN": "pattern"
   },
-  "aliases": {
-    "TIMES": [
-      "multiplied by"
-    ],
-    "DIVIDED_BY": [
-      "split by"
-    ]
-  },
   "punctuation": {
     "statementEnd": ".",
     "listSeparator": ",",
@@ -104,34 +96,14 @@
     "fullWidthToHalf": false,
     "whitespaceMode": "ENGLISH",
     "removeArticles": true,
-    "articles": [
-      "a",
-      "an",
-      "the"
-    ],
+    "articles": ["a", "an", "the"],
     "allowedDuplicates": [
-      [
-        "TO_WORD",
-        "FUNC_TO"
-      ],
-      [
-        "LESS_THAN",
-        "UNDER"
-      ],
-      [
-        "GREATER_THAN",
-        "MORE_THAN",
-        "OVER"
-      ]
+      ["TO_WORD", "FUNC_TO"],
+      ["LESS_THAN", "UNDER"],
+      ["GREATER_THAN", "MORE_THAN", "OVER"]
     ],
-    "preTranslationTransformers": [
-      "english-possessive",
-      "is-comparator"
-    ],
-    "postTranslationTransformers": [
-      "result-is",
-      "set-to"
-    ]
+    "preTranslationTransformers": ["english-possessive", "is-comparator"],
+    "postTranslationTransformers": ["result-is", "set-to"]
   },
   "messages": {
     "unexpectedToken": "Unexpected token: {token}",

--- a/src/main/resources/builtin/en-US.json
+++ b/src/main/resources/builtin/en-US.json
@@ -84,6 +84,14 @@
     "MATCHING": "matching",
     "PATTERN": "pattern"
   },
+  "aliases": {
+    "TIMES": [
+      "multiplied by"
+    ],
+    "DIVIDED_BY": [
+      "split by"
+    ]
+  },
   "punctuation": {
     "statementEnd": ".",
     "listSeparator": ",",
@@ -96,14 +104,34 @@
     "fullWidthToHalf": false,
     "whitespaceMode": "ENGLISH",
     "removeArticles": true,
-    "articles": ["a", "an", "the"],
-    "allowedDuplicates": [
-      ["TO_WORD", "FUNC_TO"],
-      ["LESS_THAN", "UNDER"],
-      ["GREATER_THAN", "MORE_THAN", "OVER"]
+    "articles": [
+      "a",
+      "an",
+      "the"
     ],
-    "preTranslationTransformers": ["english-possessive", "is-comparator"],
-    "postTranslationTransformers": ["result-is", "set-to"]
+    "allowedDuplicates": [
+      [
+        "TO_WORD",
+        "FUNC_TO"
+      ],
+      [
+        "LESS_THAN",
+        "UNDER"
+      ],
+      [
+        "GREATER_THAN",
+        "MORE_THAN",
+        "OVER"
+      ]
+    ],
+    "preTranslationTransformers": [
+      "english-possessive",
+      "is-comparator"
+    ],
+    "postTranslationTransformers": [
+      "result-is",
+      "set-to"
+    ]
   },
   "messages": {
     "unexpectedToken": "Unexpected token: {token}",

--- a/src/test/java/aster/core/canonicalizer/KeywordAliasTest.java
+++ b/src/test/java/aster/core/canonicalizer/KeywordAliasTest.java
@@ -1,0 +1,223 @@
+package aster.core.canonicalizer;
+
+import aster.core.parser.AstBuilder;
+import aster.core.ir.CoreModel;
+import aster.core.lexicon.DynamicLexicon;
+import aster.core.lexicon.Lexicon;
+import aster.core.lexicon.LexiconRegistry;
+import aster.core.lexicon.LexiconValidator;
+import aster.core.lexicon.SemanticTokenKind;
+import aster.core.lowering.CoreLowering;
+import aster.core.parser.AsterCustomLexer;
+import aster.core.parser.AsterParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 关键词别名（ADR 0022）单元测试。
+ *
+ * <p>核心不变式：别名在 canonicalize 阶段被归一成规范拼写，故「别名版」与「规范版」源码
+ * 的规范化输出**逐字节相同** —— 这等价于"下游 token 流 / Core IR 相同"，是 IR 零损的根。
+ *
+ * <p>用真实 en-US builtin JSON 注入 aliases 段构造测试 lexicon，覆盖：
+ * 声明关键词别名（Policy→Rule）、控制流别名（Whenever→If）、运算符别名（multiplied by→times）。
+ */
+class KeywordAliasTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** 取 en-US builtin 的 JSON，注入 aliases 段后构造 DynamicLexicon。 */
+    private static Lexicon enWithAliases() throws Exception {
+        // 直接复用 builtin 资源，保证与生产 en-US 完全一致，只追加 aliases。
+        String json = new String(
+            KeywordAliasTest.class.getClassLoader()
+                .getResourceAsStream("builtin/en-US.json").readAllBytes(),
+            java.nio.charset.StandardCharsets.UTF_8);
+        ObjectNode root = (ObjectNode) MAPPER.readTree(json);
+        ObjectNode aliases = root.putObject("aliases");
+        aliases.set("FUNC_TO", arr("Policy"));
+        aliases.set("IF", arr("Whenever"));
+        aliases.set("TIMES", arr("multiplied by"));
+        return DynamicLexicon.fromJsonString(MAPPER.writeValueAsString(root));
+    }
+
+    private static ArrayNode arr(String... vals) {
+        ArrayNode a = MAPPER.createArrayNode();
+        for (String v : vals) a.add(v);
+        return a;
+    }
+
+    @Test
+    void aliasSourceCanonicalizesIdenticallyToCanonical() throws Exception {
+        Lexicon lex = enWithAliases();
+        Canonicalizer canon = new Canonicalizer(lex);
+
+        // 别名版：Policy（=Rule）、Whenever（=If）、multiplied by（=times）
+        String aliasSrc = """
+            Module Pricing.
+
+            Policy discountedPrice given amount as Int, produce Int:
+              Whenever amount greater than 100
+                Return amount multiplied by 90 divided by 100.
+              Return amount.""";
+
+        // 规范版：同一逻辑用规范拼写
+        String canonicalSrc = """
+            Module Pricing.
+
+            Rule discountedPrice given amount as Int, produce Int:
+              If amount greater than 100
+                Return amount times 90 divided by 100.
+              Return amount.""";
+
+        String outAlias = canon.canonicalize(aliasSrc);
+        String outCanonical = canon.canonicalize(canonicalSrc);
+
+        // 规范化输出逐字节相同 → 下游 token/IR 必然相同（ADR 0022 不变式）
+        assertThat(outAlias).isEqualTo(outCanonical);
+    }
+
+    @Test
+    void noAliasesIsBackwardCompatible() throws Exception {
+        // 显式移除 aliases 段的 lexicon：getAliases() 为空，行为与历史一致。
+        // （builtin en-US.json 现已自带 aliases，故这里删掉该段以测"无别名"路径。）
+        String json = new String(
+            KeywordAliasTest.class.getClassLoader()
+                .getResourceAsStream("builtin/en-US.json").readAllBytes(),
+            java.nio.charset.StandardCharsets.UTF_8);
+        ObjectNode root = (ObjectNode) MAPPER.readTree(json);
+        root.remove("aliases");
+        Lexicon lex = DynamicLexicon.fromJsonString(MAPPER.writeValueAsString(root));
+        assertThat(lex.getAliases()).isEmpty();
+    }
+
+    @Test
+    void aliasesAppearInKeywordIndexAndFindKind() throws Exception {
+        Lexicon lex = enWithAliases();
+        Map<String, SemanticTokenKind> index = lex.buildKeywordIndex();
+        assertThat(index.get("policy")).isEqualTo(SemanticTokenKind.FUNC_TO);
+        assertThat(index.get("whenever")).isEqualTo(SemanticTokenKind.IF);
+        // 规范拼写仍在
+        assertThat(index.get("rule")).isEqualTo(SemanticTokenKind.FUNC_TO);
+        // findSemanticTokenKind 也认别名
+        assertThat(lex.findSemanticTokenKind("Policy")).contains(SemanticTokenKind.FUNC_TO);
+        // 多词别名进最长匹配集
+        assertThat(lex.getMultiWordKeywords()).contains("multiplied by");
+    }
+
+    @Test
+    void validatorRejectsAliasShadowingCanonical() throws Exception {
+        // 别名 "If" 给 FUNC_TO → 撞 IF 的规范拼写 → 必须 error
+        String json = new String(
+            KeywordAliasTest.class.getClassLoader()
+                .getResourceAsStream("builtin/en-US.json").readAllBytes(),
+            java.nio.charset.StandardCharsets.UTF_8);
+        ObjectNode root = (ObjectNode) MAPPER.readTree(json);
+        root.putObject("aliases").set("FUNC_TO", arr("If"));
+        Lexicon bad = DynamicLexicon.fromJsonString(MAPPER.writeValueAsString(root));
+
+        LexiconRegistry.ValidationResult result = LexiconValidator.validateLexicon(bad);
+        assertThat(result.valid()).isFalse();
+        assertThat(result.errors()).anyMatch(e -> e.contains("shadows canonical keyword"));
+    }
+
+    @Test
+    void validatorRejectsDuplicateAliasAcrossKinds() throws Exception {
+        // 同一别名 "Foo" 给两个 kind → error
+        String json = new String(
+            KeywordAliasTest.class.getClassLoader()
+                .getResourceAsStream("builtin/en-US.json").readAllBytes(),
+            java.nio.charset.StandardCharsets.UTF_8);
+        ObjectNode root = (ObjectNode) MAPPER.readTree(json);
+        ObjectNode aliases = root.putObject("aliases");
+        aliases.set("FUNC_TO", arr("Foo"));
+        aliases.set("TYPE_DEF", arr("Foo"));
+        Lexicon bad = DynamicLexicon.fromJsonString(MAPPER.writeValueAsString(root));
+
+        LexiconRegistry.ValidationResult result = LexiconValidator.validateLexicon(bad);
+        assertThat(result.valid()).isFalse();
+        assertThat(result.errors()).anyMatch(e -> e.contains("defined for both"));
+    }
+
+    /**
+     * 端到端：用内置 en-US（现自带别名）走完整 Java 管线 Canonicalize → ANTLR Parse →
+     * AstBuilder → CoreLowering，断言「别名版」与「规范版」降到**结构一致的 Core IR**
+     * （剥离 origin 源码位置元数据，与 ADR 0016 / TS 端同口径）。这是 Java 侧的
+     * 「别名→同 IR」权威证明，与 ts keyword-aliases.test 对称。
+     */
+    @Test
+    void aliasLowersToSameCoreIrViaFullPipeline() throws Exception {
+        // 用内置 en-US 的首批多词别名（multiplied by→times、split by→divided by）。
+        // 单词别名不进内置（占标识符命名空间），故此处用多词别名验证端到端。
+        String aliasSrc = """
+            Module Pricing.
+
+            Rule discountedPrice given amount as Int, produce Int:
+              If amount greater than 100
+                Return amount multiplied by 90 split by 100.
+              Return amount.""";
+        String canonicalSrc = """
+            Module Pricing.
+
+            Rule discountedPrice given amount as Int, produce Int:
+              If amount greater than 100
+                Return amount times 90 divided by 100.
+              Return amount.""";
+
+        JsonNode aliasIr = stripOrigin(lowerToCoreIr(aliasSrc));
+        JsonNode canonIr = stripOrigin(lowerToCoreIr(canonicalSrc));
+
+        assertThat(aliasIr).isEqualTo(canonIr);
+    }
+
+    /** 走默认 Canonicalizer（内置 en-US + 别名）的完整管线，返回 Core IR JSON。 */
+    private static JsonNode lowerToCoreIr(String source) {
+        Canonicalizer canonicalizer = new Canonicalizer();
+        String canonical = canonicalizer.canonicalize(source);
+        AsterCustomLexer lexer = new AsterCustomLexer(CharStreams.fromString(canonical));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        tokens.fill();
+        tokens.seek(0);
+        AsterParser parser = new AsterParser(tokens);
+        AsterParser.ModuleContext moduleCtx = parser.module();
+        aster.core.ast.Module ast = new AstBuilder().visitModule(moduleCtx);
+        CoreModel.Module core = new CoreLowering().lowerModule(ast);
+        return MAPPER.valueToTree(core);
+    }
+
+    /** 递归剥离 origin/span 等源码位置字段（派生层），用于结构级 IR 比较。 */
+    private static JsonNode stripOrigin(JsonNode node) {
+        if (node.isObject()) {
+            ObjectNode out = MAPPER.createObjectNode();
+            Iterator<Map.Entry<String, JsonNode>> it = node.fields();
+            while (it.hasNext()) {
+                Map.Entry<String, JsonNode> e = it.next();
+                String k = e.getKey();
+                if (k.equals("origin") || k.equals("span") || k.equals("line") || k.equals("col")) {
+                    continue;
+                }
+                out.set(k, stripOrigin(e.getValue()));
+            }
+            return out;
+        }
+        if (node.isArray()) {
+            ArrayNode out = MAPPER.createArrayNode();
+            for (JsonNode child : node) {
+                out.add(stripOrigin(child));
+            }
+            return out;
+        }
+        return node;
+    }
+}

--- a/src/test/java/aster/core/canonicalizer/KeywordAliasTest.java
+++ b/src/test/java/aster/core/canonicalizer/KeywordAliasTest.java
@@ -151,21 +151,24 @@ class KeywordAliasTest {
     }
 
     /**
-     * 端到端：用内置 en-US（现自带别名）走完整 Java 管线 Canonicalize → ANTLR Parse →
-     * AstBuilder → CoreLowering，断言「别名版」与「规范版」降到**结构一致的 Core IR**
-     * （剥离 origin 源码位置元数据，与 ADR 0016 / TS 端同口径）。这是 Java 侧的
-     * 「别名→同 IR」权威证明，与 ts keyword-aliases.test 对称。
+     * 端到端：把别名经**编译期注入**（方案 D 形态：aliasSet 注入 lexicon，而非内置）
+     * 走完整 Java 管线 Canonicalize → ANTLR Parse → AstBuilder → CoreLowering，断言
+     * 「别名版」与「规范版」降到**结构一致的 Core IR**（剥离 origin，与 ADR 0016 同口径）。
+     * 这是 Java 侧的「别名→同 IR」权威证明，与 ts keyword-aliases.test 对称。
+     *
+     * <p>官方 builtin 不含别名（方案 A 已回滚）：别名版用注入了多词别名的 lexicon，
+     * 规范版用默认 builtin lexicon。
      */
     @Test
     void aliasLowersToSameCoreIrViaFullPipeline() throws Exception {
-        // 用内置 en-US 的首批多词别名（multiplied by→times、split by→divided by）。
-        // 单词别名不进内置（占标识符命名空间），故此处用多词别名验证端到端。
+        // 注入多词别名（FUNC_TO=Policy 单词不可，故用多词运算符别名验证端到端）。
+        Lexicon aliasLex = enWithAliases(); // 注入 FUNC_TO=Policy / IF=Whenever / TIMES=multiplied by
         String aliasSrc = """
             Module Pricing.
 
-            Rule discountedPrice given amount as Int, produce Int:
-              If amount greater than 100
-                Return amount multiplied by 90 split by 100.
+            Policy discountedPrice given amount as Int, produce Int:
+              Whenever amount greater than 100
+                Return amount multiplied by 90 divided by 100.
               Return amount.""";
         String canonicalSrc = """
             Module Pricing.
@@ -175,15 +178,18 @@ class KeywordAliasTest {
                 Return amount times 90 divided by 100.
               Return amount.""";
 
-        JsonNode aliasIr = stripOrigin(lowerToCoreIr(aliasSrc));
-        JsonNode canonIr = stripOrigin(lowerToCoreIr(canonicalSrc));
+        JsonNode aliasIr = stripOrigin(lowerToCoreIr(aliasSrc, aliasLex));
+        JsonNode canonIr = stripOrigin(lowerToCoreIr(canonicalSrc, null));
 
         assertThat(aliasIr).isEqualTo(canonIr);
     }
 
-    /** 走默认 Canonicalizer（内置 en-US + 别名）的完整管线，返回 Core IR JSON。 */
-    private static JsonNode lowerToCoreIr(String source) {
-        Canonicalizer canonicalizer = new Canonicalizer();
+    /**
+     * 走完整管线返回 Core IR JSON。lexicon 为 null 时用默认 builtin（无别名）。
+     * 提供 lexicon 时用注入别名的 Canonicalizer（方案 D 编译期注入形态）。
+     */
+    private static JsonNode lowerToCoreIr(String source, Lexicon lexicon) {
+        Canonicalizer canonicalizer = lexicon != null ? new Canonicalizer(lexicon) : new Canonicalizer();
         String canonical = canonicalizer.canonicalize(source);
         AsterCustomLexer lexer = new AsterCustomLexer(CharStreams.fromString(canonical));
         CommonTokenStream tokens = new CommonTokenStream(lexer);

--- a/src/test/java/aster/core/canonicalizer/KeywordAliasTest.java
+++ b/src/test/java/aster/core/canonicalizer/KeywordAliasTest.java
@@ -91,7 +91,8 @@ class KeywordAliasTest {
     @Test
     void noAliasesIsBackwardCompatible() throws Exception {
         // 显式移除 aliases 段的 lexicon：getAliases() 为空，行为与历史一致。
-        // （builtin en-US.json 现已自带 aliases，故这里删掉该段以测"无别名"路径。）
+        // （builtin en-US.json 本身无 aliases 段——方案 A 官方别名已撤；此处仍显式 remove
+        //  以稳健测"无别名"路径，不依赖 builtin 当前是否带 aliases。）
         String json = new String(
             KeywordAliasTest.class.getClassLoader()
                 .getResourceAsStream("builtin/en-US.json").readAllBytes(),


### PR DESCRIPTION
## What

Recognition-side keyword **alias mechanism** for ADR 0022 Plan D. A semantic
(`SemanticTokenKind`) can be recognized by multiple spellings; the Canonicalizer
normalizes aliases to the canonical spelling before lowering, so alias-written
and canonical-written sources produce **structurally identical Core IR**.

- `Lexicon.getAliases()` default-empty; `buildKeywordIndex`/`getMultiWordKeywords`/
  `findSemanticTokenKind`/`isKeyword` fold in aliases (canonical wins on clash).
- `DynamicLexicon` parses an optional `aliases` segment; `FallbackLexicon` passes
  target aliases through; `Canonicalizer` maps aliases to the same symbol/canonical
  English; `LexiconExporter` emits `aliases`; `LexiconValidator` rejects shadow/dup.
- Plan A (official builtin aliases) was reverted — **no builtin lexicon carries
  aliases**, so behavior is unchanged for existing lexicons (backward compatible).

## Why this is the dependency root

aster-api consumes core via includeBuild; the published core is the engine for
aster-api and the parity reference for aster-lang-ts. This must merge + release
first (core → ts → api/cloud).

## Verification

`KeywordAliasTest` proves end-to-end alias→same Core IR via the full ANTLR
pipeline; index/lookup; validator shadow/dup rejection. Full core test suite
green. `en-US.json` is byte-identical to main (Plan-A data reverted; no
gratuitous reformat — caught in pre-release full-diff review).

ADR: aster-api/.claude/adr/0022-keyword-aliases.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)