### PR TITLE
release: core 1.0.4 (keyword alias mechanism)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "cloud.aster-lang"
-version = "1.0.3"
+version = "1.0.4"
 
 publishing {
     publications {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.5")
+            from("cloud.aster-lang:aster-lang-platform:1.0.6")
         }
     }
 }


### PR DESCRIPTION
Version bump 1.0.3 → 1.0.4 to release the ADR 0022 keyword alias mechanism (merged in #36). After merge, tag v1.0.4 to trigger Maven publish (release.yml verifies tag == build.gradle.kts version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)