### PR TITLE
release: ecosystem 1.0.4 lockstep (keyword aliases)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "cloud.aster-lang"
-version = "1.0.3"
+version = "1.0.4"
 
 publishing {
     publications {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.5")
+            from("cloud.aster-lang:aster-lang-platform:1.0.6")
         }
     }
 }


### PR DESCRIPTION
Ecosystem lockstep bump to 1.0.4 (catalog 1.0.6) for ADR 0022 keyword-alias-mechanism release. All participating repos share the branch name `release/alias-1.0.4` so checkout-sibling matches them and validates the cascade together before any merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)