### PR TITLE
chore(release): Renovate platform-pin governance (ADR 0023 阶段1)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>aster-cloud/aster-lang-platform"],
+  "enabledManagers": ["custom.regex"],
+  "dependencyDashboard": true
+}


### PR DESCRIPTION
## 背景
ADR 0023 多模块发布漂移治理，阶段1（版本来源单一化）。依赖 aster-lang-platform PR #9 的共享 preset。

## 改动
`renovate.json`：thin config，`extends: ["github>aster-cloud/aster-lang-platform"]`。Renovate 自动 bump 本仓 settings 的 aster-lang-platform version catalog pin → 消除跨仓手工同步散点。`enabledManagers: ["custom.regex"]` 仅治理 platform pin，不碰其它依赖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)