### PR TITLE
ci: bump actions/setup-python v5→v6 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       # 防漂移 gate（ADR 0023 阶段6）：本仓版本/platform pin 必须符合 release-plan.json
       # 单一事实源（脚本在 platform 仓，单点维护）。PR 时即拦截漂移，不等到发布。
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with: { python-version: '3.12' }
       - name: Release-plan drift gate
         run: |


### PR DESCRIPTION
Node 20 弃用修复：actions/setup-python@v5 bundle Node 20（阶段6 drift gate 引入），被 runner 强制跑 Node 24 + 发弃用警告（2025-09-19 changelog）。升级 @v6（node24，python-version 输入不变）。