### PR TITLE
chore(release): bump self→1.0.5 + pin→1.0.7 (ADR 0023 全发版 1.0.5)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "cloud.aster-lang"
-version = "1.0.4"
+version = "1.0.5"
 
 publishing {
     publications {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.6")
+            from("cloud.aster-lang:aster-lang-platform:1.0.7")
         }
     }
 }


### PR DESCRIPTION
ADR 0023 全发版（B 方案）：bump 到 1.0.5 生态 / 1.0.7 platform pin。依赖 platform PR #18（已合并，main 有 1.0.7 catalog）。本地 drift gate 全 13 artifact 已预演 PASS。合并后跑 release-train 真发。