### PR TITLE
chore(release): bump 1.0.6 + pin 1.0.8 (ADR 0024)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "cloud.aster-lang"
-version = "1.0.5"
+version = "1.0.6"
 
 publishing {
     publications {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.7")
+            from("cloud.aster-lang:aster-lang-platform:1.0.8")
         }
     }
 }


### PR DESCRIPTION
ADR 0024 发版（ecosystem 1.0.6 / platform pin 1.0.8）。配套 platform#21（已合）+ 同批各引擎仓 release bump。drift gate 据 release-plan(main) 验。

🤖 Generated with [Claude Code](https://claude.com/claude-code)