### PR TITLE
fix(parser): allow MAX/ATTEMPTS as soft keywords (List.max member collision)

### DIFF
--- a/src/main/antlr/AsterParser.g4
+++ b/src/main/antlr/AsterParser.g4
@@ -193,7 +193,6 @@ nameIdent
     | TYPE_IDENT
     | TYPE
     | VERSION
-    | MAX
     | REQUIRED
     | BETWEEN
     | structKeywordName
@@ -222,6 +221,13 @@ structKeywordName
     // ADR 0019 G2a：THEN 也是结构关键词 token，同样在标识符位置当软关键字
     // （如 `Http.get(...).then(handle)` 的 .then 方法名）。
     | THEN
+    // MAX/ATTEMPTS 是 workflow retry 语法 `max attempts: N.` 的 lexer 硬 token
+    // （AsterLexer.g4），但在标识符位置（DOT 成员、变量名、参数、字段）应当软关键字——
+    // 否则 stdlib `List.max(xs)` / `List.attempts(xs)` 的成员名被卡（生产实测
+    // "extraneous 'max'"）。retryDirective 起点仍按 MAX/ATTEMPTS token 分派，不受影响。
+    // 同 ADR 0019 G1 的 LET/IF/RETURN 软关键字范式（ADR 0024 §poker 纯 CNL 前置修复）。
+    | MAX
+    | ATTEMPTS
     ;
 
 /**

--- a/src/main/java/aster/core/parser/AsterCustomLexer.java
+++ b/src/main/java/aster/core/parser/AsterCustomLexer.java
@@ -298,7 +298,9 @@ public class AsterCustomLexer extends AsterLexer {
             || type == AsterParser.RETURN || type == AsterParser.RULE
             || type == AsterParser.DEFINE || type == AsterParser.WHEN
             || type == AsterParser.START || type == AsterParser.WAIT
-            || type == AsterParser.ELSE || type == AsterParser.THEN;
+            || type == AsterParser.ELSE || type == AsterParser.THEN
+            // MAX/ATTEMPTS 同列入 structKeywordName（retry 语法 token，标识符位置当软关键字）
+            || type == AsterParser.MAX || type == AsterParser.ATTEMPTS;
     }
 
     /** 把英文展开形（如 "result of"）重新词法化成 token，全部入 pending。 */

--- a/src/test/java/aster/core/parser/MaxAttemptsMemberNameTest.java
+++ b/src/test/java/aster/core/parser/MaxAttemptsMemberNameTest.java
@@ -1,0 +1,102 @@
+package aster.core.parser;
+
+import aster.core.canonicalizer.Canonicalizer;
+import aster.core.lexicon.LexiconRegistry;
+import org.antlr.v4.runtime.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 回归测试：workflow retry 语法的 `max attempts` 让 lexer 把 max/attempts 提升为硬 token
+ * （AsterLexer.g4 MAX/ATTEMPTS），但在标识符位置（DOT 成员名、变量名、参数、字段）应当
+ * 软关键字——否则 stdlib `List.max(xs)` / `List.attempts(xs)` 的成员名被卡，生产实测
+ * 报 "extraneous 'max'"。
+ * <p>
+ * 修复：把 MAX/ATTEMPTS 收进 structKeywordName 软关键字集（同 ADR 0019 G1 的
+ * LET/IF/RETURN 范式），retryDirective 起点仍按 MAX/ATTEMPTS token 分派不受影响。
+ * 这是 ADR 0024 poker 纯 CNL 重写（用 List.max/List.min 比牌力）的前置修复。
+ */
+class MaxAttemptsMemberNameTest {
+
+    /** 走生产 canonicalize→lex→parse 路径（en-US）。返回是否无语法错误。 */
+    private boolean parses(String src) {
+        var canon = new Canonicalizer(LexiconRegistry.getInstance().getOrThrow("en-US"), null);
+        String en = canon.canonicalize(src);
+        final boolean[] err = {false};
+        try {
+            var lexer = new AsterCustomLexer(CharStreams.fromString(en));
+            var tokens = new CommonTokenStream(lexer);
+            tokens.fill();
+            tokens.seek(0);
+            var parser = new AsterParser(tokens);
+            parser.removeErrorListeners();
+            parser.addErrorListener(new BaseErrorListener() {
+                @Override
+                public void syntaxError(Recognizer<?, ?> r, Object s, int l, int c, String m, RecognitionException e) {
+                    err[0] = true;
+                }
+            });
+            parser.module();
+        } catch (Exception e) {
+            err[0] = true;
+        }
+        return !err[0];
+    }
+
+    // ── 主修复：DOT 成员位置的 max/attempts（生产挂点） ──────────────────────
+
+    @Test
+    void listMaxAsMemberCall() {
+        assertTrue(parses("Module a.b.\n\nRule f given xs as List, produce Int:\n  Return List.max(xs).\n"),
+            "List.max(xs) 成员调用");
+    }
+
+    @Test
+    void listMinAsMemberCall() {
+        // min 从来不是 token，本就该通过——作 unaffected baseline 锁住
+        assertTrue(parses("Module a.b.\n\nRule f given xs as List, produce Int:\n  Return List.min(xs).\n"),
+            "List.min(xs) 成员调用（baseline）");
+    }
+
+    @Test
+    void listAttemptsAsMemberCall() {
+        assertTrue(parses("Module a.b.\n\nRule f given xs as List, produce Int:\n  Return List.attempts(xs).\n"),
+            "List.attempts(xs) 成员调用");
+    }
+
+    @Test
+    void chainedMaxMember() {
+        assertTrue(parses("Module a.b.\n\nRule f given xs as List, produce Int:\n  Return List.max(xs) minus List.min(xs).\n"),
+            "List.max minus List.min（poker span 模式）");
+    }
+
+    // ── 变量名 / 参数名位置 ────────────────────────────────────────────────
+
+    @Test
+    void maxAsParamAndVar() {
+        assertTrue(parses("Module a.b.\n\nRule f given max as Int, produce Int:\n  Return max.\n"),
+            "max 当参数名 + 引用");
+        assertTrue(parses("Module a.b.\n\nRule f given x as Int, produce Int:\n  Let max be x.\n  Return max.\n"),
+            "max 当变量名 + 引用");
+    }
+
+    @Test
+    void attemptsAsParamAndVar() {
+        assertTrue(parses("Module a.b.\n\nRule f given attempts as Int, produce Int:\n  Return attempts.\n"),
+            "attempts 当参数名 + 引用");
+    }
+
+    // ── 字段名位置 ────────────────────────────────────────────────────────
+
+    @Test
+    void maxAttemptsAsFieldNames() {
+        assertTrue(parses("Module a.b.\n\nDefine Box has max, attempts.\n"),
+            "max/attempts 当字段名");
+    }
+
+    // 注：retry block 不回归的保障 = 全量套件里既有的 workflow/retry corpus 测试
+    // （aster-lang-test runtime-retry/type-checker fixtures）。本修复只把 MAX/ATTEMPTS
+    // 加进 structKeywordName 软关键字集，retryDirective: MAX ATTEMPTS COLON ... 规则与
+    // lexer token 定义都未动，故 retry 解析不受影响——不在此处重复弱 helper 的 workflow 解析。
+}


### PR DESCRIPTION
## 问题
生产实测 `List.max(xs)` 解析报 'extraneous max'。根因：workflow retry 语法 `max attempts: N.` 让 lexer 把 max/attempts 提升为硬 token（MAX/ATTEMPTS），但 postfixSuffix 成员位只接受 IDENT|TYPE_IDENT|structKeywordName。List.sum/distinct/length 正常（无对应硬 token）。

## 修复
MAX/ATTEMPTS 加进 structKeywordName 软关键字集（复用 ADR 0019 G1 范式，Codex 两轮确认优于 semantic predicate）。retryDirective + token 定义不动 → retry 不受影响。AsterCustomLexer.startsExpression 同步。

## 验证
- MaxAttemptsMemberNameTest 7 例全过（List.max/min/attempts 成员 + var/param/field）
- core 全量 1267 测试 0 fail（含 retry 无回归）
- TsSampleParseInventoryTest 过（Java 解析所有 TS-accepted tier1 样本）
- 配套 aster-lang-test 同名分支加 List.max/min parity 样本

这是 ADR 0024 poker 纯 CNL 重写（用 List.max/min 比牌力）的前置修复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)