### PR TITLE
chore(release): ecosystem 1.0.7 / platform pin 1.0.9

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.8")
+            from("cloud.aster-lang:aster-lang-platform:1.0.9")
         }
     }
 }


### PR DESCRIPTION
ecosystem 1.0.7 发版（List.max 软关键字修复 core#47 + List.combinations truffle#32 进 maven）。catalog-derived 仓 version 自动派生 1.0.7，仅 settings platform pin 1.0.8→1.0.9。配套 platform chore/release-1.0.7（须先合，drift gate 据 release-plan 验）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)