### PR TITLE
feat: Decimal first-class type — grammar + Core IR + typecheck (ADR 0025 M1+M2)

### DIFF
--- a/src/main/antlr/AsterLexer.g4
+++ b/src/main/antlr/AsterLexer.g4
@@ -87,6 +87,11 @@ BOOL_LITERAL: 'true' | 'false';
 // null 字面量
 NULL_LITERAL: 'null';
 
+// Decimal 字面量（带 m/M 后缀，ADR 0025）：精确十进制金额类型，区别于二进制浮点
+// FLOAT_LITERAL。必须排在 FLOAT/INT/LONG 之前——否则 ANTLR 最长匹配把 `1.08m` 切成
+// FLOAT_LITERAL(1.08) + 标识符(m)。整数形 `10m` 与小数形 `1.08m` 都接受。
+DECIMAL_LITERAL: [0-9]+ ('.' [0-9]+)? [mM];
+
 // 长整型字面量（带 L 后缀）
 LONG_LITERAL: [0-9]+ [Ll];
 

--- a/src/main/antlr/AsterParser.g4
+++ b/src/main/antlr/AsterParser.g4
@@ -632,6 +632,7 @@ primaryExpr
     | STRING_LITERAL                       # StringExpr
     | INT_LITERAL                          # IntExpr
     | FLOAT_LITERAL                        # FloatExpr
+    | DECIMAL_LITERAL                      # DecimalExpr
     | LONG_LITERAL                         # LongExpr
     | BOOL_LITERAL                         # BoolExpr
     | NULL_LITERAL                         # NullExpr

--- a/src/main/java/aster/core/ast/Expr.java
+++ b/src/main/java/aster/core/ast/Expr.java
@@ -21,6 +21,7 @@ import java.util.List;
     @JsonSubTypes.Type(value = Expr.Int.class, name = "Int"),
     @JsonSubTypes.Type(value = Expr.Long.class, name = "Long"),
     @JsonSubTypes.Type(value = Expr.Double.class, name = "Double"),
+    @JsonSubTypes.Type(value = Expr.Decimal.class, name = "Decimal"),
     @JsonSubTypes.Type(value = Expr.String.class, name = "String"),
     @JsonSubTypes.Type(value = Expr.Null.class, name = "Null"),
     @JsonSubTypes.Type(value = Expr.Call.class, name = "Call"),
@@ -35,7 +36,7 @@ import java.util.List;
     @JsonSubTypes.Type(value = Expr.IfExpr.class, name = "IfExpr")
 })
 public sealed interface Expr extends AstNode
-    permits Expr.Name, Expr.Bool, Expr.Int, Expr.Long, Expr.Double, Expr.String, Expr.Null,
+    permits Expr.Name, Expr.Bool, Expr.Int, Expr.Long, Expr.Double, Expr.Decimal, Expr.String, Expr.Null,
             Expr.Call, Expr.Construct, Expr.Ok, Expr.Err, Expr.Some, Expr.None, Expr.ListLiteral,
             Expr.Lambda, Expr.Await, Expr.IfExpr {
 
@@ -121,6 +122,27 @@ public sealed interface Expr extends AstNode
         @Override
         public java.lang.String kind() {
             return "Double";
+        }
+    }
+
+    /**
+     * Decimal 精确十进制字面量（ADR 0025，m 后缀）
+     *
+     * <p>value 是 canonical 十进制字符串（如 "1.08"/"1"/"0"），NOT 二进制浮点——
+     * 与 TS decimal.js、truffle BigDecimal 逐位一致。金融/保险金额规则用此避免
+     * Double 的二进制误差。
+     *
+     * @param value canonical 十进制字符串
+     * @param span  源码位置信息
+     */
+    @JsonTypeName("Decimal")
+    record Decimal(
+        @JsonProperty("value") java.lang.String value,
+        @JsonProperty("span") Span span
+    ) implements Expr {
+        @Override
+        public java.lang.String kind() {
+            return "Decimal";
         }
     }
 

--- a/src/main/java/aster/core/inference/TypeInference.java
+++ b/src/main/java/aster/core/inference/TypeInference.java
@@ -126,7 +126,8 @@ public final class TypeInference {
             "Text".equals(typeName) ||
             "DateTime".equals(typeName) ||
             "Long".equals(typeName) ||
-            "Double".equals(typeName)
+            "Double".equals(typeName) ||
+            "Decimal".equals(typeName)
         );
     }
 }

--- a/src/main/java/aster/core/ir/CoreModel.java
+++ b/src/main/java/aster/core/ir/CoreModel.java
@@ -417,6 +417,7 @@ public final class CoreModel {
     @JsonSubTypes.Type(value = IntE.class, name = "Int"),
     @JsonSubTypes.Type(value = LongE.class, name = "Long"),
     @JsonSubTypes.Type(value = DoubleE.class, name = "Double"),
+    @JsonSubTypes.Type(value = DecimalE.class, name = "Decimal"),
     @JsonSubTypes.Type(value = StringE.class, name = "String"),
     @JsonSubTypes.Type(value = NullE.class, name = "Null"),
     @JsonSubTypes.Type(value = Ok.class, name = "Ok"),
@@ -430,7 +431,7 @@ public final class CoreModel {
     @JsonSubTypes.Type(value = IfE.class, name = "IfExpr"),
     @JsonSubTypes.Type(value = ListE.class, name = "ListLit")
   })
-  public sealed interface Expr permits Name, Bool, IntE, LongE, DoubleE, StringE, NullE, Ok, Err, Some, NoneE, Construct, Call, Lambda, Await, IfE, ListE {}
+  public sealed interface Expr permits Name, Bool, IntE, LongE, DoubleE, DecimalE, StringE, NullE, Ok, Err, Some, NoneE, Construct, Call, Lambda, Await, IfE, ListE {}
 
   @JsonTypeName("Name")
   public static final class Name implements Expr {
@@ -459,6 +460,15 @@ public final class CoreModel {
   @JsonTypeName("Double")
   public static final class DoubleE implements Expr {
     public double value;    // 浮点数
+    public Origin origin;
+  }
+
+  // Decimal 字面量（ADR 0025）：value 是 canonical 十进制字符串（如 "1.08"/"1"/"0"），
+  // 非二进制浮点——与 TS Core.Decimal、truffle DecimalE 逐位一致。两引擎 eval 时
+  // 还原为 decimal.js / BigDecimal 做精确算术。
+  @JsonTypeName("Decimal")
+  public static final class DecimalE implements Expr {
+    public String value;    // canonical 十进制字符串
     public Origin origin;
   }
 

--- a/src/main/java/aster/core/ir/visitor/CoreVisitor.java
+++ b/src/main/java/aster/core/ir/visitor/CoreVisitor.java
@@ -141,6 +141,10 @@ public interface CoreVisitor<Ctx, R> {
     return visitExpression(d, ctx);
   }
 
+  default R visitDecimal(CoreModel.DecimalE dec, Ctx ctx) {
+    return visitExpression(dec, ctx);
+  }
+
   default R visitString(CoreModel.StringE s, Ctx ctx) {
     return visitExpression(s, ctx);
   }

--- a/src/main/java/aster/core/ir/visitor/DefaultCoreVisitor.java
+++ b/src/main/java/aster/core/ir/visitor/DefaultCoreVisitor.java
@@ -225,6 +225,7 @@ public class DefaultCoreVisitor<Ctx> implements CoreVisitor<Ctx, Void> {
       case CoreModel.IntE i -> null;
       case CoreModel.LongE l -> null;
       case CoreModel.DoubleE d -> null;
+      case CoreModel.DecimalE dec -> null;
       case CoreModel.StringE s -> null;
       case CoreModel.NullE n -> null;
       case CoreModel.NoneE n -> null;

--- a/src/main/java/aster/core/lowering/CoreLowering.java
+++ b/src/main/java/aster/core/lowering/CoreLowering.java
@@ -358,6 +358,12 @@ public final class CoreLowering {
         out.origin = spanToOrigin(dbl.span());
         yield out;
       }
+      case Expr.Decimal dec -> {
+        CoreModel.DecimalE out = new CoreModel.DecimalE();
+        out.value = dec.value();  // 已是 canonical 字符串（AstBuilder 归一）
+        out.origin = spanToOrigin(dec.span());
+        yield out;
+      }
       case Expr.String str -> {
         CoreModel.StringE out = new CoreModel.StringE();
         out.value = str.value();

--- a/src/main/java/aster/core/module/ModuleGraphLinker.java
+++ b/src/main/java/aster/core/module/ModuleGraphLinker.java
@@ -346,6 +346,8 @@ public final class ModuleGraphLinker {
         }
         case CoreModel.DoubleE ignored -> {
         }
+        case CoreModel.DecimalE ignored -> {
+        }
         case CoreModel.StringE ignored -> {
         }
         case CoreModel.NullE ignored -> {

--- a/src/main/java/aster/core/parser/AstBuilder.java
+++ b/src/main/java/aster/core/parser/AstBuilder.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 public class AstBuilder extends AsterParserBaseVisitor<Object> {
 
     private static final Set<String> BUILTIN_TYPE_NAMES = Set.of(
-        "Int", "Bool", "Text", "Long", "Double", "Number", "Float", "Option", "Result", "List", "Map"
+        "Int", "Bool", "Text", "Long", "Double", "Decimal", "Number", "Float", "Option", "Result", "List", "Map"
     );
 
     private final Set<String> declaredTypeNames = new HashSet<>();
@@ -1444,6 +1444,36 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
     public Expr visitFloatExpr(AsterParser.FloatExprContext ctx) {
         double value = Double.parseDouble(ctx.FLOAT_LITERAL().getText());
         return new Expr.Double(value, spanFrom(ctx));
+    }
+
+    @Override
+    public Expr visitDecimalExpr(AsterParser.DecimalExprContext ctx) {
+        // Decimal 字面量（ADR 0025）：去 m/M 后缀，归一为 canonical 十进制字符串
+        // （去前导/尾零、零归 "0"），与 TS canonicalizeDecimal、truffle BigDecimal
+        // toPlainString 逐位一致——双引擎 Core IR value 必须字节相同。
+        String raw = ctx.DECIMAL_LITERAL().getText();
+        String digits = raw.substring(0, raw.length() - 1); // 去掉末尾 m/M
+        String canonical = canonicalizeDecimal(digits);
+        // ADR 0025 v1：Decimal 有效位 ≤38。超限会让 TS decimal.js（precision 80）乘法静默舍入、
+        // BigDecimal 精确 → 双引擎分歧（Codex 审查 P1）。硬拒以保 parity 与确定性。
+        int sigDigits = canonical.replaceAll("[.-]", "").replaceFirst("^0+(?=\\d)", "").length();
+        if (sigDigits > 38) {
+            throw new IllegalStateException(
+                "Decimal literal has " + sigDigits + " significant digits; the v1 maximum is 38 (ADR 0025).");
+        }
+        return new Expr.Decimal(canonical, spanFrom(ctx));
+    }
+
+    /** 把十进制数字串归一为 canonical 形：去前导零、去尾零，零归 "0"（不产生 "-0"/指数）。 */
+    private static String canonicalizeDecimal(String digits) {
+        int dot = digits.indexOf('.');
+        String intPart = dot < 0 ? digits : digits.substring(0, dot);
+        String fracPart = dot < 0 ? "" : digits.substring(dot + 1);
+        intPart = intPart.replaceFirst("^0+(?=\\d)", "");
+        if (intPart.isEmpty()) intPart = "0";
+        fracPart = fracPart.replaceFirst("0+$", "");
+        String out = fracPart.isEmpty() ? intPart : intPart + "." + fracPart;
+        return out.equals("-0") || out.isEmpty() ? "0" : out;
     }
 
     @Override

--- a/src/main/java/aster/core/typecheck/BuiltinTypes.java
+++ b/src/main/java/aster/core/typecheck/BuiltinTypes.java
@@ -27,6 +27,9 @@ public final class BuiltinTypes {
   /** 双精度浮点数类型 */
   public static final String DOUBLE = "Double";
 
+  /** 精确十进制类型（ADR 0025，金融/保险金额，区别于二进制浮点 Double） */
+  public static final String DECIMAL = "Decimal";
+
   /** 字符串类型（标准名称） */
   public static final String STRING = "String";
 
@@ -59,6 +62,7 @@ public final class BuiltinTypes {
         || BOOL.equals(typeName)
         || LONG.equals(typeName)
         || DOUBLE.equals(typeName)
+        || DECIMAL.equals(typeName)
         || isStringType(typeName)
         || NUMBER.equals(typeName);
   }

--- a/src/main/java/aster/core/typecheck/ErrorCode.java
+++ b/src/main/java/aster/core/typecheck/ErrorCode.java
@@ -39,6 +39,9 @@ public enum ErrorCode {
   COMPENSATE_NEW_CAPABILITY("E028", Category.CAPABILITY, Severity.ERROR, "Compensate block for step '%s' in function '%s' introduces new capability %s that does not appear in the main step body.", "Compensate 只能重复主体已使用的能力；如需额外调用，请将相同行为移至主体或在主体中声明该 capability。"),
   WORKFLOW_UNKNOWN_STEP_DEPENDENCY("E029", Category.SCOPE, Severity.ERROR, "Workflow step '%s' depends on undefined step '%s'.", "仅引用当前 workflow 中已声明的步骤名称，或修正依赖拼写。"),
   WORKFLOW_CIRCULAR_DEPENDENCY("E030", Category.TYPE, Severity.ERROR, "Workflow contains circular step dependency: %s", "移除或重构循环依赖，确保步骤可拓扑排序执行。"),
+  // ADR 0025：Decimal↔Double 混算编译期拦截（与 TS E031 对齐）。Double 是二进制浮点，
+  // 与精确 Decimal 混算会注入舍入误差，破坏可证明性；Int/Long→Decimal 精确提升放行。
+  DECIMAL_DOUBLE_MIXING("E031", Category.TYPE, Severity.ERROR, "Cannot combine Decimal and Double in '{operator}'. Double is binary floating-point and would inject rounding error into an exact Decimal. Use Decimal literals (e.g. 1.08m) on both sides, or Int/Long (exact promotion).", "使两侧操作数都为 Decimal（m 后缀），或改用 Int/Long（可精确提升为 Decimal）。"),
   // P0-R3 (codex review High #3): 与 TS 端 ERROR_METADATA category 对齐——
   // 5 个核心 PII codes 从 Category.TYPE 改为 Category.PII。之前的 'TYPE'
   // 分类是历史包袱，让任何按 category 派生 PII 集合的代码（如跨语言

--- a/src/main/java/aster/core/typecheck/TypeSystem.java
+++ b/src/main/java/aster/core/typecheck/TypeSystem.java
@@ -494,6 +494,7 @@ public final class TypeSystem {
       case CoreModel.IntE i -> createTypeName("Int");
       case CoreModel.LongE l -> createTypeName("Long");
       case CoreModel.DoubleE d -> createTypeName("Double");
+      case CoreModel.DecimalE dec -> createTypeName("Decimal");
       case CoreModel.StringE s -> createTypeName("String");
       case CoreModel.NullE n -> {
         var maybe = new CoreModel.Maybe();

--- a/src/main/java/aster/core/typecheck/checkers/BaseTypeChecker.java
+++ b/src/main/java/aster/core/typecheck/checkers/BaseTypeChecker.java
@@ -54,6 +54,7 @@ public final class BaseTypeChecker {
       case CoreModel.IntE i -> createTypeName("Int");
       case CoreModel.LongE l -> createTypeName("Long");
       case CoreModel.DoubleE d -> createTypeName("Double");
+      case CoreModel.DecimalE dec -> createTypeName("Decimal");
       case CoreModel.StringE s -> createTypeName("String");
       case CoreModel.NullE n -> {
         var maybe = new CoreModel.Maybe();
@@ -275,6 +276,42 @@ public final class BaseTypeChecker {
         typeOfExpr(call.args.get(0), ctx);
       }
       return createTypeName("Bool");
+    }
+
+    // 算术 + 比较运算符（+/-/*///% 与 == != < <= > >=，lower 为 Call{Name op}）：Decimal↔Double
+    // 混算编译期拦截（ADR 0025，与 TS expression.ts 对齐）。Double 是二进制浮点，与精确 Decimal
+    // 混算注入舍入误差；Int/Long↔Decimal 精确提升放行。Codex 审查 P0：不止算术，比较运算符也须拦
+    // ——`1.0m equals to 1.0` TS runtime 当 Int 提升、Truffle 抛错 = 双引擎分歧。算术任一
+    // Decimal/Int/Long 组合 → 结果 Decimal（传播，使嵌套继续被检查）；比较返回 Bool（不在此设）。
+    if (call.target instanceof CoreModel.Name opName
+        && (isArithmeticOperator(opName.name) || isComparisonOperator(opName.name)) && call.args.size() == 2) {
+      var lt = typeOfExpr(call.args.get(0), ctx);
+      var rt = typeOfExpr(call.args.get(1), ctx);
+      boolean lDec = isTypeNamed(lt, "Decimal"), rDec = isTypeNamed(rt, "Decimal");
+      boolean lDbl = isTypeNamed(lt, "Double"), rDbl = isTypeNamed(rt, "Double");
+      if ((lDec && rDbl) || (lDbl && rDec)) {
+        diagnostics.error(ErrorCode.DECIMAL_DOUBLE_MIXING, Optional.ofNullable(call.origin),
+            Map.of("operator", opName.name));
+      }
+      if (isArithmeticOperator(opName.name)) {
+        boolean lIntLong = isTypeNamed(lt, "Int") || isTypeNamed(lt, "Long");
+        boolean rIntLong = isTypeNamed(rt, "Int") || isTypeNamed(rt, "Long");
+        if ((lDec || rDec) && (lDec || lIntLong) && (rDec || rIntLong)) {
+          return createTypeName("Decimal");
+        }
+      }
+    }
+
+    // Codex 审查 P0：Decimal.round(x,…)/Decimal.divide(x,y,…) 的 Decimal 操作数位不得是 Double。
+    if (call.target instanceof CoreModel.Name fn
+        && ("Decimal.round".equals(fn.name) || "Decimal.divide".equals(fn.name))) {
+      int decimalArgCount = "Decimal.divide".equals(fn.name) ? 2 : 1;
+      for (int i = 0; i < Math.min(decimalArgCount, call.args.size()); i++) {
+        if (isTypeNamed(typeOfExpr(call.args.get(i), ctx), "Double")) {
+          diagnostics.error(ErrorCode.DECIMAL_DOUBLE_MIXING, Optional.ofNullable(call.origin),
+              Map.of("operator", fn.name));
+        }
+      }
     }
 
     // 如果不是函数类型，返回 unknown
@@ -531,6 +568,23 @@ public final class BaseTypeChecker {
     var type = new CoreModel.TypeName();
     type.name = name;
     return type;
+  }
+
+  /** 算术运算符（lower 后的 Call target Name）：+/-/*///%。 */
+  private boolean isArithmeticOperator(String op) {
+    return "+".equals(op) || "-".equals(op) || "*".equals(op)
+        || "/".equals(op) || "//".equals(op) || "%".equals(op);
+  }
+
+  /** 比较运算符（lower 后的 Call target Name）：== != < <= > >=。 */
+  private boolean isComparisonOperator(String op) {
+    return "==".equals(op) || "!=".equals(op) || "<".equals(op)
+        || "<=".equals(op) || ">".equals(op) || ">=".equals(op);
+  }
+
+  /** 类型是否为指定名的 TypeName（如 "Decimal"/"Double"/"Int"/"Long"）。 */
+  private boolean isTypeNamed(Type t, String name) {
+    return t instanceof CoreModel.TypeName tn && name.equals(tn.name);
   }
 
   /**

--- a/src/main/java/aster/core/typecheck/pii/PiiTypeChecker.java
+++ b/src/main/java/aster/core/typecheck/pii/PiiTypeChecker.java
@@ -161,8 +161,8 @@ public final class PiiTypeChecker {
       return cloneMeta(env.get(name.name));
     }
     if (expr instanceof CoreModel.Bool || expr instanceof CoreModel.IntE || expr instanceof CoreModel.LongE
-      || expr instanceof CoreModel.DoubleE || expr instanceof CoreModel.StringE || expr instanceof CoreModel.NullE
-      || expr instanceof CoreModel.NoneE) {
+      || expr instanceof CoreModel.DoubleE || expr instanceof CoreModel.DecimalE || expr instanceof CoreModel.StringE
+      || expr instanceof CoreModel.NullE || expr instanceof CoreModel.NoneE) {
       return null;
     }
     if (expr instanceof CoreModel.Call call) {
@@ -538,6 +538,7 @@ public final class PiiTypeChecker {
     if (expr instanceof CoreModel.IntE i) return i.origin;
     if (expr instanceof CoreModel.LongE l) return l.origin;
     if (expr instanceof CoreModel.DoubleE d) return d.origin;
+    if (expr instanceof CoreModel.DecimalE dec) return dec.origin;
     if (expr instanceof CoreModel.StringE s) return s.origin;
     if (expr instanceof CoreModel.NullE n) return n.origin;
     if (expr instanceof CoreModel.Ok ok) return ok.origin;

--- a/src/test/java/aster/core/ast/CoreIrSchemaAbiTest.java
+++ b/src/test/java/aster/core/ast/CoreIrSchemaAbiTest.java
@@ -41,6 +41,7 @@ class CoreIrSchemaAbiTest {
         // 表达式 Expr
         "Name", "Call", "Construct", "Lambda", "Await",
         "Int", "Long", "Double", "Bool", "String", "Null",
+        "Decimal", // ADR 0025：Decimal 精确十进制字面量（只增不删，V1 向后兼容——旧 IR 无此 kind）
         "Ok", "Err", "Some", "None", "ListLiteral",
         "IfExpr", // ADR 0019 G2b：表达式级 if（只增不删）
 

--- a/src/test/java/aster/core/parser/DecimalLiteralTest.java
+++ b/src/test/java/aster/core/parser/DecimalLiteralTest.java
@@ -1,0 +1,102 @@
+package aster.core.parser;
+
+import aster.core.ast.Expr;
+import aster.core.ir.CoreModel;
+import aster.core.lowering.CoreLowering;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Decimal 字面量（ADR 0025，m 后缀）解析 + 降级测试。
+ *
+ * <p>验证 `1.08m` → AST Expr.Decimal(canonical 字符串) → Core IR DecimalE。canonical
+ * 化规则（去前导/尾零、零归 "0"）必须与 TS canonicalizeDecimal、truffle BigDecimal
+ * toPlainString 逐位一致——三引擎 Core IR value 字节相同是 parity 契约。fixture 与
+ * ts decimal-literals.test.ts、truffle DecimalBuiltinTest 同源。
+ */
+class DecimalLiteralTest {
+
+    private aster.core.ast.Module parseAndBuild(String input) {
+        CharStream charStream = CharStreams.fromString(input);
+        AsterCustomLexer lexer = new AsterCustomLexer(charStream);
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        tokens.fill();
+        tokens.seek(0);
+        AsterParser parser = new AsterParser(tokens);
+        parser.removeErrorListeners();
+        AsterParser.ModuleContext moduleCtx = parser.module();
+        assertNotNull(moduleCtx, "解析返回 null ModuleContext: " + input);
+        aster.core.ast.Module module = new AstBuilder().visitModule(moduleCtx);
+        assertNotNull(module, "AstBuilder 返回 null: " + input);
+        return module;
+    }
+
+    /** 解析单个 `Return <expr>.` 规则体，取出返回表达式的 AST 节点。 */
+    private Expr returnExprOf(String literal) {
+        String src = "Module probe.\n\nRule main produce Decimal:\n  Return " + literal + ".\n";
+        var module = parseAndBuild(src);
+        var func = (aster.core.ast.Decl.Func) module.decls().get(0);
+        var ret = (aster.core.ast.Stmt.Return) func.body().statements().get(0);
+        return ret.expr();
+    }
+
+    /** 解析 + 降级，取出 Core IR 中返回表达式的 DecimalE.value。 */
+    private String loweredDecimalValue(String literal) {
+        String src = "Module probe.\n\nRule main produce Decimal:\n  Return " + literal + ".\n";
+        var module = parseAndBuild(src);
+        var core = new CoreLowering().lowerModule(module);
+        var func = (CoreModel.Func) core.decls.get(0);
+        var ret = (CoreModel.Return) func.body.statements.get(0);
+        assertInstanceOf(CoreModel.DecimalE.class, ret.expr,
+            "返回表达式应降级为 DecimalE，实际: " + ret.expr.getClass().getSimpleName());
+        return ((CoreModel.DecimalE) ret.expr).value;
+    }
+
+    @Test void parsesAsDecimalNotFloat() {
+        // `1.08m` 必须解析为 Expr.Decimal（而非 FLOAT + 标识符 m）
+        Expr e = returnExprOf("1.08m");
+        assertInstanceOf(Expr.Decimal.class, e, "1.08m 应解析为 Decimal，实际: " + e.kind());
+        assertEquals("1.08", ((Expr.Decimal) e).value());
+        // 整数形 `10m` 同样
+        assertInstanceOf(Expr.Decimal.class, returnExprOf("10m"));
+    }
+
+    @Test void canonicalLowering() {
+        // canonical 化：去尾零 / 去前导+尾零 / 零归 "0" / 整数保持
+        assertEquals("1.08", loweredDecimalValue("1.08m"));
+        assertEquals("1", loweredDecimalValue("1.00m"));
+        assertEquals("1.23", loweredDecimalValue("001.2300m"));
+        assertEquals("0", loweredDecimalValue("0.000m"));
+        assertEquals("10", loweredDecimalValue("10m"));
+        assertEquals("100", loweredDecimalValue("100m"));
+        // 大写 M 后缀也接受
+        assertEquals("2.5", loweredDecimalValue("2.5M"));
+    }
+
+    @Test void digitLimitV1() {
+        // ADR 0025 v1：≤38 有效位（Codex 审查 P1）。38 接受，39 拒绝（与 TS 一致）。
+        String d38 = "1".repeat(38);
+        String d39 = "1".repeat(39);
+        org.junit.jupiter.api.Assertions.assertEquals(d38, loweredDecimalValue(d38 + "m"));
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+            () -> loweredDecimalValue(d39 + "m"), "39 位应拒绝");
+        // 纯小数前导零不计有效位
+        String frac = "0." + "0".repeat(38) + "1";
+        org.junit.jupiter.api.Assertions.assertEquals(frac, loweredDecimalValue(frac + "m"));
+    }
+
+    @Test void floatStillParsesAsDouble() {
+        // 回归：无 m 后缀的 `1.08` 仍是 Double（不被 Decimal 抢走）
+        String src = "Module probe.\n\nRule main produce Double:\n  Return 1.08.\n";
+        var module = parseAndBuild(src);
+        var core = new CoreLowering().lowerModule(module);
+        var func = (CoreModel.Func) core.decls.get(0);
+        var ret = (CoreModel.Return) func.body.statements.get(0);
+        assertInstanceOf(CoreModel.DoubleE.class, ret.expr,
+            "1.08（无 m）应仍是 Double，实际: " + ret.expr.getClass().getSimpleName());
+    }
+}

--- a/src/test/java/aster/core/typecheck/DecimalMixingTypeCheckTest.java
+++ b/src/test/java/aster/core/typecheck/DecimalMixingTypeCheckTest.java
@@ -1,0 +1,72 @@
+package aster.core.typecheck;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import aster.core.canonicalizer.Canonicalizer;
+import aster.core.lowering.CoreLowering;
+import aster.core.parser.AstBuilder;
+import aster.core.parser.AsterCustomLexer;
+import aster.core.parser.AsterParser;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Decimal↔Double 混算编译期拦截（ADR 0025，M1 后续；与 TS decimal-mixing-typecheck 对齐）。
+ *
+ * <p>runtime 只能 catch 非整数 Double（2.5）；整数值 Double（2.0）与 Int（2）在底层数值
+ * 不可分——必须靠 typechecker 按 AST/Core IR 节点 kind（Double vs Decimal）在编译期拦截。
+ * Int/Long↔Decimal 精确提升放行。错误码 E031 DECIMAL_DOUBLE_MIXING。
+ */
+class DecimalMixingTypeCheckTest {
+
+  private boolean hasMixingError(String body) {
+    String src = "Module probe.\n\n" + body + "\n";
+    String canonical = new Canonicalizer().canonicalize(src);
+    var lexer = new AsterCustomLexer(CharStreams.fromString(canonical));
+    var tokens = new CommonTokenStream(lexer);
+    tokens.fill();
+    tokens.seek(0);
+    var parser = new AsterParser(tokens);
+    parser.removeErrorListeners();
+    var ast = new AstBuilder().visitModule(parser.module());
+    var core = new CoreLowering().lowerModule(ast);
+    var diags = new TypeChecker().typecheckModule(core);
+    return diags.stream().anyMatch(d -> d.code() == ErrorCode.DECIMAL_DOUBLE_MIXING);
+  }
+
+  @Test void mixingProducesError() {
+    // 整数值 Double（runtime 抓不到）+ 非整数 Double + 嵌套传播
+    assertTrue(hasMixingError("Rule main produce Decimal:\n  Return 1.08m plus 2.0."));
+    assertTrue(hasMixingError("Rule main produce Decimal:\n  Return 2.0 times 3m."));
+    assertTrue(hasMixingError("Rule main produce Decimal:\n  Return 1.08m minus 2.5."));
+    // 嵌套：(100.00m times 1.08m) 结果 Decimal，与 0.5(Double) 混算 → error
+    assertTrue(hasMixingError("Rule main produce Decimal:\n  Return 100.00m times 1.08m plus 0.5."));
+  }
+
+  @Test void legalCombinationsNoError() {
+    // Int/Long→Decimal 精确提升 + 纯 Decimal + 纯 Double 都合法
+    assertFalse(hasMixingError("Rule main produce Decimal:\n  Return 1.08m plus 2."));
+    assertFalse(hasMixingError("Rule main produce Decimal:\n  Return 1.08m plus 2.50m."));
+    assertFalse(hasMixingError("Rule main produce Double:\n  Return 1.08 plus 2.5."));
+    assertFalse(hasMixingError("Rule main produce Int:\n  Return 1 plus 2."));
+  }
+
+  @Test void comparisonAndBuiltinArgMixing() {
+    // Codex 审查 P0：比较运算符混算（整数值 Double 不可 runtime catch）
+    assertTrue(hasMixingError("Rule main produce Bool:\n  Return 1.0m equals to 1.0."));
+    assertTrue(hasMixingError("Rule main produce Bool:\n  Return 1.0m at most 2.0."));
+    assertTrue(hasMixingError("Rule main produce Bool:\n  Return 2.0 greater than 1.0m."));
+    // Decimal.round/divide 的 Decimal 参数位混 Double
+    assertTrue(hasMixingError("Rule main produce Decimal:\n  Return Decimal.divide(1m, 2.0, 2, \"HALF_UP\")."));
+    assertTrue(hasMixingError("Rule main produce Decimal:\n  Return Decimal.round(2.0, 1, \"HALF_UP\")."));
+  }
+
+  @Test void comparisonAndBuiltinLegalNoError() {
+    assertFalse(hasMixingError("Rule main produce Bool:\n  Return 1.0m equals to 1.00m."));
+    assertFalse(hasMixingError("Rule main produce Bool:\n  Return 1.0m at most 2."));
+    assertFalse(hasMixingError("Rule main produce Decimal:\n  Return Decimal.divide(1m, 2m, 2, \"HALF_UP\")."));
+    assertFalse(hasMixingError("Rule main produce Bool:\n  Return 1.0 equals to 2.0."));
+  }
+}


### PR DESCRIPTION
First-class `Decimal` type for exact financial/insurance amount rules (ADR 0025, compliance-primitives #1 P0 after Date.*).

## What
- `m`-suffix Decimal literals (`1.08m`); `1.08` stays Double.
- `DECIMAL_LITERAL` lexer rule (before FLOAT/INT/LONG), `#DecimalExpr`, `Expr.Decimal` + `CoreModel.DecimalE` (value = **canonical decimal string**, byte-identical to truffle BigDecimal / ts decimal.js).
- 8 exhaustive switches kept total + ABI guard registers `"Decimal"` (V1 additive).
- Compile-time **Double↔Decimal mixing ban** (E031) over arithmetic AND comparison operators + `Decimal.round`/`Decimal.divide` args (runtime cannot distinguish integer-valued `2.0` from Int `2` — typechecker-only).
- 38-digit literal cap (matches ts) keeps cross-engine canonical exact.

## Verification
- Dual-engine parity (aster-lang-test#feat/decimal): parse 215/215, ir-full 0 divergent, eval 251/251 identical.
- Codex cross-review 92/100 (session 019f1350). Long>2^53→Decimal precision documented as known limitation (ADR 0025 §4).

Part of the Decimal release: aster-lang-{core,ts,truffle,test}#feat/decimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)