### PR TITLE
chore(release): bump platform pin 1.0.9→1.0.10 (ecosystem 1.0.8, Decimal)

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.9")
+            from("cloud.aster-lang:aster-lang-platform:1.0.10")
         }
     }
 }


### PR DESCRIPTION
Release Decimal first-class type (#49) via the 1.0.8 ecosystem cascade. catalog-derived version resolves asterLang=1.0.8 from platform 1.0.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)