### PR TITLE
feat(grammar): multi-line continuation (ADR 0026) + paren-free call `apply f to x` (ADR 0027)

### DIFF
--- a/src/main/antlr/AsterLexer.g4
+++ b/src/main/antlr/AsterLexer.g4
@@ -143,6 +143,9 @@ VERSION: 'version';
 LET: [Ll][Ee][Tt];
 BE: 'be';
 RETURN: [Rr][Ee][Tt][Uu][Rr][Nn];
+// ADR 0027：无括号单参调用引入词 `apply <fn> to <arg>`。软关键词——在标识符位置
+// （structKeywordName）放行，故 `Rule apply given …` 不破。
+APPLY: [Aa][Pp][Pp][Ll][Yy];
 IF: [Ii][Ff];
 // ADR 0019 G2a：内联 if 的 then 连接词（大小写不敏感，与其它结构关键词一致）。
 THEN: [Tt][Hh][Ee][Nn];

--- a/src/main/antlr/AsterParser.g4
+++ b/src/main/antlr/AsterParser.g4
@@ -228,6 +228,9 @@ structKeywordName
     // 同 ADR 0019 G1 的 LET/IF/RETURN 软关键字范式（ADR 0024 §poker 纯 CNL 前置修复）。
     | MAX
     | ATTEMPTS
+    // ADR 0027：APPLY 是无括号调用引入词的硬 token，但在标识符位置当软关键字——
+    // 否则 `Rule apply given …`（函数名叫 apply）被卡。applyExpr 起点仍按 APPLY 分派。
+    | APPLY
     ;
 
 /**
@@ -599,7 +602,30 @@ multiplicativeExpr
 
 unaryExpr
     : NOT unaryExpr                      # NotExpr
+    // ADR 0027：无括号单参调用 `apply <fn> to <arg>`，lower 成 Call(fn,[arg])，零新 IR 节点。
+    // 放在 unaryExpr 层（而非 primaryExpr）以免 postfixExpr 对 apply 结果接调用/成员后缀；
+    // arg 取顶层 expr（贪婪），故 `apply gather to stars less 1` = `gather(stars less 1)`。
+    | applyExpr                          # ApplyCallExpr
     | postfixExpr                        # PostfixUnary
+    ;
+
+/**
+ * ADR 0027：无括号单参调用。fn 用专门的 callTarget（裸名/限定名点链，不含调用后缀），
+ * 与 TS 引擎 parseCallTargetName 对齐——否则 `apply f(y) to x` 会一引擎接受一引擎拒，破坏 parity。
+ */
+applyExpr
+    : APPLY callTarget TO_WORD expr
+    ;
+
+callTarget
+    : callTargetSegment (DOT callTargetSegment)*
+    ;
+
+// 每段放行集对齐 TS parseCallTargetName（TS 无 MAP token，`Map` 处处是 TYPE_IDENT）——
+// MAP 须出现在**任意段**而非仅首段，否则 `apply Foo.Map to x` 一引擎收一引擎拒
+// （Codex 审查 019f1639 致命问题 #1）。
+callTargetSegment
+    : IDENT | TYPE_IDENT | MAP | structKeywordName
     ;
 
 /**

--- a/src/main/antlr/AsterParser.g4
+++ b/src/main/antlr/AsterParser.g4
@@ -551,13 +551,20 @@ ifExpr
 // 逻辑或（最低优先级，左结合）。and/or 在表达式上下文是逻辑运算符；
 // 在 givenParamList / fieldList / constructFields / typeList / waitStmt 等
 // 列表上下文，AND 由各自规则显式消费，不进入此表达式链。
+// ADR 0026：等缩进多行表达式续行——运算符前后可有零或多个 NEWLINE（只吞 NEWLINE，
+// 绝不含 INDENT/DEDENT，故块的缩进栈不受影响）。与 fieldList 里 `NEWLINE* (AND|COMMA) NEWLINE*`
+// 同构。ALL(*) 靠运算符 first-set 与「NEWLINE 后接 DEDENT/语句引导」区分续行 vs 块边界。
+nlOpt
+    : NEWLINE*
+    ;
+
 orExpr
-    : andExpr (OR andExpr)*
+    : andExpr (nlOpt OR nlOpt andExpr)*
     ;
 
 // 逻辑与（高于 or，低于 not / 比较，左结合）
 andExpr
-    : comparisonExpr (AND comparisonExpr)*
+    : comparisonExpr (nlOpt AND nlOpt comparisonExpr)*
     ;
 
 // 比较表达式。除符号/多词比较词 token 外，`under` / `over` 作为**软关键字**
@@ -565,13 +572,13 @@ andExpr
 // 软关键字前可带一个可选的 `is` 连接词（`is under` / `is over`），由语义谓词
 // 识别 IDENT 文本，避免在 lexer 无条件保留这些常见英文单词。
 comparisonExpr
-    : additiveExpr (
+    : additiveExpr ( nlOpt (
           op=(LT | GT | LTE | GTE | NEQ | EQ | EQUALS
               | LESS_THAN_WORD | GREATER_THAN_WORD
               | LESS_THAN_OR_EQUAL_WORD | GREATER_THAN_OR_EQUAL_WORD
-              | EQUALS_TO_WORD | NOT_EQUAL_TO_WORD) additiveExpr
-        | softCmp=softComparator additiveExpr
-      )?
+              | EQUALS_TO_WORD | NOT_EQUAL_TO_WORD) nlOpt additiveExpr
+        | softCmp=softComparator nlOpt additiveExpr
+      ) )?
     ;
 
 // 软比较词：`under` / `over`，前置可选 `is`。用语义谓词匹配 IDENT 文本，使
@@ -583,11 +590,11 @@ softComparator
     ;
 
 additiveExpr
-    : multiplicativeExpr (op=(PLUS | MINUS | PLUS_WORD | MINUS_WORD) multiplicativeExpr)*
+    : multiplicativeExpr (nlOpt op=(PLUS | MINUS | PLUS_WORD | MINUS_WORD) nlOpt multiplicativeExpr)*
     ;
 
 multiplicativeExpr
-    : unaryExpr (op=(STAR | SLASH | TIMES_WORD | DIVIDED_BY_WORD | INTEGER_DIVIDED_BY_WORD | MODULO_WORD) unaryExpr)*
+    : unaryExpr (nlOpt op=(STAR | SLASH | TIMES_WORD | DIVIDED_BY_WORD | INTEGER_DIVIDED_BY_WORD | MODULO_WORD) nlOpt unaryExpr)*
     ;
 
 unaryExpr

--- a/src/main/java/aster/core/parser/AstBuilder.java
+++ b/src/main/java/aster/core/parser/AstBuilder.java
@@ -1380,6 +1380,35 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
     }
 
     /**
+     * ADR 0027：无括号单参调用 `apply <fn> to <arg>`，lower 成与 `fn(arg)` 完全一致的
+     * Call(Name, [arg])——零新 IR 节点。fn 是 callTarget（裸名或限定名点链），arg 取顶层
+     * expr（贪婪），故 `apply gather to stars less 1` 等价 `gather(stars less 1)`。
+     */
+    @Override
+    public Expr visitApplyCallExpr(AsterParser.ApplyCallExprContext ctx) {
+        AsterParser.ApplyExprContext apply = ctx.applyExpr();
+        Expr.Name target = visitCallTargetName(apply.callTarget());
+        Expr arg = (Expr) visit(apply.expr());
+        // 复用普通调用构造路径（Codex 审查 019f1639 致命问题 #2）：createCallExpression 对
+        // Ok/Err/Some/None 内置变体作 AST 规范化（→ Expr.Some 等），故 `apply Some to x` 与
+        // `Some(x)` lower 到**完全相同**节点——这正是 ADR 0027「等价 fn(arg)」不变式所要求。
+        return createCallExpression(target, List.of(arg), spanFrom(ctx));
+    }
+
+    /**
+     * callTarget = 裸名/限定名点链（不含调用后缀），拼成单个点号分隔的 Expr.Name，
+     * 与后缀调用路径（combineName）及 TS parseCallTargetName 的命名口径一致。
+     */
+    private Expr.Name visitCallTargetName(AsterParser.CallTargetContext ctx) {
+        List<MemberSegment> segments = new ArrayList<>();
+        for (AsterParser.CallTargetSegmentContext seg : ctx.callTargetSegment()) {
+            segments.add(new MemberSegment(seg.getText(), spanFrom(seg)));
+        }
+        String qualified = combineName(null, segments);
+        return new Expr.Name(qualified, spanFrom(ctx));
+    }
+
+    /**
      * Lambda 表达式的 alternative 入口
      * 语法: function with x: T, produce R: body
      */

--- a/src/test/java/aster/core/parser/ApplyCallTest.java
+++ b/src/test/java/aster/core/parser/ApplyCallTest.java
@@ -1,0 +1,184 @@
+package aster.core.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import aster.core.canonicalizer.Canonicalizer;
+import aster.core.ir.CoreModel;
+import aster.core.lowering.CoreLowering;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 无括号单参调用 `apply <fn> to <arg>`（ADR 0027）—— Java 引擎。lower 成与 `fn(arg)`
+ * **完全相同**的 Core IR（Call(Name,[arg])，零新节点）；与 TS 引擎双引擎一致由 tier1-parity 锁。
+ * 软关键词（Codex 设计审查 019f1614）：APPLY 在 structKeywordName 放行，故 `Rule apply given …`
+ * （函数名叫 apply）与 `apply(x)` 后缀调用不破——applyExpr 仅 `apply <名> to` 形态触发。
+ */
+class ApplyCallTest {
+
+  /** 经 Canonicalizer → ANTLR → AstBuilder → CoreLowering，返回 Core IR。 */
+  private CoreModel.Module lower(String src) {
+    String canonical = new Canonicalizer().canonicalize(src);
+    var lexer = new AsterCustomLexer(CharStreams.fromString(canonical));
+    var tokens = new CommonTokenStream(lexer);
+    tokens.fill();
+    tokens.seek(0);
+    var parser = new AsterParser(tokens);
+    parser.removeErrorListeners();
+    var moduleCtx = parser.module();
+    assertNotNull(moduleCtx, "解析 null: " + src);
+    var ast = new AstBuilder().visitModule(moduleCtx);
+    assertNotNull(ast, "AstBuilder null: " + src);
+    return new CoreLowering().lowerModule(ast);
+  }
+
+  /** `apply …` 版与括号版的 Core IR 结构一致（origin/span 不入指纹）。 */
+  private void assertSameIr(String applyForm, String parenForm) {
+    assertEquals(fingerprint(lower(parenForm)), fingerprint(lower(applyForm)),
+        "apply 版 IR 应与括号调用版完全一致");
+  }
+
+  private String fingerprint(CoreModel.Module m) {
+    try {
+      var mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+      var tree = mapper.valueToTree(m);
+      stripOrigin(tree);
+      return mapper.writeValueAsString(tree);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void stripOrigin(com.fasterxml.jackson.databind.JsonNode node) {
+    if (node instanceof com.fasterxml.jackson.databind.node.ObjectNode obj) {
+      obj.remove("origin");
+      obj.remove("span");
+      obj.fields().forEachRemaining(e -> stripOrigin(e.getValue()));
+    } else if (node.isArray()) {
+      node.forEach(this::stripOrigin);
+    }
+  }
+
+  /** 解析并返回语法错误数（core 默认 error-recover 不抛，须用 listener 计数）。 */
+  private int syntaxErrors(String src) {
+    String canonical = new Canonicalizer().canonicalize(src);
+    var lexer = new AsterCustomLexer(CharStreams.fromString(canonical));
+    var tokens = new CommonTokenStream(lexer);
+    tokens.fill();
+    tokens.seek(0);
+    var parser = new AsterParser(tokens);
+    parser.removeErrorListeners();
+    var count = new int[]{0};
+    parser.addErrorListener(new org.antlr.v4.runtime.BaseErrorListener() {
+      @Override public void syntaxError(org.antlr.v4.runtime.Recognizer<?, ?> r, Object sym,
+          int line, int pos, String msg, org.antlr.v4.runtime.RecognitionException e) {
+        count[0]++;
+      }
+    });
+    parser.module();
+    return count[0];
+  }
+
+  @Test void bareNameSameAsParenCall() {
+    // `apply double to x` ≡ `double(x)`。
+    assertSameIr(
+        "Module t.\n\nRule r given x:\n  Return apply double to x.",
+        "Module t.\n\nRule r given x:\n  Return double(x).");
+  }
+
+  @Test void greedyArgEqualsParenthesizedExpr() {
+    // arg 取顶层 expr（贪婪）：`apply f to a plus 2` ≡ `f(a plus 2)`（不是 `f(a) plus 2`）。
+    assertSameIr(
+        "Module t.\n\nRule r given a:\n  Return apply f to a plus 2.",
+        "Module t.\n\nRule r given a:\n  Return f(a plus 2).");
+  }
+
+  @Test void recursiveApplyEqualsParenCall() {
+    // 递归调用（诗 demo 的核心场景）：`apply gather to stars less 1` ≡ `gather(stars less 1)`。
+    assertSameIr(
+        "Module t.\n\nRule gather given stars:\n  Return apply gather to stars less 1.",
+        "Module t.\n\nRule gather given stars:\n  Return gather(stars less 1).");
+  }
+
+  @Test void qualifiedTargetSameAsParenCall() {
+    // 限定名点链 target：`apply Math.abs to x` ≡ `Math.abs(x)`。
+    assertSameIr(
+        "Module t.\n\nRule r given x:\n  Return apply Math.abs to x.",
+        "Module t.\n\nRule r given x:\n  Return Math.abs(x).");
+  }
+
+  @Test void wrapperConstructorSameAsParenCall() {
+    // Codex 审查 019f1639 #2：apply 须复用普通调用路径（createCallExpression 把 Some/Ok
+    // 规范成 Expr.Some/Expr.Ok）。`apply Some to x` ≡ `Some(x)`（同为 Expr.Some），否则
+    // apply 版是裸 Call、括号版是 Expr.Some → Java 内部破不变式。
+    assertSameIr(
+        "Module t.\n\nRule r given x:\n  Return apply Some to x.",
+        "Module t.\n\nRule r given x:\n  Return Some(x).");
+    assertSameIr(
+        "Module t.\n\nRule r given x:\n  Return apply Ok to x.",
+        "Module t.\n\nRule r given x:\n  Return Ok(x).");
+  }
+
+  @Test void mapQualifierAnySegmentSameAsParenCall() {
+    // Codex 审查 019f1639 #1：MAP 须在 callTarget **任意段**放行（TS 处处把 Map 当
+    // TYPE_IDENT）。`apply Map.get to m` ≡ `Map.get(m)`；`apply Foo.Map to x` 不报错。
+    assertSameIr(
+        "Module t.\n\nRule r given m:\n  Return apply Map.get to m.",
+        "Module t.\n\nRule r given m:\n  Return Map.get(m).");
+    assertEquals(0, syntaxErrors("Module t.\n\nRule r given x:\n  Return apply Foo.Map to x."),
+        "`apply Foo.Map to x`（Map 作后续段）应零语法错误");
+  }
+
+  @Test void greedyArgInBinaryRightOperand() {
+    // Codex 审查 019f1639 #3：apply 在二元右操作数（`a plus apply f to b plus c`），arg 贪婪
+    // 取顶层 expr → `a plus f(b plus c)`，两引擎一致（parity 样本另锁）。这里只验单引擎结构稳定。
+    assertSameIr(
+        "Module t.\n\nRule r given a, b, c:\n  Return a plus apply f to b plus c.",
+        "Module t.\n\nRule r given a, b, c:\n  Return a plus f(b plus c).");
+  }
+
+  @Test void applyAsFunctionNameNotBroken() {
+    // 软关键词铁律：函数名叫 apply 不破（applyExpr 仅 `apply <名> to` 形态触发）。
+    assertEquals(0, syntaxErrors("Module t.\n\nRule apply given x:\n  Return x plus 1."),
+        "`Rule apply given …`（函数名 apply）应零语法错误");
+  }
+
+  @Test void applyParenCallNotBroken() {
+    // 软关键词：`apply(x)` 后缀调用形态（apply 后是 `(` 非 `名 to`）仍当普通调用。
+    assertEquals(0, syntaxErrors("Module t.\n\nRule apply given x:\n  Return x.\n\nRule r given y:\n  Return apply(y)."),
+        "`apply(y)` 后缀调用应零语法错误");
+  }
+
+  @Test void setToNotBroken() {
+    // 复用 TO_WORD 不与 `Set x to y` 冲突（apply 起头消歧）。
+    assertEquals(0, syntaxErrors("Module t.\n\nRule r given x:\n  Let m be x.\n  Set m to x plus 1.\n  Return m."),
+        "`Set m to …` 应零语法错误");
+  }
+
+  @Test void softKeywordTargetAccepted() {
+    // Codex 审查 019f1639 #3：软关键词（structKeywordName 成员）可作 callTarget 名——
+    // `apply if to x` / `apply let to x` / `apply return to x` 两引擎都接受。
+    assertEquals(0, syntaxErrors("Module t.\n\nRule r given x:\n  Return apply if to x."),
+        "`apply if to x`（软关键词 if 作目标）应零语法错误");
+    assertEquals(0, syntaxErrors("Module t.\n\nRule r given x:\n  Return apply return to x."),
+        "`apply return to x`（软关键词 return 作目标）应零语法错误");
+  }
+
+  @Test void hardKeywordTargetRejected() {
+    // Codex 审查 019f1639 #3：硬关键词（and/or/not/with/given/produce/set）**不**可作
+    // callTarget 名——TS 已对齐拒绝，两引擎一致（否则 TS 收/Java 拒 = parse 分歧）。
+    assertTrue(syntaxErrors("Module t.\n\nRule r given x:\n  Return apply and to x.") > 0,
+        "`apply and to x`（硬关键词 and 作目标）应报语法错误");
+    assertTrue(syntaxErrors("Module t.\n\nRule r given x:\n  Return apply with to x.") > 0,
+        "`apply with to x`（硬关键词 with 作目标）应报语法错误");
+  }
+
+  @Test void missingToIsError() {
+    // 缺 `to`：`apply f x`（无 to）应产生语法错误。
+    assertTrue(syntaxErrors("Module t.\n\nRule r given x:\n  Return apply f x.") > 0,
+        "缺 `to` 的 apply 应产生语法错误");
+  }
+}

--- a/src/test/java/aster/core/parser/MultilineContinuationTest.java
+++ b/src/test/java/aster/core/parser/MultilineContinuationTest.java
@@ -1,0 +1,137 @@
+package aster.core.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import aster.core.canonicalizer.Canonicalizer;
+import aster.core.ir.CoreModel;
+import aster.core.lowering.CoreLowering;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 等缩进多行表达式续行（ADR 0026）—— Java 引擎。续行（与语句起始行同缩进、运算符打头/结尾）
+ * 解析到与单行**完全相同**的 Core IR（零新节点）；与 TS 引擎双引擎一致由 tier1-parity 锁。
+ * 安全性（Codex 审查 019f157b）：nlOpt 只吞 NEWLINE，不碰 INDENT/DEDENT，块结构零风险。
+ */
+class MultilineContinuationTest {
+
+  /** 经 Canonicalizer → ANTLR → AstBuilder → CoreLowering，返回 Core IR JSON（剥 origin 比较）。 */
+  private CoreModel.Module lower(String src) {
+    String canonical = new Canonicalizer().canonicalize(src);
+    var lexer = new AsterCustomLexer(CharStreams.fromString(canonical));
+    var tokens = new CommonTokenStream(lexer);
+    tokens.fill();
+    tokens.seek(0);
+    var parser = new AsterParser(tokens);
+    parser.removeErrorListeners();
+    var moduleCtx = parser.module();
+    assertNotNull(moduleCtx, "解析 null: " + src);
+    var ast = new AstBuilder().visitModule(moduleCtx);
+    assertNotNull(ast, "AstBuilder null: " + src);
+    return new CoreLowering().lowerModule(ast);
+  }
+
+  /** 取首个规则体首条语句的表达式（Return/Let）。 */
+  private CoreModel.Expr firstExpr(CoreModel.Module m) {
+    var func = (CoreModel.Func) m.decls.get(0);
+    var stmt = func.body.statements.get(0);
+    if (stmt instanceof CoreModel.Return r) return r.expr;
+    if (stmt instanceof CoreModel.Let l) return l.expr;
+    throw new IllegalStateException("unexpected stmt " + stmt.getClass());
+  }
+
+  /** 续行版与单行版的 Core IR 表达式结构一致（用 toString 作结构指纹，origin 不入）。 */
+  private void assertSameIr(String multiline, String singleline) {
+    // CoreModel 节点无 equals；用 jackson 序列化后剥 origin 比较结构。
+    var ml = lower(multiline);
+    var sl = lower(singleline);
+    assertEquals(fingerprint(sl), fingerprint(ml), "续行版 IR 应与单行版一致");
+  }
+
+  /** 结构指纹：序列化 Core IR 并剥除 origin/span 行列（派生层）。 */
+  private String fingerprint(CoreModel.Module m) {
+    try {
+      var mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+      var tree = mapper.valueToTree(m);
+      stripOrigin(tree);
+      return mapper.writeValueAsString(tree);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void stripOrigin(com.fasterxml.jackson.databind.JsonNode node) {
+    if (node instanceof com.fasterxml.jackson.databind.node.ObjectNode obj) {
+      obj.remove("origin");
+      obj.remove("span");
+      obj.fields().forEachRemaining(e -> stripOrigin(e.getValue()));
+    } else if (node.isArray()) {
+      node.forEach(this::stripOrigin);
+    }
+  }
+
+  @Test void equalIndentOpLeading() {
+    // 行首运算符续行（加法）：1 plus 2 plus 3 跨行 ≡ 单行。
+    assertSameIr(
+        "Module t.\n\nRule r given a:\n  Return 1 plus 2\n  plus 3.",
+        "Module t.\n\nRule r given a:\n  Return 1 plus 2 plus 3.");
+  }
+
+  @Test void equalIndentOpTrailing() {
+    // 行尾运算符续行：1 plus\n 2 ≡ 单行。
+    assertSameIr(
+        "Module t.\n\nRule r given a:\n  Return 1 plus\n  2.",
+        "Module t.\n\nRule r given a:\n  Return 1 plus 2.");
+  }
+
+  @Test void multiplicativeAndComparisonAndLogical() {
+    assertSameIr(
+        "Module t.\n\nRule r given a:\n  Return 6 times 2\n  times 3.",
+        "Module t.\n\nRule r given a:\n  Return 6 times 2 times 3.");
+    assertSameIr(
+        "Module t.\n\nRule r given a:\n  Return a at least 1\n  and a at most 9.",
+        "Module t.\n\nRule r given a:\n  Return a at least 1 and a at most 9.");
+  }
+
+  /** 解析并返回语法错误数（core 默认 error-recover 不抛异常，须用 listener 计数）。 */
+  private int syntaxErrors(String src) {
+    String canonical = new Canonicalizer().canonicalize(src);
+    var lexer = new AsterCustomLexer(CharStreams.fromString(canonical));
+    var tokens = new CommonTokenStream(lexer);
+    tokens.fill();
+    tokens.seek(0);
+    var parser = new AsterParser(tokens);
+    parser.removeErrorListeners();
+    var count = new int[]{0};
+    parser.addErrorListener(new org.antlr.v4.runtime.BaseErrorListener() {
+      @Override public void syntaxError(org.antlr.v4.runtime.Recognizer<?, ?> r, Object sym,
+          int line, int pos, String msg, org.antlr.v4.runtime.RecognitionException e) {
+        count[0]++;
+      }
+    });
+    parser.module();
+    return count[0];
+  }
+
+  @Test void equalIndentNoSyntaxError() {
+    // 等缩进续行：零语法错误（与单行一样干净）。
+    assertEquals(0, syntaxErrors("Module t.\n\nRule r given a:\n  Return 1 plus 2\n  plus 3."));
+  }
+
+  @Test void deeperIndentRejected() {
+    // 本批不支持更深缩进续行（Codex：nlOpt 只吞 NEWLINE 不碰 INDENT/DEDENT）。更深缩进的 `plus`
+    // 前有未被吞的 INDENT → 语法错误（与 TS「Unknown statement」对应：两引擎都不接受深缩进续行）。
+    assertTrue(syntaxErrors("Module t.\n\nRule r given a:\n  Return 1 plus 2\n    plus 3.") > 0,
+        "更深缩进续行应产生语法错误（本批不支持）");
+  }
+
+  @Test void blockBoundaryIntact() {
+    // 两条独立语句不被续行误并：let m be …. / Return m. 各自成句。
+    var m = lower("Module t.\n\nRule r given a:\n  Let m be a plus 1.\n  Return m.");
+    var func = (CoreModel.Func) m.decls.get(0);
+    assertEquals(2, func.body.statements.size(), "应为两条独立语句");
+  }
+}


### PR DESCRIPTION
Two grammar features, both dual-engine + PR-blocking parity, both lowering to existing Core IR (zero new nodes).

## ADR 0026 — equal-indent multi-line expression continuation
Operator-leading/trailing continuation at equal indent (`nlOpt : NEWLINE*`); only eats NEWLINE, never INDENT/DEDENT (block structure intact). Codex design review reshaped deep-indent out.

## ADR 0027 — paren-free single-arg call \`apply <fn> to <arg>\`
Hides the last "program tell" in the source-is-poem demo: recursive `gather(stars less 1)` → `apply gather to stars minus 1`.
- `applyExpr` in the unaryExpr layer; arg is the full top-level expr (greedy). callTarget split into callTargetSegment (MAP allowed in every segment, matching TS). APPLY in structKeywordName (soft keyword — `Rule apply given …` still parses).
- visitApplyCallExpr routes through createCallExpression so `apply Some to x` ≡ `Some(x)` ≡ Expr.Some.

Codex implementation review 3 rounds (78→86→94 PASS), three real dual-engine divergences found & fixed (MAP dotted segment, apply bypassing createCallExpression, hard keywords as targets).

ApplyCallTest 13/13 + MultilineContinuationTest; core suite 1300/0. Dual-engine parse 217/217 + eval 255/255 (incl. Truffle) green via aster-lang-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)