### PR TITLE
chore(release): bump platform pin 1.0.11 (ecosystem 1.0.9)

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.10")
+            from("cloud.aster-lang:aster-lang-platform:1.0.11")
         }
     }
 }


### PR DESCRIPTION
Catalog-derived version → 1.0.9 (ADR 0026 multi-line continuation + ADR 0027 paren-free `apply f to x`). Platform pin 1.0.10→1.0.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)