### PR TITLE
chore(deps): bump platform pin 1.0.11→1.0.12 (ecosystem 1.0.10)

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.11")
+            from("cloud.aster-lang:aster-lang-platform:1.0.12")
         }
     }
 }


### PR DESCRIPTION
红队加固批次生态级联：platform catalog pin 1.0.11→1.0.12（ecosystem asterLang 1.0.9→1.0.10）。platform 1.0.12 已发布到 GH Packages。release-train drift gate 断言此 pin。

🤖 Generated with [Claude Code](https://claude.com/claude-code)