### PR TITLE
chore(deps): bump platform pin 1.0.12→1.0.13 (ecosystem 1.0.11)

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.12")
+            from("cloud.aster-lang:aster-lang-platform:1.0.13")
         }
     }
 }


### PR DESCRIPTION
生态级联：platform pin 1.0.12→1.0.13（ecosystem asterLang 1.0.10→1.0.11，LITERAL 特性）。platform 1.0.13 已发布。release-train drift gate 断言此 pin。

🤖 Generated with [Claude Code](https://claude.com/claude-code)