### PR TITLE
fix(canonicalizer): identifier 切分纳入组合记号(Mark)，天城文 matra 不再被切碎

### DIFF
--- a/src/main/java/aster/core/canonicalizer/Canonicalizer.java
+++ b/src/main/java/aster/core/canonicalizer/Canonicalizer.java
@@ -177,9 +177,14 @@ public final class Canonicalizer {
      * <p>
      * ANTLR 保留词（{@code true}/{@code false} 等）天然不在关键词词集合的转写目标里，
      * 故无需单独保护——它们转写后不是关键词，gate 会保留原样。
+     * <p>
+     * token 部分含 {@code \p{M}}（组合记号）：天城文(Hindi)等元音符号(matra)属 Unicode Mark，
+     * 不纳入会把 जागे 切成 ज+ग。数字用 {@code \p{Nd}}（十进制）而非 {@code \p{N}}：与
+     * {@link #isIdentifierPart}（isLetterOrDigit）及 TS 引擎 {@code identifierTokenRegex}
+     * 的 {@code [\p{L}_][\p{L}\p{M}\p{Nd}_]*} 对齐（跨引擎 parity）。
      */
     private static final Pattern WORD_PATTERN =
-        Pattern.compile("[\\p{L}_][\\p{L}\\p{N}_]*", Pattern.UNICODE_CHARACTER_CLASS);
+        Pattern.compile("[\\p{L}_][\\p{L}\\p{M}\\p{Nd}_]*", Pattern.UNICODE_CHARACTER_CLASS);
 
     /**
      * 使用默认词法表（en-US）创建规范化器
@@ -891,10 +896,20 @@ public final class Canonicalizer {
     /**
      * 判断字符是否可以作为标识符的一部分
      * <p>
-     * 包括：Unicode 字母、数字、下划线
+     * 包括：Unicode 字母、数字、下划线，以及**组合记号**（Mark：非间距记号 Mn、
+     * 间距组合记号 Mc、包围记号 Me）。天城文（Hindi）等印度系文字的元音符号（matra，
+     * 如 जागे 里的 ा/े）属于 Mark 而非 Letter，若不纳入会把 जागे 切成 ज+ग 丢失元音，
+     * 导致标识符/字面量宏永不匹配。与 TS 引擎的 {@code [\p{L}_][\p{L}\p{M}\p{Nd}_]*}
+     * 口径对齐（跨脚本 parity）。
      */
     private boolean isIdentifierPart(char ch) {
-        return Character.isLetterOrDigit(ch) || ch == '_';
+        if (Character.isLetterOrDigit(ch) || ch == '_') {
+            return true;
+        }
+        int type = Character.getType(ch);
+        return type == Character.NON_SPACING_MARK
+            || type == Character.COMBINING_SPACING_MARK
+            || type == Character.ENCLOSING_MARK;
     }
 
     /**

--- a/src/test/java/aster/core/identifier/LiteralMacroTest.java
+++ b/src/test/java/aster/core/identifier/LiteralMacroTest.java
@@ -1,6 +1,8 @@
 package aster.core.identifier;
 
 import aster.core.canonicalizer.Canonicalizer;
+import aster.core.lexicon.DynamicLexicon;
+import aster.core.lexicon.Lexicon;
 import aster.core.lexicon.LexiconRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -116,5 +118,56 @@ class LiteralMacroTest {
             List.of(IdentifierMapping.struct("静夜思", "月")),  // 非法：canonical 非 ASCII
             List.of(), List.of(), List.of(), List.of(), null);
         assertFalse(vocab.validate().valid(), "普通标识符 canonical 非 ASCII 仍应被拒");
+    }
+
+    /** 最小 Hindi lexicon（danda 句末符 + ASCII 引号 + 关键词），仅供本测试。 */
+    private static Lexicon hindiLexicon() {
+        String json = """
+            {
+              "meta": { "id": "hi-IN", "name": "हिन्दी", "direction": "LTR" },
+              "keywords": {
+                "MODULE_DECL": "मॉड्यूल", "FUNC_TO": "नियम",
+                "FUNC_PRODUCE": "उत्पन्न", "RETURN": "लौटाएं"
+              },
+              "punctuation": {
+                "statementEnd": "।", "listSeparator": ",", "enumSeparator": ",",
+                "blockStart": ":", "stringQuoteOpen": "\\"", "stringQuoteClose": "\\""
+              },
+              "canonicalization": {
+                "fullWidthToHalf": false, "whitespaceMode": "ENGLISH", "removeArticles": false
+              },
+              "messages": {}
+            }
+            """;
+        return DynamicLexicon.fromJsonString(json);
+    }
+
+    /**
+     * 回归：canonicalizer 的 isIdentifierPart 原用 Character.isLetterOrDigit，对天城文元音
+     * 符号（matra，如 जागे 里的 ◌ा/◌े，属 NON_SPACING_MARK/COMBINING_SPACING_MARK）返回
+     * false，把 जागे 切成 ज+ग 丢失元音 → 天城文字面量宏触发词永不匹配。修为纳入 Mark 后
+     * जागे 作为整词匹配并展开。与 TS 的 {@code [\p{L}_][\p{L}\p{M}\p{Nd}_]*} 对齐。
+     * 动机：Gitanjali #35 印地语 demo。注意 lexer 早已修（见 DevanagariLexerTest），
+     * canonicalizer 的 translateIdentifiers 是独立路径，本次才补齐。
+     */
+    @Test
+    void hindiLiteralMacroWithMatraExpands() {
+        DomainVocabulary vocab = DomainVocabulary.builder("gitanjali", "Gitanjali", "hi-IN")
+            .addLiteral("Into that heaven of freedom, let my country awake", "जागे")
+            .build();
+        assertTrue(vocab.validate().valid(), "合法字面量宏应通过校验: " + vocab.validate().errors());
+
+        IdentifierIndex index = IdentifierIndex.build(vocab);
+        assertTrue(index.isLiteral("जागे"), "जागे（含元音符号 matra）应作为整词标记为字面量宏");
+        assertEquals("Into that heaven of freedom, let my country awake",
+            index.canonicalize("जागे"), "canonicalize 返回内容");
+
+        // Hindi stringQuotes 是 ASCII "，无「」→" 转换。जागे 应整词展开成 ASCII 字符串字面量。
+        Canonicalizer canon = new Canonicalizer(hindiLexicon(), index);
+        String out = canon.canonicalize("लौटाएं जागे।");
+        assertTrue(out.contains("\"Into that heaven of freedom, let my country awake\""),
+            "天城文触发词应展开成 ASCII 字符串字面量，实际: " + out);
+        assertFalse(out.contains("जागे"),
+            "原天城文 token 不应残留（含元音符号也须整词匹配）: " + out);
     }
 }


### PR DESCRIPTION
## Bug
canonicalizer 的标识符/字面量宏切分对天城文（Devanagari）元音符号（matra，如 `जागे` 里的 `◌ा`/`◌े`）处理错误：matra 属 Unicode **Mark**（Mn/Mc/Me）而非 Letter，原判定不认 Mark → 把 `जागे` 切成 `ज+ग` 丢失元音 → **天城文标识符/字面量宏触发词永不匹配**。

两条切分路径都有此 bug：
- `isIdentifierPart`（`translateIdentifiers` 路径）用 `Character.isLetterOrDigit`
- `WORD_PATTERN`（`applyCustomRulesKeywordGated` 路径）用 `[\p{L}_][\p{L}\p{N}_]*`

## 修复
- `isIdentifierPart`：追加 `NON_SPACING_MARK` / `COMBINING_SPACING_MARK` / `ENCLOSING_MARK` 三类 Mark。
- `WORD_PATTERN`：`[\p{L}_][\p{L}\p{M}\p{Nd}_]*`。
- `isIdentifierStart` 保持 letter-only（matra 不应单独开头；独立元音 `अ/आ` 是 Letter，OK）。
- 数字用 `\p{Nd}`（十进制，对齐 `Character.isDigit`；不含 Nl/No）与 TS 引擎 `identifierTokenRegex` = `/[\p{L}_][\p{L}\p{M}\p{Nd}_]*/gu` 逐字符类对齐（跨引擎 parity）。

## 背景
lexer 早已正确处理天城文 matra（ADR 0017 Phase 1，见 `DevanagariLexerTest`）；canonicalizer 的 `translateIdentifiers`/`customRules` 是**独立代码路径**，本次才补齐——消除"两路径口径不一致"的 latent bug。

## 验证
- `LiteralMacroTest` +1（`लौटाएं जागे` → `"Into that heaven of freedom, let my country awake"` ASCII 字面量，天城文 token 不残留）→ **9/0/0**
- `CanonicalizerTest` 20 + `VocabularyIntegrationTests` 15 全绿（无回归）
- Codex 交叉审 82→86→**96「通过」**（抓出 `\p{N}` parity 过宽 + Java `WORD_PATTERN` 第二路径遗漏，均已修）

动机：泰戈尔 Gitanjali #35 印地语 demo 用字面量宏输出英文名句。

🤖 Generated with [Claude Code](https://claude.com/claude-code)