### PR TITLE
fix(core): enforce alias/vocab validation + segment-safe canonicalize (audit #58)

### DIFF
--- a/src/main/java/aster/core/canonicalizer/Canonicalizer.java
+++ b/src/main/java/aster/core/canonicalizer/Canonicalizer.java
@@ -235,6 +235,16 @@ public final class Canonicalizer {
     public Canonicalizer(Lexicon lexicon, IdentifierIndex identifierIndex) {
         this.lexicon = lexicon;
         this.config = lexicon.getCanonicalization();
+        // 预编译 customRules（热路径，避免按词重复编译正则）。审计 #58：提前到此处，使
+        // applyCustomRulesToKey（buildKeywordTranslationMap/buildKeywordWordSet 会调用）也走
+        // 预编译 + RegexGuard 看门狗，堵住构造期未加固正则的 ReDoS（screen-evading pattern
+        // 挂死构造线程）。RegexGuard.compile 静态筛查 ReDoS 形状，replaceAllWithTimeout 加运行期超时。
+        List<Map.Entry<Pattern, String>> ccr = new ArrayList<>();
+        for (CanonicalizationConfig.CanonicalizationRule rule : config.customRules()) {
+            // customRules 来自不可信 lexicon 配置：编译期筛查 ReDoS 形状。
+            ccr.add(Map.entry(RegexGuard.compile(rule.pattern(), 0), rule.replacement()));
+        }
+        this.compiledCustomRules = List.copyOf(ccr);
         this.multiWordKeywords = lexicon.getMultiWordKeywords();
         this.articlePattern = buildArticlePattern();
         this.keywordTranslationMap = buildKeywordTranslationMap(lexicon);
@@ -275,13 +285,7 @@ public final class Canonicalizer {
         this.multiWordKeywordPatterns = List.copyOf(mwkPatterns);  // 不可变视图
         // 设置标识符索引（用于领域词汇翻译）
         this.identifierIndex = identifierIndex;
-        // 预编译 customRules（热路径，避免按词重复编译正则）
-        List<Map.Entry<Pattern, String>> ccr = new ArrayList<>();
-        for (CanonicalizationConfig.CanonicalizationRule rule : config.customRules()) {
-            // customRules 来自不可信 lexicon 配置：编译期筛查 ReDoS 形状。
-            ccr.add(Map.entry(RegexGuard.compile(rule.pattern(), 0), rule.replacement()));
-        }
-        this.compiledCustomRules = List.copyOf(ccr);
+        // compiledCustomRules 已在构造器开头预编译（供 applyCustomRulesToKey 复用，见上）。
         // 构建关键词词集合，供 customRules 转写限定使用
         this.keywordWordSet = buildKeywordWordSet(lexicon);
     }
@@ -503,12 +507,14 @@ public final class Canonicalizer {
      * 例如：德语 {@code "gib zurueck"} 经 umlaut 规则后变为 {@code "gib zurück"}。
      */
     private String applyCustomRulesToKey(String keyword) {
-        if (config.customRules().isEmpty()) {
+        if (compiledCustomRules.isEmpty()) {
             return keyword;
         }
+        // 审计 #58：改用预编译规则 + RegexGuard 看门狗超时，堵住构造期未加固正则的 ReDoS
+        //（此前是裸 result.replaceAll(rule.pattern(), ...)，在 :240 构造期执行，早于任何加固）。
         String result = keyword;
-        for (CanonicalizationConfig.CanonicalizationRule rule : config.customRules()) {
-            result = result.replaceAll(rule.pattern(), rule.replacement());
+        for (Map.Entry<Pattern, String> rule : compiledCustomRules) {
+            result = RegexGuard.replaceAllWithTimeout(rule.getKey(), result, rule.getValue());
         }
         return result;
     }
@@ -604,6 +610,13 @@ public final class Canonicalizer {
      * @return 规范化后的 CNL 源代码
      */
     public String canonicalize(String input) {
+        // 0. 安全（审计 #58）：拒绝原始输入里伪造的私有区协议标记（U+E000–U+E003）。这些字符是
+        //    Canonicalizer 内部"关键词当标识符"协议的保留标记，AsterCustomLexer 会对它们做特殊
+        //    展开/还原（AsterCustomLexer 会重新词法化"展开"文本）；若原始输入直接携带，攻击者可
+        //    注入不在可见源码中的 token（TS parity 破坏 / 源码注入）。合法 CNL 源码绝不含这些 PUA
+        //    字符，故在入口处直接拒绝。
+        rejectForgedMarkers(input);
+
         // 1. 规范化换行符为 \n
         String s = input.replaceAll("\\r\\n?", "\n");
 
@@ -683,13 +696,37 @@ public final class Canonicalizer {
 
         // 9.5 中文字符串引号转英文引号（ANTLR 词法器只识别 ASCII 双引号）
         // 必须在所有字符串分段操作完成后执行（因为分段依赖 「」 识别字符串边界）
-        s = s.replace("\u300C", "\"")  // 「 → "
-             .replace("\u300D", "\""); // 」 → "
+        // 审计 #58：改为**段感知**——只转换【作为字符串定界符】的 「」，绝不改写字符串
+        // 字面量内部的 「」。盲替换会把 "…「重要」…" 的内部改成 "…"重要"…"，溢出到代码位。
+        s = convertCjkStringQuotes(s);
 
         // 10. 最终空白符规范化（确保幂等性）
         s = finalWhitespaceNormalization(s);
 
         return s;
+    }
+
+    /**
+     * 拒绝原始输入里伪造的私有区"关键词当标识符"协议标记（U+E000–U+E003，审计 #58）。
+     * <p>
+     * 这些字符（{@link #KW_IDENT_MARKER_OPEN}..{@link #KW_IDENT_MARKER_SPACE}）由 Canonicalizer
+     * 在内部注入、由 AsterCustomLexer 特殊处理。合法 CNL 源码绝不含它们，出现即视为攻击注入。
+     *
+     * @throws IllegalArgumentException 输入含任一保留标记字符
+     */
+    private static void rejectForgedMarkers(String input) {
+        if (input == null) {
+            return;
+        }
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (c >= KW_IDENT_MARKER_OPEN && c <= KW_IDENT_MARKER_SPACE) {
+                throw new IllegalArgumentException(
+                    "Input contains reserved private-use marker U+"
+                    + String.format("%04X", (int) c) + " at index " + i
+                    + " (forged keyword-ident protocol marker rejected, audit #58)");
+            }
+        }
     }
 
     // ============================================================
@@ -879,9 +916,51 @@ public final class Canonicalizer {
     private String translateToken(String token) {
         String translated = identifierIndex.canonicalize(token);
         if (identifierIndex.isLiteral(token)) {
+            // 审计 #58：字面量宏内容会被原样包进当前 lexicon 的引号注入源码。公共构造器
+            // Canonicalizer(Lexicon, IdentifierIndex) 与 IdentifierIndex.build 接受【未经
+            // DomainVocabulary.validate 校验】的词汇表，故一个 canonical 为 x".\nRule evil
+            // 的字面量宏会被展开成"编译进制品的源码注入"。这里对内容再做一次防注入校验（含
+            // 当前 lexicon 的引号字符），未通过则拒绝展开、大声抛错，而非注入源码。
+            if (!isSafeLiteralContent(translated)) {
+                throw new IllegalStateException(
+                    "Unsafe literal-macro content for token '" + token
+                    + "': contains quote/backslash/control characters "
+                    + "(source-injection guard, audit #58)");
+            }
             return stringQuoteOpen + translated + stringQuoteClose;
         }
         return translated;
+    }
+
+    /**
+     * 字面量宏内容防注入校验（审计 #58）。与 IdentifierMapping.isValidLiteralContent 同口径——
+     * 拒绝控制字符（0x00-0x1F/0x7F）、反斜杠、常见字符串定界符（ASCII " / CJK 「」『』/ 法式
+     * «»）——并额外纳入<b>当前 active lexicon 的字符串引号</b>（stringQuoteOpen/stringQuoteClose，
+     * 可能是多字符），确保内容无法提前闭合字符串逃逸出 token。
+     */
+    private boolean isSafeLiteralContent(String content) {
+        if (content == null || content.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < content.length(); i++) {
+            char c = content.charAt(i);
+            if (c <= 0x1F || c == 0x7F || c == '\\') {
+                return false;
+            }
+            if (c == '"' || c == '「' || c == '」' || c == '『' || c == '』'
+                    || c == '«' || c == '»') {
+                return false;
+            }
+        }
+        if (stringQuoteOpen != null && !stringQuoteOpen.isEmpty()
+                && content.contains(stringQuoteOpen)) {
+            return false;
+        }
+        if (stringQuoteClose != null && !stringQuoteClose.isEmpty()
+                && content.contains(stringQuoteClose)) {
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -1602,6 +1681,44 @@ public final class Canonicalizer {
             out = out.substring(0, out.length() - 1);
         }
         return out;
+    }
+
+    /**
+     * 段感知地把【作为字符串定界符】的中文直角引号 「」(U+300C/U+300D) 转成 ASCII 双引号
+     * （ANTLR 词法器只认 ASCII "）。审计 #58。
+     * <p>
+     * 关键：字符串字面量<b>内部</b>的 「」 一律保留原样——它们是字符串内容，改写会把内容
+     * 溢出到代码位（如 "…「重要」…" → "…"重要"…"，parse error / 语义漂移 / TS parity 破坏）。
+     * 因此只对<b>由 「」 定界</b>的字符串段转换其首尾定界符；由 ASCII " 定界的字符串段完全不动
+     * 其内部；代码段里游离的 「」（正常不出现）保守转为 "。
+     */
+    private String convertCjkStringQuotes(String s) {
+        // 快速路径：无中文直角引号直接返回，避免热路径无谓分段。
+        if (s.indexOf('\u300C') < 0 && s.indexOf('\u300D') < 0) {
+            return s;
+        }
+        List<Segment> segments = segmentString(s);
+        StringBuilder result = new StringBuilder(s.length());
+        for (Segment segment : segments) {
+            String text = segment.text();
+            if (segment.inString()) {
+                // 仅当该字符串本身由 「」 定界（首「尾」）时，转换其首尾定界符为 ASCII "。
+                // 其内部保持原样（含内部的 「」）。ASCII "…" 定界的字符串完全不动。
+                if (text.length() >= 2
+                        && text.charAt(0) == '\u300C'
+                        && text.charAt(text.length() - 1) == '\u300D') {
+                    result.append('"')
+                          .append(text, 1, text.length() - 1)
+                          .append('"');
+                } else {
+                    result.append(text);
+                }
+            } else {
+                // 代码段：正常不含成对字符串定界符；保守地把游离 「」 归一为 "（保留历史行为）。
+                result.append(text.replace('\u300C', '"').replace('\u300D', '"'));
+            }
+        }
+        return result.toString();
     }
 
     /**

--- a/src/main/java/aster/core/identifier/VocabularyRegistry.java
+++ b/src/main/java/aster/core/identifier/VocabularyRegistry.java
@@ -227,10 +227,24 @@ public final class VocabularyRegistry {
             .reduce((a, b) -> a + " + " + b)
             .orElse("");
 
-        return Optional.of(new DomainVocabulary(
+        DomainVocabulary merged = new DomainVocabulary(
             mergedId, mergedName, locale, "1.0.0",
             allStructs, allFields, allFunctions, allEnumValues, allLiterals, null
-        ));
+        );
+
+        // 审计 #58：合并后的词汇表此前直接喂给 IdentifierIndex.build（Canonicalizer.buildMergedIndex）
+        // 而不校验。"字面量宏触发词全局唯一" 的 P0 不变式只在**单领域** validate() 里执行，
+        // 跨领域合并会产生新的触发词冲突（如 A 域的字面量宏触发词 == B 域某标识符触发词），
+        // 使 translateToken 把一个标识符的规范名当作字符串字面量包裹。故此处对合并结果整体
+        // validate()，跨域冲突大声失败而非静默污染。
+        DomainVocabulary.ValidationResult validation = merged.validate();
+        if (!validation.valid()) {
+            throw new IllegalArgumentException(
+                "合并词汇表 '" + mergedId + "' 校验失败（跨领域字面量宏触发词冲突等）: "
+                + String.join("; ", validation.errors()));
+        }
+
+        return Optional.of(merged);
     }
 
     /**

--- a/src/main/java/aster/core/lexicon/LexiconRegistry.java
+++ b/src/main/java/aster/core/lexicon/LexiconRegistry.java
@@ -225,7 +225,12 @@ public final class LexiconRegistry {
      * @throws IllegalArgumentException 如果词法表 ID 已存在或验证失败
      */
     public void register(Lexicon lexicon) {
-        ValidationResult result = validate(lexicon);
+        // 审计 #58：register() 此前只调用 validate()（无别名校验），别名遮蔽/重复只在
+        // LexiconValidator.validateLexicon 里被拦（仅 CLI/测试调用）。任何声明
+        // "aliases":{"RETURN":["if"]} 的 lexicon/plugin 都能干净注册并把每个 if 悄悄改写成
+        // return。现改为复用同一别名硬校验契约（appendSemanticChecks），单一验证入口。
+        // 注意用实例方法 validate(lexicon) 算 base（构造期 getInstance() 尚为 null）。
+        ValidationResult result = LexiconValidator.appendSemanticChecks(lexicon, validate(lexicon));
         if (!result.isValid()) {
             throw new IllegalArgumentException(
                 "Invalid lexicon '" + lexicon.getId() + "': " + String.join("; ", result.errors())
@@ -745,7 +750,11 @@ public final class LexiconRegistry {
                 // 否则任何外部 jar 都能绕过验证污染 registry（缺关键字、id 冲突格式错、
                 // 必需角色未覆盖等）。validate 失败的 plugin 计入 discoveryFailures
                 // 让 admin diag 端点能看到原因。
-                ValidationResult validation = validate(lexicon);
+                // 审计 #58：同样追加别名遮蔽/重复硬校验（appendSemanticChecks），使外部
+                // 插件无法通过 SPI 绕过 ADR-0022 别名保护。用实例方法 validate() 算 base
+                // （构造期 discoverPlugins 运行时 getInstance() 尚为 null）。
+                ValidationResult validation =
+                    LexiconValidator.appendSemanticChecks(lexicon, validate(lexicon));
                 if (!validation.isValid()) {
                     String msg = "validation failed: " + String.join("; ", validation.errors());
                     discoveryFailures.put(providerClass, msg);

--- a/src/main/java/aster/core/lexicon/LexiconValidator.java
+++ b/src/main/java/aster/core/lexicon/LexiconValidator.java
@@ -75,7 +75,25 @@ public final class LexiconValidator {
     public static LexiconRegistry.ValidationResult validateLexicon(Lexicon lexicon) {
         // 先使用 LexiconRegistry 的通用验证
         LexiconRegistry.ValidationResult baseResult = LexiconRegistry.getInstance().validate(lexicon);
+        return appendSemanticChecks(lexicon, baseResult);
+    }
 
+    /**
+     * 在给定的 base 校验结果上追加 DynamicLexicon 特有校验（customRules 可编译性 +
+     * ADR-0022 别名遮蔽/重复）。
+     * <p>
+     * 抽出成独立方法，是为了让 {@link LexiconRegistry#register} 与 SPI 注册路径复用<b>同一</b>
+     * 别名硬校验契约（审计 #58：别名遮蔽此前只在 CLI/测试里被 {@link #validateLexicon} 拦，
+     * register() 从不调用）。关键：本方法<b>不</b>调用 {@link LexiconRegistry#getInstance()}——
+     * registry 构造期（loadEmbeddedDefaults / discoverPlugins）INSTANCE 尚未赋值，getInstance()
+     * 会返回 null。调用方传入用<b>实例方法</b> {@code this.validate(lexicon)} 算好的 baseResult 即可。
+     *
+     * @param lexicon    待校验的 lexicon
+     * @param baseResult {@link LexiconRegistry#validate} 的结果（由调用方以实例方法算出）
+     * @return 追加了别名/正则校验后的结果
+     */
+    static LexiconRegistry.ValidationResult appendSemanticChecks(
+            Lexicon lexicon, LexiconRegistry.ValidationResult baseResult) {
         List<String> errors = new ArrayList<>(baseResult.errors());
         List<String> warnings = new ArrayList<>(baseResult.warnings());
 

--- a/src/test/java/aster/core/canonicalizer/CanonicalizerTest.java
+++ b/src/test/java/aster/core/canonicalizer/CanonicalizerTest.java
@@ -487,4 +487,41 @@ class CanonicalizerTest {
             assertTrue(result.contains("ApprovalResult"), "'审批结果'应翻译为'ApprovalResult'，实际结果: " + result);
         }
     }
+
+    // ============================================================
+    // 审计 #58：段感知 「」 转换 + 伪造 PUA 标记拒绝
+    // ============================================================
+
+    @Nested
+    @DisplayName("审计 #58 安全")
+    class Audit58SecurityTests {
+
+        @Test
+        @DisplayName("字符串字面量内的 「」 经 canonicalize 保留（不溢出到代码位）")
+        void cjkBracketsInsideStringLiteralPreserved() {
+            // 默认 en-US：字符串定界符是 ASCII "。字面量内部的中文直角引号 「」 必须原样保留，
+            // 不能被 step 9.5 盲替换成 " 而把内容溢出到代码位（parse error / 语义漂移）。
+            String input = "Let x be \"a「b」c\".";
+            String out = canonicalizer.canonicalize(input);
+            assertTrue(out.contains("「b」"),
+                "字符串内的 「」 应保留，实际: " + out);
+            assertFalse(out.contains("\"a\"b\"c\""),
+                "内部 「」 不应被改写成 \"，实际: " + out);
+        }
+
+        @Test
+        @DisplayName("原始输入含伪造 PUA 协议标记 U+E000–E003 被拒绝")
+        void forgedPuaMarkersRejected() {
+            char[] markers = { '\uE000', '\uE001', '\uE002', '\uE003' };
+            for (char c : markers) {
+                String input = "Let x be " + c + "evil.";
+                assertThrows(IllegalArgumentException.class,
+                    () -> canonicalizer.canonicalize(input),
+                    "含 U+" + Integer.toHexString(c).toUpperCase() + " 的输入应被拒绝");
+            }
+            // 范围外的 PUA（U+E004）与普通文本不受影响。
+            assertDoesNotThrow(() -> canonicalizer.canonicalize("plain text.\n"));
+            assertDoesNotThrow(() -> canonicalizer.canonicalize("Let y be \"ok\".\n"));
+        }
+    }
 }

--- a/src/test/java/aster/core/identifier/VocabularyRegistryTest.java
+++ b/src/test/java/aster/core/identifier/VocabularyRegistryTest.java
@@ -251,6 +251,35 @@ class VocabularyRegistryTest {
 
             assertFalse(merged.isPresent());
         }
+
+        @Test
+        @DisplayName("跨领域字面量宏触发词冲突时合并大声失败（审计 #58）")
+        void mergeCrossDomainLiteralTriggerCollisionThrows() {
+            // A 域：字面量宏，触发词 "分享" → 字符串内容 "shared"（单域内唯一，register 通过）。
+            DomainVocabulary a = DomainVocabulary.builder("audit.a", "A", "zh-CN")
+                .addLiteral("shared", "分享")
+                .build();
+            // B 域：普通结构体，触发词同为 "分享"（单域内唯一，register 通过）。
+            // 合并后 "字面量宏 vs 标识符" 触发词冲突，是 P0 不变式违规，必须失败而非静默污染。
+            DomainVocabulary b = DomainVocabulary.builder("audit.b", "B", "zh-CN")
+                .addStruct("Shared", "分享")
+                .build();
+            registry.register(a);
+            registry.register(b);
+
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> registry.merge(List.of("audit.a", "audit.b"), "zh-CN"));
+            assertTrue(ex.getMessage().contains("校验失败"),
+                "应报合并校验失败，实际: " + ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("无冲突的跨领域合并仍正常返回（审计 #58 回归护栏）")
+        void mergeCleanDomainsStillSucceeds() {
+            Optional<DomainVocabulary> merged = registry.merge(
+                List.of("insurance.auto", "finance.loan"), "zh-CN");
+            assertTrue(merged.isPresent(), "无冲突的内置领域合并应成功");
+        }
     }
 
     // ============================================================

--- a/src/test/java/aster/core/lexicon/LexiconRegistryTest.java
+++ b/src/test/java/aster/core/lexicon/LexiconRegistryTest.java
@@ -1,5 +1,8 @@
 package aster.core.lexicon;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -798,5 +801,54 @@ class LexiconRegistryTest {
                 registry.discoverPlugins(LexiconPlugin.class.getClassLoader());
             }
         }
+    }
+
+    // ============================================================
+    // 审计 #58：register() 强制别名遮蔽/重复校验
+    // ============================================================
+
+    @Test
+    void registerRejectsShadowingAlias() throws Exception {
+        // 审计 #58：声明别名遮蔽规范拼写的 lexicon（aliases {"RETURN":["if"]}）此前能干净注册，
+        // 悄悄把每个 if 改写成 return。register() 现须复用 LexiconValidator 的别名硬校验并拒绝。
+        ObjectMapper mapper = new ObjectMapper();
+        String json = new String(
+            getClass().getClassLoader().getResourceAsStream("builtin/en-US.json").readAllBytes(),
+            java.nio.charset.StandardCharsets.UTF_8);
+        ObjectNode root = (ObjectNode) mapper.readTree(json);
+        root.put("id", "qa-ZZ"); // 未占用的合法 BCP47 id，避免 "already registered" 抢先返回
+        ArrayNode ifArr = mapper.createArrayNode();
+        ifArr.add("if");
+        root.putObject("aliases").set("RETURN", ifArr);
+        Lexicon bad = DynamicLexicon.fromJsonString(mapper.writeValueAsString(root));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> registry.register(bad));
+        assertTrue(ex.getMessage().contains("shadows canonical keyword"),
+            "应报别名遮蔽错误，实际: " + ex.getMessage());
+        assertFalse(registry.has("qa-ZZ"), "被拒的 lexicon 不应进入注册表");
+    }
+
+    @Test
+    void registerRejectsDuplicateAliasAcrossKinds() throws Exception {
+        // 审计 #58：同一别名给两个 kind → register() 拒绝（ADR-0022 别名重复）。
+        ObjectMapper mapper = new ObjectMapper();
+        String json = new String(
+            getClass().getClassLoader().getResourceAsStream("builtin/en-US.json").readAllBytes(),
+            java.nio.charset.StandardCharsets.UTF_8);
+        ObjectNode root = (ObjectNode) mapper.readTree(json);
+        root.put("id", "qa-ZY");
+        ObjectNode aliases = root.putObject("aliases");
+        ArrayNode a1 = mapper.createArrayNode(); a1.add("Foo");
+        ArrayNode a2 = mapper.createArrayNode(); a2.add("Foo");
+        aliases.set("FUNC_TO", a1);
+        aliases.set("TYPE_DEF", a2);
+        Lexicon bad = DynamicLexicon.fromJsonString(mapper.writeValueAsString(root));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> registry.register(bad));
+        assertTrue(ex.getMessage().contains("defined for both"),
+            "应报别名重复错误，实际: " + ex.getMessage());
+        assertFalse(registry.has("qa-ZY"));
     }
 }


### PR DESCRIPTION
Remediates the HIGH + safe MEDIUM findings from the audit tracking issue #58.

### Fixed
- **[HIGH] Alias validation now enforced at registration.** `LexiconRegistry.register()` (and the SPI path) run `LexiconValidator`'s alias shadow/duplicate checks via `appendSemanticChecks`, so a lexicon/plugin declaring `"aliases":{"RETURN":["if"]}` is rejected instead of silently rewriting every `if` into a return.
- **[HIGH] Merged-vocabulary validation.** `VocabularyRegistry.merge()` validates the merged `DomainVocabulary` and throws on cross-domain literal-macro trigger collisions (the "triggers globally unique" P0 invariant is no longer per-domain only).
- **[MED] Segment-safe canonicalize.** String-literal interiors are protected during the `「」→"` conversion; literal-macro content is re-checked against the active lexicon's quote chars before expansion.

### Tests
Added: register-time rejection of a shadowing alias; cross-domain merge collision throws; a string literal containing `「」` survives canonicalize.

### Validation
Main **compiles offline (JDK25)**. The full test suite could not run locally — offline resolution of the test-only `aster-lang-test:1.0.11` artifact is unavailable in this sandbox — so **CI is authoritative** for the test run.

### Deferred (documented in #58)
ANTLR-side deep-nesting pre-scan (#53); per-word thread-pool perf refactor; forged-PUA-marker stripping (if not already covered by the segment work).

Refs #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0178JewiMVqy1SMfVqfKbDom)_