### PR TITLE
perf(ci): 加 concurrency 取消过时 CI 运行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# 同一 ref 上新 push 到来时取消尚在跑的过时 CI（PR 连续 push 常见）——省算力/排队。
+# 该仓 CI 无发布/部署副作用（release 是独立 workflow），故可直接 cancel 过时 run。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
加 concurrency 取消过时 CI 运行，省算力/排队（PR 连续 push 时）。本仓 CI 无发布/部署副作用（release 独立 workflow，publishToMavenLocal 是 runner 本地状态），故可直接 cancel。Aster 生态 CI 时长优化的通用模式推广（Codex 审确认无副作用）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)