### PR TITLE
chore(deps): bump platform pin →1.0.14 (ADR 0029)

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.13")
+            from("cloud.aster-lang:aster-lang-platform:1.0.14")
         }
     }
 }


### PR DESCRIPTION
配合 ADR 0029 发版 train。platform catalog 1.0.13→1.0.14 (asterLang 1.0.12, lexicon 新增 THEN)。release-train drift gate 要求各仓 main pin==plan.platformVersion=1.0.14。

🤖 Generated with [Claude Code](https://claude.com/claude-code)