### PR TITLE
fix(typecheck): 补齐 ErrorCode 双引擎码表 drift + parity 守门

### DIFF
--- a/src/main/java/aster/core/typecheck/ErrorCode.java
+++ b/src/main/java/aster/core/typecheck/ErrorCode.java
@@ -53,6 +53,9 @@ public enum ErrorCode {
   UNDEFINED_VARIABLE("E101", Category.SCOPE, Severity.ERROR, "Undefined variable: %s", "在使用变量前先声明并初始化。"),
   MULTIPLE_ENTRY_RULES("E102", Category.SCOPE, Severity.ERROR, "Multiple @entry rules in module: {rules}", "每个模块最多保留一个 @entry Rule。"),
   IMPORT_SYMBOL_CONFLICT("E103", Category.SCOPE, Severity.WARNING, "Import symbol conflict: {symbol}", "调整 import alias 或本地顶层声明名称，避免导入符号冲突。"),
+  // 与 TS 端 ErrorCode.DUPLICATE_SYMBOL 对齐（原 TS 端占 E102，反向重建 error_codes.json
+  // 时按用户裁决迁至 E104，让 E102 归 MULTIPLE_ENTRY_RULES）。
+  DUPLICATE_SYMBOL("E104", Category.SCOPE, Severity.ERROR, "Symbol '{name}' is already defined in this scope.", "选择不同的名称或检查是否存在意外的重复声明。"),
   EFF_MISSING_IO("E200", Category.EFFECT, Severity.ERROR, "Function '%s' may perform I/O but is missing @io effect.", "为具有 IO 行为的函数声明 @io 效果。"),
   EFF_MISSING_CPU("E201", Category.EFFECT, Severity.ERROR, "Function '%s' may perform CPU-bound work but is missing @cpu (or @io) effect.", "为 CPU 密集型函数声明 @cpu 或 @io 效果。"),
   EFF_SUPERFLUOUS_IO_CPU_ONLY("E202", Category.EFFECT, Severity.INFO, "Function '%s' declares @io but only CPU-like work found; @io subsumes @cpu and may be unnecessary.", "若函数仅执行 CPU 工作，可移除多余的 @io 声明。"),
@@ -63,6 +66,10 @@ public enum ErrorCode {
   EFF_INFER_REDUNDANT_IO("E207", Category.EFFECT, Severity.WARNING, "函数 '%s' 声明了 @io，但推断未发现 IO 副作用。", "确认是否需要保留 @io 声明。"),
   EFF_INFER_REDUNDANT_CPU("E208", Category.EFFECT, Severity.WARNING, "函数 '%s' 声明了 @cpu，但推断未发现 CPU 副作用。", "若无 CPU 副作用，可删除 @cpu 声明。"),
   EFF_INFER_REDUNDANT_CPU_WITH_IO("E209", Category.EFFECT, Severity.WARNING, "函数 '%s' 同时声明 @cpu 和 @io；由于需要 @io，@cpu 可移除。", "保留 @io 即可满足需求，移除多余的 @cpu。"),
+  // 与 TS 端 ErrorCode.EFFECT_VAR_UNDECLARED / EFFECT_VAR_UNRESOLVED 对齐（TS 端已有，
+  // 补齐 Java 侧码表使双引擎 error_codes.json 契约一致；Java 引擎实现效果变量检查时可 emit）。
+  EFFECT_VAR_UNDECLARED("E210", Category.TYPE, Severity.ERROR, "Effect variable {var} undeclared", "在函数签名的效果参数列表中添加效果类型参数。"),
+  EFFECT_VAR_UNRESOLVED("E211", Category.TYPE, Severity.ERROR, "Effect variable {vars} could not be resolved to concrete effects", "提供明确效果（pure/cpu/io/workflow）或移除未使用的效果变量。"),
   CAPABILITY_NOT_ALLOWED("E300", Category.CAPABILITY, Severity.ERROR, "Function '%s' requires %s capability but manifest for module '%s' denies it.", "更新能力清单或修改函数实现以符合限制。"),
   EFF_CAP_MISSING("E301", Category.CAPABILITY, Severity.ERROR, "Function '%s' uses %s capability but header declares [%s].", "在函数头部声明实际使用到的能力。"),
   EFF_CAP_SUPERFLUOUS("E302", Category.CAPABILITY, Severity.INFO, "Function '%s' declares %s capability but it is not used.", "移除未使用的能力声明以保持清晰。"),

--- a/src/test/java/aster/core/typecheck/ErrorCodeParityTest.java
+++ b/src/test/java/aster/core/typecheck/ErrorCodeParityTest.java
@@ -1,0 +1,146 @@
+package aster.core.typecheck;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 错误码单源一致性测试（防 drift 复发，Java 侧）。
+ *
+ * <p>{@code shared/error_codes.json}（byte-identical 副本置于 test resources
+ * {@code diagnostics/error_codes.json}）是错误码码表数据的唯一真源。本测试锁定
+ * Java 枚举 {@link ErrorCode} 与该 json 的「结构字段」一致——name 集合、code、
+ * category、severity。
+ *
+ * <p>为何不逐字节比对 message/help：Java 侧历史生成物的 message 模板用
+ * {@code %s} 位置占位符（{@code String.format} 路径），而 json 用 {@code {name}}
+ * 命名占位符（{@link DiagnosticBuilder#error} 的 Map 命名参数路径），两种表示无法逐字节
+ * 相等。ts 侧 error-codes-parity 测试对同一份 json 做「含 message/help」的强校验，
+ * 两份 json 的 byte-identical 由 ts 侧断言保证——传递性上确保 ts ↔ Java 码表一致。
+ */
+class ErrorCodeParityTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private JsonNode loadTable() throws Exception {
+        try (InputStream in =
+                     getClass().getClassLoader().getResourceAsStream("diagnostics/error_codes.json")) {
+            assertNotNull(in, "diagnostics/error_codes.json 应在 test classpath 中");
+            return MAPPER.readTree(in);
+        }
+    }
+
+    /** json category（小写）→ Java Category 枚举名。 */
+    private static ErrorCode.Category toCategory(String jsonCategory) {
+        return ErrorCode.Category.valueOf(jsonCategory.toUpperCase());
+    }
+
+    /** json severity（小写）→ Java Severity 枚举名。 */
+    private static ErrorCode.Severity toSeverity(String jsonSeverity) {
+        return ErrorCode.Severity.valueOf(jsonSeverity.toUpperCase());
+    }
+
+    @Test
+    void enumNameSetMatchesJson() throws Exception {
+        JsonNode table = loadTable();
+
+        Set<String> jsonNames = new TreeSet<>();
+        for (Iterator<String> it = table.fieldNames(); it.hasNext(); ) {
+            jsonNames.add(it.next());
+        }
+
+        Set<String> enumNames = new TreeSet<>();
+        for (ErrorCode ec : ErrorCode.values()) {
+            enumNames.add(ec.name());
+        }
+
+        assertEquals(jsonNames, enumNames,
+                "ErrorCode 枚举名集合必须与 shared/error_codes.json 完全一致（防码表 drift）");
+    }
+
+    @Test
+    void codeCategorySeverityMatchJson() throws Exception {
+        JsonNode table = loadTable();
+
+        Map<String, ErrorCode> byName = new HashMap<>();
+        for (ErrorCode ec : ErrorCode.values()) {
+            byName.put(ec.name(), ec);
+        }
+
+        List<String> mismatches = new ArrayList<>();
+        for (Iterator<Map.Entry<String, JsonNode>> it = table.fields(); it.hasNext(); ) {
+            Map.Entry<String, JsonNode> e = it.next();
+            String name = e.getKey();
+            JsonNode spec = e.getValue();
+            ErrorCode ec = byName.get(name);
+            if (ec == null) {
+                mismatches.add(name + ": Java 枚举缺失");
+                continue;
+            }
+            String jsonCode = spec.get("code").asText();
+            if (!jsonCode.equals(ec.code())) {
+                mismatches.add(name + ".code: json=" + jsonCode + " java=" + ec.code());
+            }
+            if (toCategory(spec.get("category").asText()) != ec.category()) {
+                mismatches.add(name + ".category: json=" + spec.get("category").asText()
+                        + " java=" + ec.category());
+            }
+            if (toSeverity(spec.get("severity").asText()) != ec.severity()) {
+                mismatches.add(name + ".severity: json=" + spec.get("severity").asText()
+                        + " java=" + ec.severity());
+            }
+        }
+
+        assertTrue(mismatches.isEmpty(),
+                "code/category/severity 与 json 不一致:\n" + String.join("\n", mismatches));
+    }
+
+    @Test
+    void codesAreUnique() throws Exception {
+        JsonNode table = loadTable();
+        Set<String> seen = new TreeSet<>();
+        List<String> dup = new ArrayList<>();
+        for (ErrorCode ec : ErrorCode.values()) {
+            if (!seen.add(ec.code())) {
+                dup.add(ec.code() + " (" + ec.name() + ")");
+            }
+        }
+        assertTrue(dup.isEmpty(), "枚举 code 应唯一，重复: " + String.join(", ", dup));
+        // json 侧 code 唯一性
+        Set<String> jsonSeen = new TreeSet<>();
+        List<String> jsonDup = new ArrayList<>();
+        for (Iterator<Map.Entry<String, JsonNode>> it = table.fields(); it.hasNext(); ) {
+            String code = it.next().getValue().get("code").asText();
+            if (!jsonSeen.add(code)) {
+                jsonDup.add(code);
+            }
+        }
+        assertTrue(jsonDup.isEmpty(), "json code 应唯一，重复: " + String.join(", ", jsonDup));
+    }
+
+    @Test
+    void userRulingIsApplied() throws Exception {
+        JsonNode table = loadTable();
+        assertEquals("E102", table.get("MULTIPLE_ENTRY_RULES").get("code").asText());
+        assertEquals("E103", table.get("IMPORT_SYMBOL_CONFLICT").get("code").asText());
+        assertEquals("E104", table.get("DUPLICATE_SYMBOL").get("code").asText());
+        assertEquals("E210", table.get("EFFECT_VAR_UNDECLARED").get("code").asText());
+        assertEquals("E211", table.get("EFFECT_VAR_UNRESOLVED").get("code").asText());
+        // Java 枚举侧同样落地
+        assertEquals("E102", ErrorCode.MULTIPLE_ENTRY_RULES.code());
+        assertEquals("E104", ErrorCode.DUPLICATE_SYMBOL.code());
+    }
+}

--- a/src/test/resources/diagnostics/error_codes.json
+++ b/src/test/resources/diagnostics/error_codes.json
@@ -1,0 +1,492 @@
+{
+  "TYPE_MISMATCH": {
+    "code": "E001",
+    "category": "type",
+    "severity": "error",
+    "message": "Type mismatch: expected {expected}, got {actual}",
+    "help": "Check that the type annotation matches the inferred expression type."
+  },
+  "TYPE_MISMATCH_ASSIGN": {
+    "code": "E002",
+    "category": "type",
+    "severity": "error",
+    "message": "Type mismatch assigning to '{name}': {expected} vs {actual}",
+    "help": "Ensure the variable's previous binding type matches the current assignment."
+  },
+  "RETURN_TYPE_MISMATCH": {
+    "code": "E003",
+    "category": "type",
+    "severity": "error",
+    "message": "Return type mismatch: expected {expected}, got {actual}",
+    "help": "Check that the return statement matches the declared return type."
+  },
+  "TYPE_VAR_UNDECLARED": {
+    "code": "E004",
+    "category": "type",
+    "severity": "error",
+    "message": "Type variable '{name}' is used in '{func}' but not declared in its type parameters.",
+    "help": "Declare used type variables in the function signature's 'of' clause."
+  },
+  "TYPE_PARAM_UNUSED": {
+    "code": "E005",
+    "category": "type",
+    "severity": "warning",
+    "message": "Type parameter '{name}' on '{func}' is declared but not used.",
+    "help": "Remove unused type parameters to avoid confusion."
+  },
+  "TYPEVAR_LIKE_UNDECLARED": {
+    "code": "E006",
+    "category": "type",
+    "severity": "error",
+    "message": "Type variable-like '{name}' is used in '{func}' but not declared; declare it with 'of {name}'.",
+    "help": "For names that look like type variables, declare them in the 'of' clause."
+  },
+  "TYPEVAR_INCONSISTENT": {
+    "code": "E007",
+    "category": "type",
+    "severity": "error",
+    "message": "Type variable '{name}' inferred inconsistently: {previous} vs {actual}",
+    "help": "Ensure all usage sites of a type variable produce the same concrete type."
+  },
+  "IF_BRANCH_MISMATCH": {
+    "code": "E008",
+    "category": "type",
+    "severity": "error",
+    "message": "If branch type mismatch: then {thenType} vs else {elseType}",
+    "help": "Ensure both branches of an if expression return the same type."
+  },
+  "MATCH_BRANCH_MISMATCH": {
+    "code": "E009",
+    "category": "type",
+    "severity": "error",
+    "message": "Match case return types differ: {expected} vs {actual}",
+    "help": "Check that all match branches return the same type."
+  },
+  "INTEGER_PATTERN_TYPE": {
+    "code": "E010",
+    "category": "type",
+    "severity": "error",
+    "message": "Integer pattern used on non-Int scrutinee ({scrutineeType})",
+    "help": "Only use integer patterns on Int-typed match expressions."
+  },
+  "UNKNOWN_FIELD": {
+    "code": "E011",
+    "category": "type",
+    "severity": "error",
+    "message": "Unknown field '{field}' for {type}",
+    "help": "Check that the field name is correct for the data type."
+  },
+  "FIELD_TYPE_MISMATCH": {
+    "code": "E012",
+    "category": "type",
+    "severity": "error",
+    "message": "Field '{field}' expects {expected}, got {actual}",
+    "help": "Verify the field initializer expression matches the declared type."
+  },
+  "MISSING_REQUIRED_FIELD": {
+    "code": "E013",
+    "category": "type",
+    "severity": "error",
+    "message": "Construction of {type} missing required field '{field}'",
+    "help": "Provide all required fields declared in the data type."
+  },
+  "NOT_CALL_ARITY": {
+    "code": "E014",
+    "category": "type",
+    "severity": "error",
+    "message": "not(...) expects 1 argument",
+    "help": "Adjust the not() call to have exactly 1 argument."
+  },
+  "AWAIT_TYPE": {
+    "code": "E015",
+    "category": "type",
+    "severity": "warning",
+    "message": "await expects Maybe<T> or Result<T,E>, got {type}",
+    "help": "Only use await on Maybe or Result types."
+  },
+  "DUPLICATE_ENUM_CASE": {
+    "code": "E016",
+    "category": "type",
+    "severity": "warning",
+    "message": "Duplicate enum case '{case}' in match on {type}.",
+    "help": "Remove duplicate enum branches to keep the match concise."
+  },
+  "NON_EXHAUSTIVE_MAYBE": {
+    "code": "E017",
+    "category": "type",
+    "severity": "warning",
+    "message": "Non-exhaustive match on Maybe type; missing {missing} case.",
+    "help": "Add both null and non-null branches for Maybe matches."
+  },
+  "NON_EXHAUSTIVE_ENUM": {
+    "code": "E018",
+    "category": "type",
+    "severity": "warning",
+    "message": "Non-exhaustive match on {type}; missing: {missing}",
+    "help": "Add all uncovered enum branches, or add a wildcard."
+  },
+  "AMBIGUOUS_INTEROP_NUMERIC": {
+    "code": "E019",
+    "category": "type",
+    "severity": "warning",
+    "message": "Ambiguous interop call '{target}': mixing numeric kinds (Int={hasInt}, Long={hasLong}, Double={hasDouble}). Overload resolution may widen/box implicitly.",
+    "help": "Unify numeric argument types in interop calls to avoid implicit boxing and widening."
+  },
+  "LIST_ELEMENT_TYPE_MISMATCH": {
+    "code": "E020",
+    "category": "type",
+    "severity": "error",
+    "message": "List literal element type mismatch: expected {expected}, got {actual}",
+    "help": "Ensure all elements in a list literal have the same type."
+  },
+  "OPTIONAL_EXPECTED": {
+    "code": "E021",
+    "category": "type",
+    "severity": "error",
+    "message": "Optional value required here: expected Maybe or Option, but got {actual}",
+    "help": "Pass a Maybe/Option type or explicitly wrap the value."
+  },
+  "WORKFLOW_COMPENSATE_TYPE": {
+    "code": "E022",
+    "category": "type",
+    "severity": "error",
+    "message": "Compensate block for step '{step}' must return Result<Unit, {expectedErr}>, got {actual}",
+    "help": "Ensure the compensate block returns Result<Unit, E> where E is the step error type."
+  },
+  "WORKFLOW_COMPENSATE_MISSING": {
+    "code": "E023",
+    "category": "effect",
+    "severity": "warning",
+    "message": "Step '{step}' performs side effects but does not define a compensate block.",
+    "help": "Provide a compensate block for steps with IO side effects to enable rollback."
+  },
+  "WORKFLOW_RETRY_INVALID": {
+    "code": "E024",
+    "category": "type",
+    "severity": "error",
+    "message": "Workflow retry max attempts must be greater than zero (actual: {maxAttempts}).",
+    "help": "Set retry.maxAttempts to a positive integer."
+  },
+  "WORKFLOW_TIMEOUT_INVALID": {
+    "code": "E025",
+    "category": "type",
+    "severity": "error",
+    "message": "Workflow timeout must be greater than zero milliseconds (actual: {milliseconds}).",
+    "help": "Set the timeout to a positive value to ensure compensate logic can be triggered."
+  },
+  "WORKFLOW_MISSING_IO_EFFECT": {
+    "code": "E026",
+    "category": "effect",
+    "severity": "error",
+    "message": "Workflow '{func}' must declare @io effect before using a 'workflow' block.",
+    "help": "Add @io effect declaration to the function header."
+  },
+  "WORKFLOW_UNDECLARED_CAPABILITY": {
+    "code": "E027",
+    "category": "capability",
+    "severity": "error",
+    "message": "Workflow '{func}' step '{step}' uses capability {capability} that is not declared on the function header.",
+    "help": "Declare {capability} in the function header or adjust the step code."
+  },
+  "COMPENSATE_NEW_CAPABILITY": {
+    "code": "E028",
+    "category": "capability",
+    "severity": "error",
+    "message": "Compensate block for step '{step}' in function '{func}' introduces new capability {capability} that does not appear in the main step body.",
+    "help": "Compensate blocks can only reuse capabilities from the main step body."
+  },
+  "WORKFLOW_UNKNOWN_STEP_DEPENDENCY": {
+    "code": "E029",
+    "category": "scope",
+    "severity": "error",
+    "message": "Workflow step '{step}' depends on undefined step '{dependency}'.",
+    "help": "Only reference declared step names in the current workflow."
+  },
+  "WORKFLOW_CIRCULAR_DEPENDENCY": {
+    "code": "E030",
+    "category": "type",
+    "severity": "error",
+    "message": "Workflow contains circular step dependency: {cycle}",
+    "help": "Remove or restructure circular dependencies to enable topological execution."
+  },
+  "DECIMAL_DOUBLE_MIXING": {
+    "code": "E031",
+    "category": "type",
+    "severity": "error",
+    "message": "Cannot combine Decimal and Double in '{operator}'. Double is binary floating-point and would inject rounding error into an exact Decimal. Use Decimal literals (e.g. 1.08m) on both sides, or Int/Long (exact promotion).",
+    "help": "Make both operands Decimal (suffix m), or use Int/Long which promote exactly to Decimal."
+  },
+  "PII_ASSIGN_DOWNGRADE": {
+    "code": "E070",
+    "category": "pii",
+    "severity": "error",
+    "message": "Cannot assign PII data to lower-level target: {source} -> {target}",
+    "help": "Use a sanitization function or declare a matching @pii level on the target."
+  },
+  "PII_SINK_UNSANITIZED": {
+    "code": "E072",
+    "category": "pii",
+    "severity": "error",
+    "message": "PII level {level} data output to {sinkKind} without sanitization",
+    "help": "Call redact() or tokenize() before output to reduce sensitivity."
+  },
+  "PII_ARG_VIOLATION": {
+    "code": "E073",
+    "category": "pii",
+    "severity": "error",
+    "message": "PII argument type mismatch: expected {expected}, got {actual}",
+    "help": "Check the function signature to ensure PII levels and categories match."
+  },
+  "DUPLICATE_IMPORT_ALIAS": {
+    "code": "E100",
+    "category": "scope",
+    "severity": "warning",
+    "message": "Duplicate import alias '{alias}'.",
+    "help": "Use unique aliases for different imports to avoid shadowing."
+  },
+  "UNDEFINED_VARIABLE": {
+    "code": "E101",
+    "category": "scope",
+    "severity": "error",
+    "message": "Undefined variable: {name}",
+    "help": "Declare and initialize the variable before use."
+  },
+  "MULTIPLE_ENTRY_RULES": {
+    "code": "E102",
+    "category": "scope",
+    "severity": "error",
+    "message": "Multiple @entry rules in module: {rules}",
+    "help": "Keep at most one Rule annotated with @entry in a module."
+  },
+  "IMPORT_SYMBOL_CONFLICT": {
+    "code": "E103",
+    "category": "scope",
+    "severity": "warning",
+    "message": "Import symbol conflict: {symbol}",
+    "help": "Adjust the import alias or the local top-level declaration name to avoid the import symbol conflict."
+  },
+  "DUPLICATE_SYMBOL": {
+    "code": "E104",
+    "category": "scope",
+    "severity": "error",
+    "message": "Symbol '{name}' is already defined in this scope.",
+    "help": "Choose a different name or check for unintended duplicate declarations."
+  },
+  "EFF_MISSING_IO": {
+    "code": "E200",
+    "category": "effect",
+    "severity": "error",
+    "message": "Function '{func}' may perform I/O but is missing @io effect.",
+    "help": "Declare @io effect for functions that perform I/O."
+  },
+  "EFF_MISSING_CPU": {
+    "code": "E201",
+    "category": "effect",
+    "severity": "error",
+    "message": "Function '{func}' may perform CPU-bound work but is missing @cpu (or @io) effect.",
+    "help": "Declare @cpu or @io effect for CPU-intensive functions."
+  },
+  "EFF_SUPERFLUOUS_IO_CPU_ONLY": {
+    "code": "E202",
+    "category": "effect",
+    "severity": "info",
+    "message": "Function '{func}' declares @io but only CPU-like work found; @io subsumes @cpu and may be unnecessary.",
+    "help": "If the function only does CPU work, consider removing the redundant @io declaration."
+  },
+  "EFF_SUPERFLUOUS_IO": {
+    "code": "E203",
+    "category": "effect",
+    "severity": "warning",
+    "message": "Function '{func}' declares @io but no obvious I/O found.",
+    "help": "Confirm @io is needed; remove if no I/O behavior exists."
+  },
+  "EFF_SUPERFLUOUS_CPU": {
+    "code": "E204",
+    "category": "effect",
+    "severity": "warning",
+    "message": "Function '{func}' declares @cpu but no obvious CPU-bound work found.",
+    "help": "Remove the redundant @cpu declaration or add corresponding CPU work."
+  },
+  "EFF_INFER_MISSING_IO": {
+    "code": "E205",
+    "category": "effect",
+    "severity": "error",
+    "message": "Function '{func}' missing @io effect declaration, inference requires IO.",
+    "help": "Add @io effect based on inference results."
+  },
+  "EFF_INFER_MISSING_CPU": {
+    "code": "E206",
+    "category": "effect",
+    "severity": "error",
+    "message": "Function '{func}' missing @cpu effect declaration, inference requires CPU (or @io).",
+    "help": "Add @cpu or @io effect based on inference results."
+  },
+  "EFF_INFER_REDUNDANT_IO": {
+    "code": "E207",
+    "category": "effect",
+    "severity": "warning",
+    "message": "Function '{func}' declares @io but no IO side effects inferred.",
+    "help": "Confirm whether to keep the @io declaration."
+  },
+  "EFF_INFER_REDUNDANT_CPU": {
+    "code": "E208",
+    "category": "effect",
+    "severity": "warning",
+    "message": "Function '{func}' declares @cpu but no CPU side effects inferred.",
+    "help": "Remove the @cpu declaration if no CPU side effects exist."
+  },
+  "EFF_INFER_REDUNDANT_CPU_WITH_IO": {
+    "code": "E209",
+    "category": "effect",
+    "severity": "warning",
+    "message": "Function '{func}' declares both @cpu and @io; @cpu is redundant since @io is required.",
+    "help": "Keep @io only; remove the redundant @cpu."
+  },
+  "EFFECT_VAR_UNDECLARED": {
+    "code": "E210",
+    "category": "type",
+    "severity": "error",
+    "message": "Effect variable {var} undeclared",
+    "help": "Add the effect type parameter to the function signature's effect parameter list."
+  },
+  "EFFECT_VAR_UNRESOLVED": {
+    "code": "E211",
+    "category": "type",
+    "severity": "error",
+    "message": "Effect variable {vars} could not be resolved to concrete effects",
+    "help": "Provide explicit effects (pure/cpu/io/workflow) or remove unused effect variables."
+  },
+  "CAPABILITY_NOT_ALLOWED": {
+    "code": "E300",
+    "category": "capability",
+    "severity": "error",
+    "message": "Function '{func}' requires {cap} capability but manifest for module '{module}' denies it.",
+    "help": "Update the capability manifest or modify the function to comply."
+  },
+  "EFF_CAP_MISSING": {
+    "code": "E301",
+    "category": "capability",
+    "severity": "error",
+    "message": "Function '{func}' uses {cap} capability but header declares [{declared}].",
+    "help": "Declare the actually used capabilities in the function header."
+  },
+  "EFF_CAP_SUPERFLUOUS": {
+    "code": "E302",
+    "category": "capability",
+    "severity": "info",
+    "message": "Function '{func}' declares {cap} capability but it is not used.",
+    "help": "Remove unused capability declarations for clarity."
+  },
+  "CAPABILITY_INFER_MISSING_IO": {
+    "code": "E303",
+    "category": "capability",
+    "severity": "error",
+    "message": "Function '{func}' uses IO capabilities [{capabilities}] but is missing @io effect (e.g., {calls}).",
+    "help": "Declare @io effect in the function header, or remove related calls to stay pure."
+  },
+  "CAPABILITY_INFER_MISSING_CPU": {
+    "code": "E304",
+    "category": "capability",
+    "severity": "error",
+    "message": "Function '{func}' performs CPU capability calls (e.g., {calls}) but declares neither @cpu nor @io effect.",
+    "help": "Add @cpu or @io effect to cover CPU capabilities."
+  },
+  "PII_HTTP_UNENCRYPTED": {
+    "code": "E400",
+    "category": "pii",
+    "severity": "error",
+    "message": "PII data transmitted over HTTP without encryption",
+    "help": "Use an encrypted channel (HTTPS) or sanitize before transmitting PII data."
+  },
+  "PII_ANNOTATION_MISSING": {
+    "code": "E401",
+    "category": "pii",
+    "severity": "error",
+    "message": "PII annotation missing for value flowing into '{sink}'",
+    "help": "Add @pii annotation to sensitive data for tracking."
+  },
+  "PII_SENSITIVITY_MISMATCH": {
+    "code": "E402",
+    "category": "pii",
+    "severity": "warning",
+    "message": "PII sensitivity mismatch: required {required}, got {actual}",
+    "help": "Adjust the data sensitivity level or update the process requirements."
+  },
+  "PII_MISSING_CONSENT_CHECK": {
+    "code": "E403",
+    "category": "pii",
+    "severity": "warning",
+    "message": "Function '{func}' processes PII data without consent check (GDPR Art. 6)",
+    "help": "Call checkConsent() or add @consent_required annotation before processing PII data."
+  },
+  "PII_ANALYZER_FAILED": {
+    "code": "E404",
+    "category": "pii",
+    "severity": "error",
+    "message": "PII safety analysis failed for this module — the editor cannot verify whether sensitive data is correctly handled. This policy should not be deployed until the analysis succeeds. Internal reason: {reason}",
+    "help": "Try saving and reloading the file. If the error persists, contact your administrator or report this issue with the source code attached."
+  },
+  "ASYNC_START_NOT_WAITED": {
+    "code": "E500",
+    "category": "async",
+    "severity": "error",
+    "message": "Started async task '{task}' not waited",
+    "help": "Call wait on started async tasks to ensure completion."
+  },
+  "ASYNC_WAIT_NOT_STARTED": {
+    "code": "E501",
+    "category": "async",
+    "severity": "error",
+    "message": "Waiting for async task '{task}' that was never started",
+    "help": "Ensure the task name in wait matches a started task."
+  },
+  "ASYNC_DUPLICATE_START": {
+    "code": "E502",
+    "category": "async",
+    "severity": "error",
+    "message": "Async task '{task}' started multiple times ({count} occurrences)",
+    "help": "Avoid starting the same task multiple times; reuse or rename."
+  },
+  "ASYNC_DUPLICATE_WAIT": {
+    "code": "E503",
+    "category": "async",
+    "severity": "warning",
+    "message": "Async task '{task}' waited multiple times ({count} occurrences)",
+    "help": "Ensure each task is waited on only once, or use a separate synchronization mechanism."
+  },
+  "ASYNC_WAIT_BEFORE_START": {
+    "code": "E504",
+    "category": "async",
+    "severity": "error",
+    "message": "Wait for async task '{task}' occurs before any matching start",
+    "help": "Execute start before wait, and ensure both are on compatible control paths."
+  },
+  "PII_IMPLICIT_UPLEVEL": {
+    "code": "W071",
+    "category": "pii",
+    "severity": "warning",
+    "message": "Implicit PII level escalation detected: {source} -> {target}",
+    "help": "Add explicit type annotations for level changes to aid auditing."
+  },
+  "PII_SINK_UNKNOWN": {
+    "code": "W074",
+    "category": "pii",
+    "severity": "warning",
+    "message": "PII data may flow to {sinkKind} without annotation",
+    "help": "Add @pii annotation to track sensitive data flow."
+  },
+  "WORKFLOW_RETRY_INCONSISTENT": {
+    "code": "W105",
+    "category": "type",
+    "severity": "warning",
+    "message": "Workflow retry configuration may be unreasonable: {reason}",
+    "help": "Check the combination of total wait time, maxAttempts, and backoff strategy."
+  },
+  "WORKFLOW_TIMEOUT_UNREASONABLE": {
+    "code": "W106",
+    "category": "type",
+    "severity": "warning",
+    "message": "Workflow timeout configuration may be unreasonable: {reason}",
+    "help": "Check whether the timeout value is too large or too small."
+  }
+}


### PR DESCRIPTION
配合 **aster-lang-ts#66** 反向重建 `shared/error_codes.json` 单源，对齐 Java 侧码表。

## 本仓改动

- 补 `DUPLICATE_SYMBOL`(E104)：ts 端原占 E102，按用户裁决迁 E104，让 E102 归 MULTIPLE_ENTRY_RULES
- 补 `EFFECT_VAR_UNDECLARED`(E210)/`EFFECT_VAR_UNRESOLVED`(E211)：ts 端已有，补齐 Java 使双引擎码表契约一致（用 `{name}` 命名占位符，因 Java emit 走 `DiagnosticBuilder.error(code, span, Map)` 命名参数路径）
- 新增 `ErrorCodeParityTest`：断言 ErrorCode 枚举与 `shared/error_codes.json`（byte-identical 副本置于 `src/test/resources/diagnostics/`）的 name/code/category/severity 结构一致

**接受风险**：Java message 模板 %s（老码 String.format 路径）与 {name}（新码 DiagnosticBuilder Map 命名参数路径）混用是历史现状，非本次引入，作为独立后续技术债（parity 不逐字节比 message，由 ts 侧强校验 + 两 json byte-identical 传递保证）。

## ⚠️ 跨三仓，须一起合 + clean build

- **aster-lang-ts#66**（单源 + ts 生成物 + generator + parity）
- aster-lang-locales（zh diagnostic-help overlay E102 语义）

## 验证

- Java core 1336 测 0 fail（含 ErrorCodeParityTest 4 测）
- Codex 三轮对抗审 91「通过」

🤖 Generated with [Claude Code](https://claude.com/claude-code)