### PR TITLE
fix(capability): 补 Java CapabilityKind 双引擎 drift + parity 守门

### DIFF
--- a/src/main/java/aster/core/capability/CapabilityInference.java
+++ b/src/main/java/aster/core/capability/CapabilityInference.java
@@ -19,12 +19,16 @@ import java.util.Optional;
  */
 public final class CapabilityInference {
 
+  // 前缀推断表与 TS CAPABILITY_PREFIXES / shared/capabilities.json 单源对齐。
   private static final Map<CapabilityKind, List<String>> CAPABILITY_PREFIXES = Map.ofEntries(
     Map.entry(CapabilityKind.HTTP, List.of("Http.")),
+    Map.entry(CapabilityKind.NETWORK, List.of("Net.", "Network.", "Tcp.", "Udp.", "Socket.", "Ws.", "WebSocket.", "Sse.")),
     Map.entry(CapabilityKind.SQL, List.of("Db.", "Sql.")),
     Map.entry(CapabilityKind.TIME, List.of("Time.", "Clock.")),
     Map.entry(CapabilityKind.FILES, List.of("Files.", "Fs.")),
     Map.entry(CapabilityKind.SECRETS, List.of("Secrets.")),
+    Map.entry(CapabilityKind.CRYPTO, List.of("Crypto.", "Hash.", "Cipher.", "Sign.", "Kms.", "Jwt.")),
+    Map.entry(CapabilityKind.PROCESS, List.of("Process.", "Proc.", "Exec.", "Shell.", "Env.", "Os.")),
     Map.entry(CapabilityKind.AI_MODEL, List.of("Ai.")),
     Map.entry(CapabilityKind.PAYMENT, List.of("Payment.")),
     Map.entry(CapabilityKind.INVENTORY, List.of("Inventory."))

--- a/src/main/java/aster/core/capability/CapabilityKind.java
+++ b/src/main/java/aster/core/capability/CapabilityKind.java
@@ -10,10 +10,15 @@ import java.util.Optional;
  */
 public enum CapabilityKind {
   HTTP("Http"),
+  // 与 TS 端 capability taxonomy 对齐（shared/capabilities.json 单源）：
+  // NETWORK/CRYPTO/PROCESS 为 TS 后加（commit 063ff6d），Java 补齐消除双引擎枚举 drift。
+  NETWORK("Network"),
   SQL("Sql"),
   TIME("Time"),
   FILES("Files"),
   SECRETS("Secrets"),
+  CRYPTO("Crypto"),
+  PROCESS("Process"),
   AI_MODEL("AiModel"),
   CPU("Cpu"),
   PAYMENT("Payment"),

--- a/src/test/java/aster/core/capability/CapabilityParityTest.java
+++ b/src/test/java/aster/core/capability/CapabilityParityTest.java
@@ -1,0 +1,146 @@
+package aster.core.capability;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Capability 能力表单源一致性测试（防双引擎 drift 复发，Java 侧）。
+ *
+ * <p>{@code shared/capabilities.json}（byte-identical 副本置于 test resources
+ * {@code capability/capabilities.json}）是 capability 授权契约的唯一真源。本测试
+ * 锁定 Java 的两处 capability 副本与该 json 一致：
+ * <ul>
+ *   <li>{@link CapabilityKind} enum（enumName + displayName）</li>
+ *   <li>{@link CapabilityInference} 的 CAPABILITY_PREFIXES（通过 inferCapabilityFromName 行为验证）</li>
+ * </ul>
+ *
+ * <p>TS 侧由 capability-parity.test.ts 对同一份 json 守门，两份 json 的 byte-identical
+ * 由 TS 侧断言 → 传递性保证双引擎 capability 授权契约一致。
+ */
+class CapabilityParityTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private List<JsonNode> loadCapabilities() throws Exception {
+        try (InputStream in =
+                     getClass().getClassLoader().getResourceAsStream("capability/capabilities.json")) {
+            assertNotNull(in, "capability/capabilities.json 应在 test classpath 中");
+            JsonNode root = MAPPER.readTree(in);
+            List<JsonNode> out = new ArrayList<>();
+            root.get("capabilities").forEach(out::add);
+            return out;
+        }
+    }
+
+    @Test
+    void enumNameSetMatchesJson() throws Exception {
+        Set<String> jsonNames = new TreeSet<>();
+        for (JsonNode c : loadCapabilities()) {
+            jsonNames.add(c.get("enumName").asText());
+        }
+        Set<String> enumNames = new TreeSet<>();
+        for (CapabilityKind k : CapabilityKind.values()) {
+            enumNames.add(k.name());
+        }
+        assertEquals(jsonNames, enumNames,
+                "CapabilityKind 枚举名集合必须与 shared/capabilities.json 一致（防双引擎 drift）");
+    }
+
+    @Test
+    void displayNameMatchesJson() throws Exception {
+        List<String> mismatches = new ArrayList<>();
+        for (JsonNode c : loadCapabilities()) {
+            String enumName = c.get("enumName").asText();
+            String displayName = c.get("displayName").asText();
+            CapabilityKind kind;
+            try {
+                kind = CapabilityKind.valueOf(enumName);
+            } catch (IllegalArgumentException e) {
+                mismatches.add(enumName + ": Java 枚举缺失");
+                continue;
+            }
+            if (!displayName.equals(kind.displayName())) {
+                mismatches.add(enumName + ".displayName: json=" + displayName
+                        + " java=" + kind.displayName());
+            }
+        }
+        assertTrue(mismatches.isEmpty(),
+                "displayName 与 json 不一致:\n" + String.join("\n", mismatches));
+    }
+
+    @Test
+    void fromLabelResolvesEveryDisplayName() throws Exception {
+        List<String> failures = new ArrayList<>();
+        for (JsonNode c : loadCapabilities()) {
+            String displayName = c.get("displayName").asText();
+            Optional<CapabilityKind> resolved = CapabilityKind.fromLabel(displayName);
+            if (resolved.isEmpty() || !resolved.get().name().equals(c.get("enumName").asText())) {
+                failures.add(displayName + " → " + resolved.map(Enum::name).orElse("empty"));
+            }
+        }
+        assertTrue(failures.isEmpty(),
+                "fromLabel 应能解析每个 displayName: " + String.join(", ", failures));
+    }
+
+    @Test
+    void prefixInferenceMatchesJson() throws Exception {
+        // 每个 json 前缀应被 CapabilityInference 推断回对应的 CapabilityKind。
+        List<String> failures = new ArrayList<>();
+        for (JsonNode c : loadCapabilities()) {
+            String enumName = c.get("enumName").asText();
+            JsonNode prefixes = c.get("prefixes");
+            for (JsonNode p : prefixes) {
+                String prefix = p.asText();
+                // 构造一个以该前缀开头的调用名（前缀已含 '.'，补一个方法名）
+                String sample = prefix + "sample";
+                Optional<CapabilityKind> inferred =
+                        CapabilityInference.inferCapabilityFromName(sample);
+                if (inferred.isEmpty() || !inferred.get().name().equals(enumName)) {
+                    failures.add(prefix + " → " + inferred.map(Enum::name).orElse("empty")
+                            + "（期望 " + enumName + "）");
+                }
+            }
+        }
+        assertTrue(failures.isEmpty(),
+                "前缀推断与 json 不一致:\n" + String.join("\n", failures));
+    }
+
+    @Test
+    void codesAreUnique() throws Exception {
+        Set<String> names = new TreeSet<>();
+        Set<String> displays = new TreeSet<>();
+        List<String> dup = new ArrayList<>();
+        for (JsonNode c : loadCapabilities()) {
+            if (!names.add(c.get("enumName").asText())) {
+                dup.add("enumName " + c.get("enumName").asText());
+            }
+            if (!displays.add(c.get("displayName").asText())) {
+                dup.add("displayName " + c.get("displayName").asText());
+            }
+        }
+        assertTrue(dup.isEmpty(), "json enumName/displayName 应唯一，重复: " + String.join(", ", dup));
+    }
+
+    @Test
+    void newTaxonomyIsApplied() throws Exception {
+        // 钉死本次修复：Java 补齐了 NETWORK/CRYPTO/PROCESS。
+        assertNotNull(CapabilityKind.valueOf("NETWORK"));
+        assertNotNull(CapabilityKind.valueOf("CRYPTO"));
+        assertNotNull(CapabilityKind.valueOf("PROCESS"));
+        assertEquals(CapabilityKind.NETWORK, CapabilityInference.inferCapabilityFromName("Tcp.connect").orElseThrow());
+        assertEquals(CapabilityKind.CRYPTO, CapabilityInference.inferCapabilityFromName("Kms.encrypt").orElseThrow());
+        assertEquals(CapabilityKind.PROCESS, CapabilityInference.inferCapabilityFromName("Shell.exec").orElseThrow());
+    }
+}

--- a/src/test/resources/capability/capabilities.json
+++ b/src/test/resources/capability/capabilities.json
@@ -1,0 +1,65 @@
+{
+  "$comment": "Capability 能力表单源真值 (双引擎共享契约, 类比 error_codes.json)。ts CapabilityKind (src/config/semantic.ts) 与 Java CapabilityKind (aster-lang-core/.../capability/CapabilityKind.java) 均以此为准, 由 parity 测试守门。displayName 为 CNL 表面名, prefixes 为调用前缀推断表 (CapabilityInference / CAPABILITY_PREFIXES)。注: capability 的 effect 分类 (io/cpu) 双引擎当前存在 drift (ts effects.ts CPU_CLASS 含 Crypto, Java CapabilityChecker 纯 cap!=CPU=>io), 待独立组 A3 统一后再纳入本单源, 本文件暂不固化 class 以免'看似单源实际漂移'。",
+  "capabilities": [
+    {
+      "enumName": "HTTP",
+      "displayName": "Http",
+      "prefixes": ["Http."]
+    },
+    {
+      "enumName": "NETWORK",
+      "displayName": "Network",
+      "prefixes": ["Net.", "Network.", "Tcp.", "Udp.", "Socket.", "Ws.", "WebSocket.", "Sse."]
+    },
+    {
+      "enumName": "SQL",
+      "displayName": "Sql",
+      "prefixes": ["Db.", "Sql."]
+    },
+    {
+      "enumName": "TIME",
+      "displayName": "Time",
+      "prefixes": ["Time.", "Clock."]
+    },
+    {
+      "enumName": "FILES",
+      "displayName": "Files",
+      "prefixes": ["Files.", "Fs."]
+    },
+    {
+      "enumName": "SECRETS",
+      "displayName": "Secrets",
+      "prefixes": ["Secrets."]
+    },
+    {
+      "enumName": "CRYPTO",
+      "displayName": "Crypto",
+      "prefixes": ["Crypto.", "Hash.", "Cipher.", "Sign.", "Kms.", "Jwt."]
+    },
+    {
+      "enumName": "PROCESS",
+      "displayName": "Process",
+      "prefixes": ["Process.", "Proc.", "Exec.", "Shell.", "Env.", "Os."]
+    },
+    {
+      "enumName": "AI_MODEL",
+      "displayName": "AiModel",
+      "prefixes": ["Ai."]
+    },
+    {
+      "enumName": "CPU",
+      "displayName": "Cpu",
+      "prefixes": []
+    },
+    {
+      "enumName": "PAYMENT",
+      "displayName": "Payment",
+      "prefixes": ["Payment."]
+    },
+    {
+      "enumName": "INVENTORY",
+      "displayName": "Inventory",
+      "prefixes": ["Inventory."]
+    }
+  ]
+}


### PR DESCRIPTION
配合 **aster-lang-ts#67** 反向重建 `shared/capabilities.json` 单源，对齐 Java 侧 + 修 exportLexicons 漏 hi。

## CapabilityKind 双引擎对齐（安全边界）
- CapabilityKind 补 `NETWORK`/`CRYPTO`/`PROCESS` 三枚举（ts 端后加，Java 落后）
- CapabilityInference CAPABILITY_PREFIXES 补对应前缀，与 ts 对齐
- 新增 `CapabilityParityTest`：断言枚举与 `capabilities.json`（byte-identical 副本置于 `src/test/resources/capability/`）的 name/displayName/prefix 推断一致

## exportLexicons 补 hi-IN
`build.gradle.kts` 的 `testRuntimeOnly` + `langPacks` 两处漏 `asterLibs.hi` → exportLexicons 的 SPI classpath 无 hi 包 → lexicons.json 不含 hi-IN → verify 无从守门。补齐后 exportLexicons 含 hi-IN（77 词）。

## ⚠️ 姊妹 PR
- **aster-lang-ts#67**（capabilities.json 单源 + ts 白名单 + parity + verify hi 注册）
- 须一起合。

## 验证
- Java 全 core 1342 测 0 fail（含 CapabilityParityTest 6 测）
- Codex 交叉审 93「通过」

🤖 Generated with [Claude Code](https://claude.com/claude-code)