### PR TITLE
fix(lexicon): APPLY 双引擎补齐(免发版迁移) + hi-IN verify 接 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,14 @@ jobs:
           path: aster-lang-locales
           token: ${{ secrets.CROSS_REPO_TOKEN }}
 
+      # aster-lang-hi 语言包：core 的 testRuntimeOnly(asterLibs.hi) + langPacks 依赖它，
+      # 缺这步会让 :testRuntimeClasspath 解析 aster-lang-hi:<ver> 失败（干净 runner 无 hi）。
+      - uses: ./.github/actions/checkout-sibling
+        with:
+          repository: aster-cloud/aster-lang-hi
+          path: aster-lang-hi
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
+
       # 共享测试 corpus（cloud.aster-lang:aster-lang-test）。core 的
       # testImplementation(asterLibs.test) 依赖它；GH Packages 未必有当前版本，
       # 故 sibling-checkout 后 publishToMavenLocal（与下方 parity job 同范式）。
@@ -82,6 +90,10 @@ jobs:
           ln -sfn "$PWD" aster-lang-core
           cd aster-lang-locales && ./gradlew publishToMavenLocal -x test
 
+      # Phase 2a: 发布 hi 语言包（core testRuntimeOnly/langPacks 依赖）。
+      - name: Build hi lang pack (from aster-lang-hi)
+        run: cd aster-lang-hi && ./gradlew publishToMavenLocal -x test
+
       # Phase 2b: 发布测试 corpus 到 Maven Local（core test 的 testImplementation 依赖）。
       - name: Publish test corpus to Maven Local
         working-directory: aster-lang-test/packages/jvm
@@ -103,6 +115,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
+    # gradle 拉取跨仓 GitHub Packages（含 aster-lang-hi 语言包）需要跨仓读权限。
+    # 默认 GITHUB_TOKEN 仅当前仓，拉 hi 包会 401；CROSS_REPO_TOKEN 是 org secret，
+    # 已被 checkout-sibling steps 使用，此处同样用于 gradle credentials。
+    env:
+      GITHUB_ACTOR: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ secrets.CROSS_REPO_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       # R-CI-1 fix: paths-filter needs a checkout to diff against. Do
       # the self-checkout first into a sub-path, then point paths-filter
@@ -158,6 +177,16 @@ jobs:
         with:
           repository: aster-cloud/aster-lang-locales
           path: aster-lang-locales
+          token: ${{ secrets.CROSS_REPO_TOKEN || github.token }}
+
+      # aster-lang-hi 语言包（hi-IN SPI）：verify:lexicon-sync 需要它进 exportLexicons
+      # 的 langPacks classpath，才能校验 hi-IN 词法与 TS 同步（此前无守门）。
+      - name: Checkout aster-lang-hi
+        if: steps.changed.outputs.parity == 'true' || github.event_name == 'push'
+        uses: ./aster-lang-core/.github/actions/checkout-sibling
+        with:
+          repository: aster-cloud/aster-lang-hi
+          path: aster-lang-hi
           token: ${{ secrets.CROSS_REPO_TOKEN || github.token }}
 
       # aster-lang-runtime + aster-lang-truffle are only needed by the
@@ -227,6 +256,24 @@ jobs:
         if: steps.changed.outputs.parity == 'true' || github.event_name == 'push'
         working-directory: aster-lang-locales
         run: ./gradlew publishToMavenLocal -x test
+
+      - name: Publish aster-lang-hi to Maven Local
+        if: steps.changed.outputs.parity == 'true' || github.event_name == 'push'
+        working-directory: aster-lang-hi
+        run: ./gradlew publishToMavenLocal -x test
+
+      # 词法同步守门（此前零 CI 调用）：从源码联编的 core + 四语包 exportLexicons，
+      # 再由 TS verify-lexicon-sync 校验 Java↔TS 词法表（含 hi-IN）完全同步。
+      # 依赖上面已 publishToMavenLocal 的 platform/core/locales/hi（源码新版）。
+      - name: Verify lexicon sync (Java exportLexicons ↔ TS)
+        if: steps.changed.outputs.parity == 'true' || github.event_name == 'push'
+        shell: bash
+        run: |
+          set -o pipefail
+          cd aster-lang-core && ./gradlew exportLexicons -x test
+          cd ../aster-lang-ts
+          node dist/scripts/verify-lexicon-sync.js \
+            ../aster-lang-core/build/generated/lexicons/lexicons.json
 
       - name: Publish aster-lang-runtime to Maven Local
         if: steps.changed.outputs.parity == 'true' || github.event_name == 'push'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,8 @@ dependencies {
     testRuntimeOnly(asterLibs.en)
     testRuntimeOnly(asterLibs.zh)
     testRuntimeOnly(asterLibs.de)
+    // hi-IN 语言包：补齐后 exportLexicons 才导出 hi-IN，verify-lexicon-sync 才能守门。
+    testRuntimeOnly(asterLibs.hi)
 
     // 共享测试 corpus：双引擎等价 + 单端 fixture
     testImplementation(asterLibs.test)
@@ -244,6 +246,7 @@ dependencies {
     langPacks(asterLibs.en)
     langPacks(asterLibs.zh)
     langPacks(asterLibs.de)
+    langPacks(asterLibs.hi)
 }
 
 // Lexicon JSON 导出任务（供 aster-lang-ts / aster-cloud 代码生成消费）

--- a/src/main/java/aster/core/lexicon/LexiconRegistry.java
+++ b/src/main/java/aster/core/lexicon/LexiconRegistry.java
@@ -40,7 +40,7 @@ public final class LexiconRegistry {
      * 全部 lexicon 加载失败（chicken-egg 发布顺序死锁）。迁移完成后可移除。
      */
     private static final Set<SemanticTokenKind> OPTIONAL_KINDS =
-        EnumSet.of(SemanticTokenKind.IMPORT_VERSION, SemanticTokenKind.THEN);
+        EnumSet.of(SemanticTokenKind.IMPORT_VERSION, SemanticTokenKind.THEN, SemanticTokenKind.APPLY);
 
     private static final LexiconRegistry INSTANCE = new LexiconRegistry();
 

--- a/src/main/java/aster/core/lexicon/SemanticTokenKind.java
+++ b/src/main/java/aster/core/lexicon/SemanticTokenKind.java
@@ -92,6 +92,11 @@ public enum SemanticTokenKind {
     /** 返回语句 - "return" / "返回" */
     RETURN,
 
+    /** 无括号单参调用引入词（ADR 0027）- "apply" / "应用"。软关键词：仅 `apply &lt;名&gt; to &lt;expr&gt;`
+     *  形态触发，其余位置仍是普通标识符。与 TS SemanticTokenKind.APPLY 对齐。
+     *  迁移期在 LexiconRegistry.OPTIONAL_KINDS 中，各语言包补齐 apply 翻译后可移除。 */
+    APPLY,
+
     /** 结果是（同义词） - "the result is" / "结果为" */
     RESULT_IS,
 
@@ -322,7 +327,7 @@ public enum SemanticTokenKind {
     public static final Map<String, List<SemanticTokenKind>> CATEGORIES = Map.ofEntries(
         Map.entry("module", Arrays.asList(MODULE_DECL, IMPORT, IMPORT_ALIAS, IMPORT_VERSION)),
         Map.entry("type", Arrays.asList(TYPE_DEF, TYPE_WITH, TYPE_HAS, TYPE_ONE_OF)),
-        Map.entry("function", Arrays.asList(FUNC_TO, FUNC_GIVEN, FUNC_PRODUCE, FUNC_PERFORMS)),
+        Map.entry("function", Arrays.asList(FUNC_TO, FUNC_GIVEN, FUNC_PRODUCE, FUNC_PERFORMS, APPLY)),
         Map.entry("control", Arrays.asList(IF, OTHERWISE, THEN, MATCH, WHEN, RETURN, RESULT_IS, FOR_EACH, IN)),
         Map.entry("variable", Arrays.asList(LET, BE, SET, TO_WORD)),
         Map.entry("boolean", Arrays.asList(OR, AND, NOT)),

--- a/src/main/resources/builtin/en-US.json
+++ b/src/main/resources/builtin/en-US.json
@@ -24,6 +24,7 @@
     "MATCH": "Match",
     "WHEN": "When",
     "RETURN": "Return",
+    "APPLY": "apply",
     "RESULT_IS": "the result is",
     "FOR_EACH": "for each",
     "IN": "in",


### PR DESCRIPTION
单源漂移审计（`aster-api/.claude/analysis/single-source-drift-audit.md`）lexicon-hi 组。

## 问题
- **hi-IN 无 lexicon parity 守门**：`verify-lexicon-sync` 漏注册 hi-IN + CI 零调用（实证根因：build.gradle 漏 `asterLibs.hi` → exportLexicons 不含 hi + parity-tier1 job 缺 token env → 拉 hi 包 401）
- **APPLY token drift**：ts SemanticTokenKind 有 APPLY（ADR0027 `apply f to x`），Java 枚举漏登记 → verify 全 token 集校验红，挡住接 CI

## 免发版迁移路径（零 tag/publish/不可逆）
给 core 枚举加 APPLY 是 breaking（published SPI 包对旧枚举编译，加载会被 registry 跳过）。用现成的 `OPTIONAL_KINDS` 迁移保险 + 源码联编避开发版：
- `SemanticTokenKind` 补 APPLY（归 `function` category）
- `LexiconRegistry.OPTIONAL_KINDS` 加 APPLY（缺失只告警不跳过包）
- `en-US.json` builtin 加 `"APPLY":"apply"`
- **实证**：platform/core/locales/hi 源码 `publishToMavenLocal` → exportLexicons `available=[de,en,hi,zh]`（不塌成 `[en]`）→ ts verify `Java 79==TS 79 错误0`，四语全覆盖必需 tokenKind

## hi-IN 守门（此前零 parity）
- `build.gradle`: `testRuntimeOnly` + `langPacks` 加 `asterLibs.hi`
- `ci.yml`:
  - parity-tier1 job: 加 env token（`CROSS_REPO_TOKEN` 修 401）+ checkout hi + publish + **"Verify lexicon sync" step**（exportLexicons + verify-lexicon-sync，此前零 CI 调用）
  - build job: 补 checkout + publish hi（`testRuntimeOnly(asterLibs.hi)` 依赖）

## ⚠️ 姊妹 PR（须一起合，同名分支跨仓 CI 联编）
- **aster-lang-locales**（en/zh/de APPLY 翻译）
- **aster-lang-hi**（hi-IN APPLY 翻译 लागू करें）
- **aster-lang-ts**（verify HI_IN 注册 + first-party 完整性守门 + APPLY function category）

## 📋 Follow-up（Codex 复审要求）
1. **所有 first-party 包公开发版后**，从 `OPTIONAL_KINDS` + ts verify 移除 APPLY optional（届时缺 APPLY 才硬 fail）
2. **hi/locales 自身 CI** 加 branch-match sibling checkout + `verify:lexicon-sync`（防单仓改 lexicon 不经 core PR 漂移）

## 验证
- 源码联编：exportLexicons 4 语齐 + verify 全绿（错误0 警告0，四语覆盖 76 必需 tokenKind）
- en byte-parity 保持（core builtin == locales en pack）
- Codex 交叉审 82→91「通过」

🤖 Generated with [Claude Code](https://claude.com/claude-code)