### PR TITLE
fix(effect): 移除 Effect.ASYNC 授权过宽漏洞（async 不再覆盖 IO 授权）

### DIFF
--- a/src/main/java/aster/core/typecheck/TypeChecker.java
+++ b/src/main/java/aster/core/typecheck/TypeChecker.java
@@ -205,7 +205,7 @@ public final class TypeChecker {
 
     // 【修复】在模块作用域（当前作用域）注册函数符号，确保跨函数调用可见
     // 存储函数声明的最高级别效果，用于后续效果推断
-    // 计算所有声明效果中的最大值（PURE < CPU < IO < ASYNC）
+    // 计算所有声明效果中的最大值（PURE < CPU < IO）
     Optional<String> declaredEffect;
     if (func.effects.isEmpty()) {
       declaredEffect = Optional.empty();

--- a/src/main/java/aster/core/typecheck/checkers/EffectChecker.java
+++ b/src/main/java/aster/core/typecheck/checkers/EffectChecker.java
@@ -19,8 +19,10 @@ import java.util.*;
  * <p>
  * 效果层次（偏序关系）：
  * PURE ⊑ CPU ⊑ IO
- * PURE ⊑ ASYNC
- * ASYNC 是顶层效果（所有效果的最小上界）
+ * <p>
+ * 注：async/await 不是授权效果轴（那是调度/并发纪律，由 AsyncDisciplineChecker 管）。
+ * 历史上 ASYNC 曾是顶层效果，导致 `It performs async` 可覆盖 IO 授权（授权过宽漏洞）；
+ * 已移除，await 表达式传播被 await 值的效果，async 声明降级为非授权废弃别名。
  * <p>
  * 核心功能：
  * - 效果推断：根据函数调用前缀和类型注解推断效果
@@ -41,19 +43,20 @@ public final class EffectChecker {
     /** CPU 密集型：计算密集但无 I/O */
     CPU,
     /** I/O 操作：包含外部交互 */
-    IO,
-    /** 异步操作：包含 async/await */
-    ASYNC;
+    IO;
 
     /**
-     * 从字符串解析效果
+     * 从字符串解析效果。
+     * <p>
+     * "async" 是调度/纪律关键字，不是效果授权轴——映射为 PURE（非授权废弃别名），
+     * 让声明 `It performs async` 的旧源码进入正常效果检查：若函数体实际做 IO，会正确
+     * 报 EFF_MISSING_IO（而非被 async 静默授权）。**不得**映射为 IO（否则漏洞换皮）。
      */
     public static Effect fromString(String str) {
       return switch (str.toLowerCase()) {
-        case "async" -> ASYNC;
         case "io" -> IO;
         case "cpu" -> CPU;
-        case "pure", "" -> PURE;
+        // "async"、"pure"、"" 及未知值均为非授权 → PURE
         default -> PURE;
       };
     }
@@ -64,7 +67,6 @@ public final class EffectChecker {
         case PURE -> "pure";
         case CPU -> "cpu";
         case IO -> "io";
-        case ASYNC -> "async";
       };
     }
   }
@@ -108,11 +110,9 @@ public final class EffectChecker {
       case CoreModel.Ok ok -> inferEffect(ok.expr, ctx);
       case CoreModel.Err err -> inferEffect(err.expr, ctx);
       case CoreModel.Some some -> inferEffect(some.expr, ctx);
-      case CoreModel.Await await -> {
-        // await 表达式总是标记为 ASYNC
-        var exprEffect = inferEffect(await.expr, ctx);
-        yield join(Effect.ASYNC, exprEffect);
-      }
+      case CoreModel.Await await ->
+        // await 本身不增加授权效果；IO/CPU 来自被 await 的表达式（对齐 TS，async 不是效果轴）。
+        inferEffect(await.expr, ctx);
       case CoreModel.Construct construct -> {
         var maxEffect = Effect.PURE;
         for (var field : construct.fields) {
@@ -279,29 +279,19 @@ public final class EffectChecker {
   /**
    * 效果 Join（格论中的最小上界）
    * <p>
-   * Join 规则：
+   * Join 规则（线性格 PURE ⊑ CPU ⊑ IO）：
    * - PURE ⊔ PURE = PURE
    * - PURE ⊔ CPU = CPU
    * - PURE ⊔ IO = IO
-   * - PURE ⊔ ASYNC = ASYNC
    * - CPU ⊔ CPU = CPU
    * - CPU ⊔ IO = IO
-   * - CPU ⊔ ASYNC = ASYNC
    * - IO ⊔ IO = IO
-   * - IO ⊔ ASYNC = ASYNC
-   * - ASYNC ⊔ ASYNC = ASYNC
-   * <p>
-   * 效果层次：ASYNC 是最高级别，独立于 IO/CPU 分支
    *
    * @param e1 效果1
    * @param e2 效果2
    * @return 最小上界
    */
   public Effect join(Effect e1, Effect e2) {
-    // ASYNC 是最高级别
-    if (e1 == Effect.ASYNC || e2 == Effect.ASYNC) {
-      return Effect.ASYNC;
-    }
     if (e1 == Effect.IO || e2 == Effect.IO) {
       return Effect.IO;
     }
@@ -314,8 +304,7 @@ public final class EffectChecker {
   /**
    * 效果子类型关系
    * <p>
-   * 偏序关系：PURE ⊑ CPU ⊑ IO，PURE ⊑ ASYNC
-   * ASYNC 是顶层效果，所有效果都是 ASYNC 的子效果
+   * 偏序关系：PURE ⊑ CPU ⊑ IO
    *
    * @param sub 子效果
    * @param sup 超效果
@@ -323,8 +312,7 @@ public final class EffectChecker {
    */
   public boolean isSubEffect(Effect sub, Effect sup) {
     return switch (sup) {
-      case ASYNC -> true; // 所有效果都是 ASYNC 的子效果
-      case IO -> sub != Effect.ASYNC; // PURE、CPU、IO 是 IO 的子效果
+      case IO -> true; // PURE、CPU、IO 都是 IO 的子效果
       case CPU -> sub == Effect.PURE || sub == Effect.CPU; // PURE 和 CPU 是 CPU 的子效果
       case PURE -> sub == Effect.PURE; // 只有 PURE 是 PURE 的子效果
     };

--- a/src/main/java/aster/core/typecheck/model/VisitorContext.java
+++ b/src/main/java/aster/core/typecheck/model/VisitorContext.java
@@ -28,9 +28,7 @@ public final class VisitorContext {
     /** CPU 密集型：计算密集但无 I/O */
     CPU,
     /** I/O 操作：包含外部交互 */
-    IO,
-    /** 异步操作：包含 async/await */
-    ASYNC
+    IO
   }
 
   // ========== 字段 ==========

--- a/src/test/java/aster/core/typecheck/checkers/EffectCheckerTest.java
+++ b/src/test/java/aster/core/typecheck/checkers/EffectCheckerTest.java
@@ -65,7 +65,6 @@ class EffectCheckerTest {
     assertEquals("pure", Effect.PURE.toString());
     assertEquals("cpu", Effect.CPU.toString());
     assertEquals("io", Effect.IO.toString());
-    assertEquals("async", Effect.ASYNC.toString());
   }
 
   // ========== 效果Join测试 ==========
@@ -444,69 +443,45 @@ class EffectCheckerTest {
     return pattern;
   }
 
-  // ========== ASYNC 效果测试 ==========
+  // ========== async 非授权语义测试（A2：移除 Effect.ASYNC 授权过宽漏洞）==========
 
   @Test
-  void testEffectFromStringAsync() {
-    // 测试 ASYNC 字符串解析
-    assertEquals(Effect.ASYNC, Effect.fromString("async"));
-    assertEquals(Effect.ASYNC, Effect.fromString("ASYNC"));
-    assertEquals(Effect.ASYNC, Effect.fromString("Async"));
+  void testEffectFromStringAsyncIsNonAuthorizingAlias() {
+    // "async" 不是效果授权轴 → 映射为 PURE（非授权废弃别名），不得授权 IO/CPU。
+    assertEquals(Effect.PURE, Effect.fromString("async"));
+    assertEquals(Effect.PURE, Effect.fromString("ASYNC"));
+    assertEquals(Effect.PURE, Effect.fromString("Async"));
   }
 
   @Test
-  void testJoinPureWithAsync() {
-    // PURE ⊔ ASYNC = ASYNC
-    assertEquals(Effect.ASYNC, checker.join(Effect.PURE, Effect.ASYNC));
-    assertEquals(Effect.ASYNC, checker.join(Effect.ASYNC, Effect.PURE));
+  void testAsyncDeclarationDoesNotAuthorizeIO() {
+    // 安全回归：函数声明 `It performs async`（declared=PURE）不再授权 IO。
+    // 历史漏洞：ASYNC 是顶层效果，isSubEffect(IO, ASYNC)=true → async 可覆盖 IO。
+    Effect declared = Effect.fromString("async");
+    assertFalse(checker.isSubEffect(Effect.IO, declared),
+        "It performs async 不应授权 IO（否则复现授权过宽漏洞）");
   }
 
   @Test
-  void testJoinCPUWithAsync() {
-    // CPU ⊔ ASYNC = ASYNC
-    assertEquals(Effect.ASYNC, checker.join(Effect.CPU, Effect.ASYNC));
-    assertEquals(Effect.ASYNC, checker.join(Effect.ASYNC, Effect.CPU));
+  void testCheckEffectCompatibilityAsyncActualIOReportsDiagnostic() {
+    // 用户可见边界：声明 async（→PURE）但实际 IO，checkEffectCompatibility 必须报诊断。
+    checker.checkEffectCompatibility(Effect.fromString("async"), Effect.IO, Optional.empty());
+    assertFalse(diagnostics.getDiagnostics().isEmpty(),
+        "declared=async 实际=IO 应报 effect 缺失诊断（授权过宽漏洞修复）");
   }
 
   @Test
-  void testJoinIOWithAsync() {
-    // IO ⊔ ASYNC = ASYNC
-    assertEquals(Effect.ASYNC, checker.join(Effect.IO, Effect.ASYNC));
-    assertEquals(Effect.ASYNC, checker.join(Effect.ASYNC, Effect.IO));
-  }
-
-  @Test
-  void testJoinAsync() {
-    // ASYNC ⊔ ASYNC = ASYNC
-    assertEquals(Effect.ASYNC, checker.join(Effect.ASYNC, Effect.ASYNC));
-  }
-
-  @Test
-  void testIsSubEffectAsync() {
-    // 所有效果都是 ASYNC 的子效果
-    assertTrue(checker.isSubEffect(Effect.PURE, Effect.ASYNC));
-    assertTrue(checker.isSubEffect(Effect.CPU, Effect.ASYNC));
-    assertTrue(checker.isSubEffect(Effect.IO, Effect.ASYNC));
-    assertTrue(checker.isSubEffect(Effect.ASYNC, Effect.ASYNC));
-
-    // ASYNC 不是 IO/CPU/PURE 的子效果
-    assertFalse(checker.isSubEffect(Effect.ASYNC, Effect.IO));
-    assertFalse(checker.isSubEffect(Effect.ASYNC, Effect.CPU));
-    assertFalse(checker.isSubEffect(Effect.ASYNC, Effect.PURE));
-  }
-
-  @Test
-  void testInferEffectAwait() {
-    // await(42) - ASYNC
+  void testInferEffectAwaitPropagatesPure() {
+    // await(42)：await 不增加授权效果，纯表达式仍为 PURE。
     var await = new CoreModel.Await();
     await.expr = createInt(42);
 
-    assertEquals(Effect.ASYNC, checker.inferEffect(await, ctx));
+    assertEquals(Effect.PURE, checker.inferEffect(await, ctx));
   }
 
   @Test
-  void testInferEffectAwaitWithIO() {
-    // await(IO.readFile()) - ASYNC（await 的效果总是 ASYNC）
+  void testInferEffectAwaitPropagatesIO() {
+    // await(IO.readFile())：await 传播被 await 值的效果（IO），要求声明 @io。
     var call = new CoreModel.Call();
     call.target = createName("IO.readFile");
     call.args = List.of();
@@ -514,33 +489,33 @@ class EffectCheckerTest {
     var await = new CoreModel.Await();
     await.expr = call;
 
-    assertEquals(Effect.ASYNC, checker.inferEffect(await, ctx));
+    assertEquals(Effect.IO, checker.inferEffect(await, ctx));
   }
 
   @Test
-  void testCompareEffectsAsync() {
-    // ASYNC 的 ordinal 最大
-    assertTrue(checker.compareEffects(Effect.PURE, Effect.ASYNC) < 0);
-    assertTrue(checker.compareEffects(Effect.CPU, Effect.ASYNC) < 0);
-    assertTrue(checker.compareEffects(Effect.IO, Effect.ASYNC) < 0);
-    assertEquals(0, checker.compareEffects(Effect.ASYNC, Effect.ASYNC));
+  void testJoinLinearLattice() {
+    // 线性格 PURE ⊑ CPU ⊑ IO（无 ASYNC 顶层）。
+    assertEquals(Effect.IO, checker.join(Effect.PURE, Effect.IO));
+    assertEquals(Effect.IO, checker.join(Effect.CPU, Effect.IO));
+    assertEquals(Effect.CPU, checker.join(Effect.PURE, Effect.CPU));
+    assertEquals(Effect.IO, checker.join(Effect.IO, Effect.IO));
   }
 
   @Test
-  void testCheckEffectCompatibilityAsyncValid() {
-    // PURE ⊑ ASYNC - 有效
-    checker.checkEffectCompatibility(Effect.ASYNC, Effect.PURE, Optional.empty());
-    assertTrue(diagnostics.getDiagnostics().isEmpty());
-
-    // IO ⊑ ASYNC - 有效
-    checker.checkEffectCompatibility(Effect.ASYNC, Effect.IO, Optional.empty());
-    assertTrue(diagnostics.getDiagnostics().isEmpty());
+  void testIsSubEffectLinearLattice() {
+    // IO 是顶：PURE/CPU/IO 都是 IO 的子效果。
+    assertTrue(checker.isSubEffect(Effect.PURE, Effect.IO));
+    assertTrue(checker.isSubEffect(Effect.CPU, Effect.IO));
+    assertTrue(checker.isSubEffect(Effect.IO, Effect.IO));
+    // CPU 的子效果只有 PURE/CPU（IO 不是）。
+    assertFalse(checker.isSubEffect(Effect.IO, Effect.CPU));
+    assertTrue(checker.isSubEffect(Effect.CPU, Effect.CPU));
+    // PURE 的子效果只有 PURE。
+    assertFalse(checker.isSubEffect(Effect.CPU, Effect.PURE));
+    assertTrue(checker.isSubEffect(Effect.PURE, Effect.PURE));
   }
 
-  @Test
-  void testCheckEffectCompatibilityAsyncInvalid() {
-    // ASYNC ⋢ IO - 无效
-    checker.checkEffectCompatibility(Effect.IO, Effect.ASYNC, Optional.empty());
-    assertFalse(diagnostics.getDiagnostics().isEmpty());
-  }
+  // 原 testCheckEffectCompatibilityAsyncValid/Invalid 已删除：它们固化了
+  // "declared=ASYNC 接受 actual=IO" 的授权过宽语义（A2 修复的漏洞本身）。
+  // 正确的非授权行为由 testAsyncDeclarationDoesNotAuthorizeIO 覆盖。
 }


### PR DESCRIPTION
单源漂移审计 A2（双引擎 Effect 枚举 drift，安全边界）。

## 🔴 安全漏洞
双引擎 Effect drift：ts `{IO,CPU,PURE}`（async 走 BUILTIN_AWAIT 非 effect）vs Java `{PURE,CPU,IO,ASYNC}` 且 **ASYNC 是顶层效果**。

`isSubEffect` 的 `case ASYNC -> true`（所有效果都是 ASYNC 子效果）→ `isSubEffect(IO, ASYNC)=true` → 函数声明 `It performs async`（declared=ASYNC）时实际执行 IO 被判合规 → **async 绕过 IO 授权**（能力授权安全边界）。

## 修复
async 是调度/纪律轴（由 AsyncDisciplineChecker 管），**不是效果授权轴**（对齐 ts）：
- `EffectChecker`: enum 删 ASYNC → 线性格 `PURE⊑CPU⊑IO`
  - `fromString("async")→PURE`（非授权废弃别名，**不映射 IO** 否则漏洞换皮）
  - `await` 传播被 await 值的效果（`inferEffect(await.expr)`），不再 `join(ASYNC)`
  - `join`/`isSubEffect` 删 ASYNC 分支
- `VisitorContext.Effect` 同删 ASYNC
- 测试：删 8 个固化错误授权的测试 + 加安全回归（`declared=async 实际=IO` 报诊断）

## 实证（零现存破坏）
- 全 core 测试 **1328 通过 0 失败**
- corpus **零程序**用 `performs async` 作 effect 声明 → 移除 ASYNC 零行为影响
- async 语句语法（`Start...as async`/`Wait for`）fixture 全在且过
- Truffle 的 `"Async"` 是独立 runtime 调度权限（非 Java Effect.ASYNC），不授权 IO

## 迁移
- 旧代码 `It performs async:` 只做纯计算 → 可删声明
- 旧代码 `It performs async:` 做 IO → 改 `It performs io:`（本就该如此）

Codex 设计规格 + 交叉审 94「通过」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)