### PR TITLE
feat(p0a): Java 权威侧 canonical JSON serializer + TS↔Java parity gate

### DIFF
--- a/src/main/java/aster/core/canonical/CanonicalJson.java
+++ b/src/main/java/aster/core/canonical/CanonicalJson.java
@@ -1,0 +1,409 @@
+package aster.core.canonical;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Canonical JSON serializer — 权威（Java）侧实现。
+ *
+ * P0-A 规则集升级回归工具（ADR 0030 §3.5 / 附录 A.2）的漂移检测地基。必须与
+ * aster-cloud TS 侧 {@code src/lib/canonical-json.ts} 产出**字节级一致**的 canonical
+ * 字符串 —— 否则 old（Java 权威引擎）↔ new toolchain 的 hash 比对会因表示差异误报
+ * regression 或碰撞漏报。TS↔Java golden fixture（{@code CanonicalJsonParityTest}）
+ * 逐条固化两侧字节一致，是发布前 parity gate。
+ *
+ * <p>铁律（与 TS 逐项对齐）：
+ * <ul>
+ *   <li>object key 按 Unicode code point 升序；array 保序。</li>
+ *   <li>null 显式；missing ≠ null；不丢空对象/空数组/false/0/""。</li>
+ *   <li>string 原值不 trim/case-fold；转义复刻 JS {@code JSON.stringify} 策略。</li>
+ *   <li>非 Decimal number **只允许 safe integer**（|n| ≤ 2^53−1）——跨引擎浮点表示不一致，
+ *       小数/超范围须走 Decimal（string 承载）+ typeCtx。</li>
+ *   <li>Decimal 类型感知规范化（无 exponent/无前导零/无 trailing zero/-0→0/整数无 .0）。</li>
+ * </ul>
+ */
+public final class CanonicalJson {
+
+    /** 当前 canonical 算法版本，写进 hash 前缀。变更算法必 bump（须与 TS CANONICALIZATION_VERSION 一致）。 */
+    public static final String CANONICALIZATION_VERSION = "aster-canonical-json/v1";
+
+    /** JS Number.MAX_SAFE_INTEGER。非 Decimal number 的绝对值上限（含）。 */
+    private static final long MAX_SAFE_INTEGER = 9007199254740991L;
+
+    /** Decimal 展开资源上限（与 TS MAX_DECIMAL_* 一致，防大指数 DoS）。 */
+    private static final int MAX_DECIMAL_DIGITS = 4096;
+    private static final int MAX_DECIMAL_EXPONENT = 4096;
+
+    private CanonicalJson() {}
+
+    /** canonical 化失败原因（对齐 TS CanonicalErrorReason / Execution.replayabilityReasons）。 */
+    public enum ErrorReason {
+        NON_CANONICAL_NUMBER,
+        NON_INTEGER_NUMBER,
+        UNSUPPORTED_VALUE,
+        DECIMAL_TOO_LARGE
+    }
+
+    /** canonical 化异常（携带原因 + JSON 路径，便于诊断 / 映射 NON_REPLAYABLE）。 */
+    public static final class CanonicalJsonException extends RuntimeException {
+        private final ErrorReason reason;
+        private final String path;
+
+        public CanonicalJsonException(ErrorReason reason, String message, String path) {
+            super(reason + " at " + path + ": " + message);
+            this.reason = reason;
+            this.path = path;
+        }
+
+        public ErrorReason reason() {
+            return reason;
+        }
+
+        public String path() {
+            return path;
+        }
+    }
+
+    /**
+     * 类型上下文：声明哪些字段路径是 Decimal（须做 decimal canonical）。
+     * 路径用点号连接，array 元素用 {@code []} 通配（如 {@code applicants[].income}）。
+     * 无 ctx 时所有 number 按 safe-integer 铁律处理。
+     */
+    public record TypeContext(Set<String> decimalPaths) {
+        public static TypeContext of(String... paths) {
+            var set = new java.util.HashSet<String>();
+            for (String p : paths) {
+                set.add(normalizePathForMatch(p));
+            }
+            return new TypeContext(set);
+        }
+
+        public static TypeContext empty() {
+            return new TypeContext(Set.of());
+        }
+
+        boolean isDecimalPath(String path) {
+            return decimalPaths.contains(normalizePathForMatch(path));
+        }
+    }
+
+    /** array 下标归一 pattern（缓存，避免反复编译）。 */
+    private static final java.util.regex.Pattern ARRAY_INDEX_PATTERN = java.util.regex.Pattern.compile("\\[\\d+]");
+
+    /** 把具体 array 下标路径归一为 {@code []} 通配，用于 typeCtx 匹配（与 TS normalizePathForMatch 一致）。 */
+    private static String normalizePathForMatch(String path) {
+        return ARRAY_INDEX_PATTERN.matcher(path).replaceAll("[]");
+    }
+
+    /**
+     * 把 JsonNode 序列化为 canonical 字符串（确定性、跨实现可复现，与 TS canonicalJson 字节一致）。
+     *
+     * @throws CanonicalJsonException 遇到 NaN/Infinity/非法 Decimal/非 JSON 值。
+     */
+    public static String canonicalJson(JsonNode value, TypeContext ctx) {
+        StringBuilder sb = new StringBuilder();
+        write(value, "", ctx, sb);
+        return sb.toString();
+    }
+
+    public static String canonicalJson(JsonNode value) {
+        return canonicalJson(value, TypeContext.empty());
+    }
+
+    /**
+     * 计算 canonical hash：{@code sha256(CANONICALIZATION_VERSION + "\n" + canonicalJson(value))}（hex）。
+     * 与 TS canonicalHash 同算法同前缀 → 同输入产同 hash。
+     */
+    public static String canonicalHash(JsonNode value, TypeContext ctx) {
+        String canonical = canonicalJson(value, ctx);
+        String payload = CANONICALIZATION_VERSION + "\n" + canonical;
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(payload.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 不可用", e);
+        }
+    }
+
+    public static String canonicalHash(JsonNode value) {
+        return canonicalHash(value, TypeContext.empty());
+    }
+
+    private static void write(JsonNode node, String path, TypeContext ctx, StringBuilder sb) {
+        if (node == null || node.isMissingNode()) {
+            throw new CanonicalJsonException(ErrorReason.UNSUPPORTED_VALUE, "missing/absent node", path);
+        }
+        switch (node.getNodeType()) {
+            case NULL -> sb.append("null");
+            case BOOLEAN -> sb.append(node.booleanValue() ? "true" : "false");
+            case STRING -> writeString(node.textValue(), path, ctx, sb);
+            case NUMBER -> writeNumber(node, path, ctx, sb);
+            case ARRAY -> writeArray((ArrayNode) node, path, ctx, sb);
+            case OBJECT -> writeObject((ObjectNode) node, path, ctx, sb);
+            // BINARY / POJO / 其它非纯 JSON 类型。
+            default -> throw new CanonicalJsonException(
+                    ErrorReason.UNSUPPORTED_VALUE, "不支持的节点类型: " + node.getNodeType(), path);
+        }
+    }
+
+    private static void writeString(String value, String path, TypeContext ctx, StringBuilder sb) {
+        if (ctx.isDecimalPath(path)) {
+            // Decimal 路径上的 string 承载精确值 → decimal canonical。
+            sb.append(canonicalDecimal(value, path));
+        } else {
+            sb.append(jsonEscape(value));
+        }
+    }
+
+    private static void writeNumber(JsonNode node, String path, TypeContext ctx, StringBuilder sb) {
+        if (ctx.isDecimalPath(path)) {
+            // ★Decimal 路径的 number 也只接受 safe integer（与 TS 一致，Codex 复审 P0#1）：
+            // 非整数 / 超 safe-integer 的 number 走 canonicalDecimal 会重引入跨引擎表示隐患，
+            // 精确小数必须以 string 承载。故此处先施加 safe-integer 铁律，再交 canonicalDecimal。
+            requireSafeIntegerNumber(node, path);
+            sb.append(canonicalDecimal(numberToRawString(node, path), path));
+            return;
+        }
+        sb.append(canonicalNumber(node, path));
+    }
+
+    /**
+     * 施加「number 只允许 safe integer」铁律（供 Decimal 路径的 number 复用），
+     * 与 TS 侧 canonicalDecimal 对 number 入参的 Number.isSafeInteger 检查对齐。
+     */
+    private static void requireSafeIntegerNumber(JsonNode node, String path) {
+        if (node.isFloatingPointNumber()) {
+            double d = node.doubleValue();
+            if (Double.isNaN(d) || Double.isInfinite(d)) {
+                throw new CanonicalJsonException(ErrorReason.NON_CANONICAL_NUMBER, "Decimal number 非 finite: " + d, path);
+            }
+            java.math.BigDecimal bd = node.decimalValue();
+            if (bd.stripTrailingZeros().scale() > 0) {
+                throw new CanonicalJsonException(ErrorReason.NON_INTEGER_NUMBER,
+                        "Decimal 路径的 number 只允许 safe integer；精确小数须以 string 承载: " + node.asText(), path);
+            }
+            checkSafeIntegerRange(bd.toBigIntegerExact(), node.asText(), path);
+        } else {
+            checkSafeIntegerRange(node.bigIntegerValue(), node.asText(), path);
+        }
+    }
+
+    private static void checkSafeIntegerRange(java.math.BigInteger bi, String raw, String path) {
+        if (bi.abs().compareTo(java.math.BigInteger.valueOf(MAX_SAFE_INTEGER)) > 0) {
+            throw new CanonicalJsonException(ErrorReason.NON_INTEGER_NUMBER,
+                    "Decimal 路径的 number 超 safe-integer 范围；须以 string 承载: " + raw, path);
+        }
+    }
+
+    /**
+     * 规范化普通 JSON number（非 Decimal 路径）——只允许 safe integer。
+     * 与 TS canonicalNumber 对齐：非整数 / 超 safe-integer 一律拒绝（跨引擎浮点表示不一致）。
+     */
+    private static String canonicalNumber(JsonNode node, String path) {
+        if (node.isFloatingPointNumber()) {
+            double d = node.doubleValue();
+            if (Double.isNaN(d) || Double.isInfinite(d)) {
+                throw new CanonicalJsonException(ErrorReason.NON_CANONICAL_NUMBER, "number 非 finite: " + d, path);
+            }
+            // 与 TS/JSON.parse parity：JSON `100.0` 数值即整数 100 → 接受输出 `100`（不按词法拒绝）；
+            // 只有**非零小数**（如 100.5）或**超 safe-integer 范围**才拒（NON_INTEGER_NUMBER）。
+            // 用 BigDecimal 判断是否恰为整数（stripTrailingZeros 后 scale≤0）且在 safe 范围内。
+            java.math.BigDecimal bd = node.decimalValue();
+            if (bd.stripTrailingZeros().scale() > 0) {
+                throw new CanonicalJsonException(ErrorReason.NON_INTEGER_NUMBER,
+                        "非 Decimal number 只允许 safe integer（小数须走 Decimal string + typeCtx）: " + node.asText(), path);
+            }
+            java.math.BigInteger bi = bd.toBigIntegerExact();
+            return checkAndFormatSafeInteger(bi, node.asText(), path);
+        }
+        // 整数类型（int/long/BigInteger）。
+        java.math.BigInteger bi = node.bigIntegerValue();
+        return checkAndFormatSafeInteger(bi, node.asText(), path);
+    }
+
+    private static String checkAndFormatSafeInteger(java.math.BigInteger bi, String raw, String path) {
+        if (bi.abs().compareTo(java.math.BigInteger.valueOf(MAX_SAFE_INTEGER)) > 0) {
+            throw new CanonicalJsonException(ErrorReason.NON_INTEGER_NUMBER,
+                    "非 Decimal number 超 safe-integer 范围（须走 Decimal string + typeCtx）: " + raw, path);
+        }
+        // -0 归一为 0（BigInteger 无 -0，天然满足）。十进制整数表示跨引擎一致。
+        return bi.toString();
+    }
+
+    /** 取 number 节点的原始字符串（供 Decimal 路径解析）。 */
+    private static String numberToRawString(JsonNode node, String path) {
+        if (node.isFloatingPointNumber()) {
+            double d = node.doubleValue();
+            if (Double.isNaN(d) || Double.isInfinite(d)) {
+                throw new CanonicalJsonException(ErrorReason.NON_CANONICAL_NUMBER, "Decimal number 非 finite: " + d, path);
+            }
+        }
+        return node.asText();
+    }
+
+    /**
+     * 规范化 Decimal 值（decimal canonical form），与 TS canonicalDecimal 字节一致：
+     * 无 exponent / 无前导 + / 无无意义前导零 / 无 trailing zero / -0→0 / 整数无 .0。
+     * string 入参不 trim（含空白即非法）。
+     */
+    /** Decimal 语法（缓存 Pattern，避免热路径反复编译，Codex 复审性能项）。 */
+    private static final java.util.regex.Pattern DECIMAL_PATTERN =
+            java.util.regex.Pattern.compile("^([+-]?)(\\d+)(?:\\.(\\d+))?(?:[eE]([+-]?\\d+))?$");
+
+    static String canonicalDecimal(String raw, String path) {
+        // 允许可选符号 + 整数部分 + 可选小数部分 + 可选指数（无前后空白）。
+        java.util.regex.Matcher m = DECIMAL_PATTERN.matcher(raw);
+        if (!m.matches()) {
+            throw new CanonicalJsonException(ErrorReason.NON_CANONICAL_NUMBER, "Decimal 格式非法: \"" + raw + "\"", path);
+        }
+        String sign = "-".equals(m.group(1)) ? "-" : "";
+        String intPart = m.group(2);
+        String fracPart = m.group(3) != null ? m.group(3) : "";
+        String expStr = m.group(4) != null ? m.group(4) : "0";
+
+        // 资源上限：与 TS 一致用**含符号**的完整指数串长度（Codex 复审 P1#3）。
+        if (expStr.length() > 10) {
+            throw new CanonicalJsonException(ErrorReason.DECIMAL_TOO_LARGE, "Decimal 指数过大: " + expStr, path);
+        }
+        // ★用 long 解析防 10 位无符号指数（如 1e9999999999）Integer.parseInt 溢出抛
+        //   NumberFormatException（Java-only 拒绝原因偏离 TS，Codex 复审 P1）。long 稳收，
+        //   再由 MAX_DECIMAL_EXPONENT 判超限 → 统一 DECIMAL_TOO_LARGE（与 TS 同因）。
+        long exp = Long.parseLong(expStr);
+        if (Math.abs(exp) > MAX_DECIMAL_EXPONENT) {
+            throw new CanonicalJsonException(ErrorReason.DECIMAL_TOO_LARGE,
+                    "Decimal 指数超限(" + exp + " > ±" + MAX_DECIMAL_EXPONENT + ")", path);
+        }
+
+        // 展开指数：把 int.frac 视为无小数点的数字串，用 exp 决定小数点位置（与 TS 同算法）。
+        // exp 已被 MAX_DECIMAL_EXPONENT(±4096) 约束，(int) 转换安全。
+        String digits = intPart + fracPart;
+        int pointPos = intPart.length() + (int) exp;
+
+        int expandedLen = Math.max(Math.max(digits.length(), pointPos), digits.length() - pointPos) + Math.abs(pointPos);
+        if (expandedLen > MAX_DECIMAL_DIGITS) {
+            throw new CanonicalJsonException(ErrorReason.DECIMAL_TOO_LARGE,
+                    "Decimal 展开位数超限(" + expandedLen + " > " + MAX_DECIMAL_DIGITS + ")", path);
+        }
+
+        if (pointPos <= 0) {
+            digits = "0".repeat(1 - pointPos) + digits;
+            pointPos = 1;
+        }
+        if (pointPos >= digits.length()) {
+            digits = digits + "0".repeat(pointPos - digits.length());
+        }
+        String newIntPart = digits.substring(0, pointPos);
+        String newFracPart = digits.substring(pointPos);
+
+        // 去无意义前导零（保留至少一位）。
+        newIntPart = newIntPart.replaceFirst("^0+(?=\\d)", "");
+        // 去 trailing zero。
+        newFracPart = newFracPart.replaceFirst("0+$", "");
+
+        String body = !newFracPart.isEmpty() ? newIntPart + "." + newFracPart : newIntPart;
+        // -0 归一为 0。
+        if ("-".equals(sign) && body.matches("^0(?:\\.0*)?$")) {
+            return newIntPart; // "0"
+        }
+        return sign + body;
+    }
+
+    private static void writeArray(ArrayNode node, String path, TypeContext ctx, StringBuilder sb) {
+        // array 保序（Jackson ArrayNode 无 hole，天然满足 own-property 语义）。
+        sb.append('[');
+        for (int i = 0; i < node.size(); i++) {
+            if (i > 0) sb.append(',');
+            write(node.get(i), path + "[" + i + "]", ctx, sb);
+        }
+        sb.append(']');
+    }
+
+    private static void writeObject(ObjectNode node, String path, TypeContext ctx, StringBuilder sb) {
+        // object key 按 Unicode code point 升序（与 TS compareByCodePoint 一致，非 UTF-16 code unit 序）。
+        List<String> keys = new ArrayList<>();
+        Iterator<String> it = node.fieldNames();
+        while (it.hasNext()) {
+            keys.add(it.next());
+        }
+        keys.sort(CODE_POINT_ORDER);
+
+        sb.append('{');
+        boolean first = true;
+        for (String k : keys) {
+            if (!first) sb.append(',');
+            first = false;
+            sb.append(jsonEscape(k)).append(':');
+            String childPath = path.isEmpty() ? k : path + "." + k;
+            write(node.get(k), childPath, ctx, sb);
+        }
+        sb.append('}');
+    }
+
+    /** 按 Unicode code point 比较（正确处理代理对），与 TS compareByCodePoint 一致。 */
+    static final Comparator<String> CODE_POINT_ORDER = (a, b) -> {
+        int[] ai = a.codePoints().toArray();
+        int[] bi = b.codePoints().toArray();
+        int n = Math.min(ai.length, bi.length);
+        for (int i = 0; i < n; i++) {
+            if (ai[i] != bi[i]) return Integer.compare(ai[i], bi[i]);
+        }
+        return Integer.compare(ai.length, bi.length);
+    };
+
+    /**
+     * JSON string 转义 —— 复刻 JS {@code JSON.stringify} 策略（与 TS canonicalString 字节一致）：
+     * 短转义 \" \\ \b \f \n \r \t；U+0000..U+001F 其余用 \\u00XX（小写 hex）；不转义 {@code /}；
+     * 不转义 U+2028/U+2029；非控制字符（含非 ASCII）原样输出（JSON.stringify 不 ASCII-escape）。
+     */
+    static String jsonEscape(String s) {
+        StringBuilder sb = new StringBuilder(s.length() + 2);
+        sb.append('"');
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"' -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\b' -> sb.append("\\b");
+                case '\f' -> sb.append("\\f");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        sb.append("\\u").append(String.format("%04x", (int) c));
+                    } else if (Character.isHighSurrogate(c)) {
+                        // ★合法代理对（high+low）原样输出；孤立 high surrogate 转义为 backslash-u-XXXX
+                        //   （与 JS JSON.stringify 一致，Codex 复审 P0#2）。
+                        if (i + 1 < s.length() && Character.isLowSurrogate(s.charAt(i + 1))) {
+                            sb.append(c).append(s.charAt(i + 1));
+                            i++; // 跳过已消费的 low surrogate。
+                        } else {
+                            sb.append("\\u").append(String.format("%04x", (int) c));
+                        }
+                    } else if (Character.isLowSurrogate(c)) {
+                        // 孤立 low surrogate（前面没配对的 high）→ 转义。
+                        sb.append("\\u").append(String.format("%04x", (int) c));
+                    } else {
+                        // 普通非控制字符原样（UTF-8 编码后与 JS 一致）。
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        sb.append('"');
+        return sb.toString();
+    }
+}

--- a/src/test/java/aster/core/canonical/CanonicalJsonParityTest.java
+++ b/src/test/java/aster/core/canonical/CanonicalJsonParityTest.java
@@ -1,0 +1,113 @@
+package aster.core.canonical;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * TS↔Java canonical JSON parity gate（P0-A 地基，ADR 0030 附录 A.2）。
+ *
+ * <p>共享 fixture {@code canonical-json-fixtures.json} 由 aster-cloud 的 TS 参考实现
+ * （{@code src/lib/canonical-json.ts}，已穷尽单测）生成，含每个用例的 input + 期望
+ * canonical 字符串 + 期望 hash。本测试用 Java {@link CanonicalJson} 跑同样 input，断言
+ * 产出与 fixture **字节级一致** —— 证明两引擎对同一决策输入产同一 canonical/hash，回归
+ * 工具的 old（Java 权威）↔ new toolchain hash 比对才不会因表示差异误报/漏报。
+ *
+ * <p>fixture 是两侧共享同源副本（cloud 侧 {@code src/lib/__fixtures__/} 与本 test resources
+ * 字节一致）。TS 侧另有测试断言其产出 == fixture，Java 侧本测试断言其产出 == fixture，
+ * 传递即 TS == Java。
+ */
+@DisplayName("Canonical JSON TS↔Java parity")
+class CanonicalJsonParityTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    record Fixture(String name, JsonNode input, List<String> decimalPaths, String canonical, String hash) {}
+
+    static Stream<Fixture> fixtures() throws Exception {
+        try (InputStream in = CanonicalJsonParityTest.class.getResourceAsStream(
+                "/canonical/canonical-json-fixtures.json")) {
+            assertNotNull(in, "共享 fixture 缺失: /canonical/canonical-json-fixtures.json");
+            JsonNode root = MAPPER.readTree(in);
+            assertEquals("aster-canonical-json/v1", root.get("version").asText(),
+                    "fixture 版本须与 CanonicalJson.CANONICALIZATION_VERSION 一致");
+            List<Fixture> out = new ArrayList<>();
+            for (JsonNode c : root.get("cases")) {
+                List<String> paths = new ArrayList<>();
+                c.get("decimalPaths").forEach(p -> paths.add(p.asText()));
+                out.add(new Fixture(
+                        c.get("name").asText(),
+                        c.get("input"),
+                        paths,
+                        c.get("canonical").asText(),
+                        c.get("hash").asText()));
+            }
+            return out.stream();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fixtures")
+    @DisplayName("Java canonical 产出与 TS fixture 字节级一致")
+    void javaMatchesTsFixture(Fixture f) {
+        CanonicalJson.TypeContext ctx = CanonicalJson.TypeContext.of(f.decimalPaths().toArray(new String[0]));
+
+        String javaCanonical = CanonicalJson.canonicalJson(f.input(), ctx);
+        assertEquals(f.canonical(), javaCanonical,
+                "canonical 字符串不一致（TS vs Java）用例=" + f.name());
+
+        String javaHash = CanonicalJson.canonicalHash(f.input(), ctx);
+        assertEquals(f.hash(), javaHash,
+                "canonical hash 不一致（TS vs Java）用例=" + f.name());
+    }
+
+    @Test
+    @DisplayName("fixture 非空（防 corpus 删除后假通过）")
+    void fixtureNotEmpty() throws Exception {
+        long n = fixtures().count();
+        org.junit.jupiter.api.Assertions.assertTrue(n >= 20,
+                "共享 fixture 用例数异常偏少(" + n + ")，疑似 corpus 损坏");
+    }
+
+    record NegativeFixture(String name, JsonNode input, List<String> decimalPaths, String expectedReason) {}
+
+    static Stream<NegativeFixture> negativeFixtures() throws Exception {
+        try (InputStream in = CanonicalJsonParityTest.class.getResourceAsStream(
+                "/canonical/canonical-json-fixtures.json")) {
+            assertNotNull(in);
+            JsonNode root = MAPPER.readTree(in);
+            List<NegativeFixture> out = new ArrayList<>();
+            for (JsonNode c : root.get("negativeCases")) {
+                List<String> paths = new ArrayList<>();
+                c.get("decimalPaths").forEach(p -> paths.add(p.asText()));
+                out.add(new NegativeFixture(
+                        c.get("name").asText(), c.get("input"), paths, c.get("expectedReason").asText()));
+            }
+            return out.stream();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("negativeFixtures")
+    @DisplayName("Java 对非法输入的拒绝原因与 TS 一致")
+    void javaRejectionMatchesTs(NegativeFixture f) {
+        CanonicalJson.TypeContext ctx = CanonicalJson.TypeContext.of(f.decimalPaths().toArray(new String[0]));
+        CanonicalJson.CanonicalJsonException ex = org.junit.jupiter.api.Assertions.assertThrows(
+                CanonicalJson.CanonicalJsonException.class,
+                () -> CanonicalJson.canonicalJson(f.input(), ctx),
+                "Java 应拒绝非法输入，用例=" + f.name());
+        assertEquals(f.expectedReason(), ex.reason().name(),
+                "拒绝原因不一致（TS vs Java）用例=" + f.name());
+    }
+}

--- a/src/test/resources/canonical/canonical-json-fixtures.json
+++ b/src/test/resources/canonical/canonical-json-fixtures.json
@@ -1,0 +1,448 @@
+{
+  "version": "aster-canonical-json/v1",
+  "cases": [
+    {
+      "name": "empty-object",
+      "input": {},
+      "decimalPaths": [],
+      "canonical": "{}",
+      "hash": "f6f3fa8261aa58e7885494398a1f39dedb8da20bbaf43e294f856f544fafb9e1"
+    },
+    {
+      "name": "key-ordering",
+      "input": {
+        "c": 3,
+        "a": 1,
+        "b": 2
+      },
+      "decimalPaths": [],
+      "canonical": "{\"a\":1,\"b\":2,\"c\":3}",
+      "hash": "79036aa14afada58e49171d3625929af2bbcb901750ce3d51d906a9b85ab6f9f"
+    },
+    {
+      "name": "nested-ordering",
+      "input": {
+        "z": {
+          "y": 1,
+          "x": 2
+        },
+        "a": 3
+      },
+      "decimalPaths": [],
+      "canonical": "{\"a\":3,\"z\":{\"x\":2,\"y\":1}}",
+      "hash": "7aa8aa0e2613b6a6ec603cbf5a3088b2d1f34876f61f8e73bce1ea3273ea1ddb"
+    },
+    {
+      "name": "array-preserves-order",
+      "input": [
+        3,
+        1,
+        2
+      ],
+      "decimalPaths": [],
+      "canonical": "[3,1,2]",
+      "hash": "3daebcda12bde313bb851aa8474c93469f28ca685b9c40410336233025c7e245"
+    },
+    {
+      "name": "uppercase-before-lowercase",
+      "input": {
+        "a": 1,
+        "A": 2
+      },
+      "decimalPaths": [],
+      "canonical": "{\"A\":2,\"a\":1}",
+      "hash": "61d0c7ba2e384302d07f2b0b7bf87e90187536374cc34204175f9e4071df74c6"
+    },
+    {
+      "name": "supplementary-plane-keys",
+      "input": {
+        "😀": 1,
+        "￿": 2
+      },
+      "decimalPaths": [],
+      "canonical": "{\"￿\":2,\"😀\":1}",
+      "hash": "eb15e6e7121683182a82fcc707821d6be7917c4ee4727c8b9ac41392f277fb41"
+    },
+    {
+      "name": "null-explicit",
+      "input": {
+        "a": null
+      },
+      "decimalPaths": [],
+      "canonical": "{\"a\":null}",
+      "hash": "77a4d4d37e14f10cb9f9985bcf900895d0c90c48d8fc2b9679be71f563406d01"
+    },
+    {
+      "name": "null-vs-missing-A",
+      "input": {
+        "a": 1,
+        "b": null
+      },
+      "decimalPaths": [],
+      "canonical": "{\"a\":1,\"b\":null}",
+      "hash": "1a71015c49ddcea3b151049a6162080d764cfdcd214d7205b85541b345054025"
+    },
+    {
+      "name": "null-vs-missing-B",
+      "input": {
+        "a": 1
+      },
+      "decimalPaths": [],
+      "canonical": "{\"a\":1}",
+      "hash": "c119cbf81654971fff9be4c3fca048f9141febed3c4dd0bce1a08d93313c6f69"
+    },
+    {
+      "name": "empty-values-kept",
+      "input": {
+        "o": {},
+        "arr": [],
+        "f": false,
+        "z": 0,
+        "s": ""
+      },
+      "decimalPaths": [],
+      "canonical": "{\"arr\":[],\"f\":false,\"o\":{},\"s\":\"\",\"z\":0}",
+      "hash": "af74a48b2249f6e4692493504b85f5b8f4ba4ccdfd9016a4f547111ae24d0d6c"
+    },
+    {
+      "name": "safe-integer",
+      "input": {
+        "n": 9007199254740991
+      },
+      "decimalPaths": [],
+      "canonical": "{\"n\":9007199254740991}",
+      "hash": "6f3152d51f7bcf75bedcf0b6987888e3de1187b068114ad7a8723e7ba1de840c"
+    },
+    {
+      "name": "negative-integer",
+      "input": {
+        "n": -42
+      },
+      "decimalPaths": [],
+      "canonical": "{\"n\":-42}",
+      "hash": "1aaac9a9ebf76dcde24907362aa30e02a856370b5902d6d655ac4137cc09432a"
+    },
+    {
+      "name": "neg-zero",
+      "input": {
+        "n": 0
+      },
+      "decimalPaths": [],
+      "canonical": "{\"n\":0}",
+      "hash": "516f6d8fa0df169f373165d8de44fe89690f5ace19a6cfa1139a3e9a1552a9ba"
+    },
+    {
+      "name": "string-not-trimmed",
+      "input": {
+        "s": "  Hello  "
+      },
+      "decimalPaths": [],
+      "canonical": "{\"s\":\"  Hello  \"}",
+      "hash": "4a874fa2246f19fa4ba94692e64422aaf02143068741162fcd457cf4b7fd5650"
+    },
+    {
+      "name": "string-vs-number",
+      "input": {
+        "a": 1,
+        "b": "1"
+      },
+      "decimalPaths": [],
+      "canonical": "{\"a\":1,\"b\":\"1\"}",
+      "hash": "0cccd2a7a4f8b4684fad03ff180826d106c9f0334437d349b319c5e10b2a80c5"
+    },
+    {
+      "name": "string-escapes",
+      "input": {
+        "s": "a\"b\\c\nd\te"
+      },
+      "decimalPaths": [],
+      "canonical": "{\"s\":\"a\\\"b\\\\c\\nd\\te\"}",
+      "hash": "3528236ff6db6cb7293f5e656cbfe6a16038c48d488eaa7bd60c81a0671ea0e6"
+    },
+    {
+      "name": "unicode-string",
+      "input": {
+        "name": "静夜思",
+        "hi": "नमस्ते"
+      },
+      "decimalPaths": [],
+      "canonical": "{\"hi\":\"नमस्ते\",\"name\":\"静夜思\"}",
+      "hash": "2d8b230ded447eaa9e078f53dfa11e7522554e1c17500814067e129dbf7cd54f"
+    },
+    {
+      "name": "decimal-trailing-zero",
+      "input": {
+        "amount": "100.500"
+      },
+      "decimalPaths": [
+        "amount"
+      ],
+      "canonical": "{\"amount\":100.5}",
+      "hash": "7a1f7f1d164c156faac856f2d4abb7de5df4ceec1561ebaf1ebe4c4b72ddf46c"
+    },
+    {
+      "name": "decimal-integer-form",
+      "input": {
+        "amount": "42.0"
+      },
+      "decimalPaths": [
+        "amount"
+      ],
+      "canonical": "{\"amount\":42}",
+      "hash": "b280ba8b6372a14401a06cc7412485c5528fb213a1376a0a1d3560f57bc08afc"
+    },
+    {
+      "name": "decimal-leading-zero",
+      "input": {
+        "amount": "007.50"
+      },
+      "decimalPaths": [
+        "amount"
+      ],
+      "canonical": "{\"amount\":7.5}",
+      "hash": "2dcdb68855ad809b5b421e85007b73f43d93ada210950ccfb365c32a775c9688"
+    },
+    {
+      "name": "decimal-neg-zero",
+      "input": {
+        "amount": "-0.00"
+      },
+      "decimalPaths": [
+        "amount"
+      ],
+      "canonical": "{\"amount\":0}",
+      "hash": "20859a64f83af0a2d65198b43841144c858ae630a7e2580d64f28ca717c5af2d"
+    },
+    {
+      "name": "decimal-negative",
+      "input": {
+        "amount": "-100.50"
+      },
+      "decimalPaths": [
+        "amount"
+      ],
+      "canonical": "{\"amount\":-100.5}",
+      "hash": "0cd7216c79be91e252918f130cb7b1d71290ae020806b7f1c0300b145a9e7d85"
+    },
+    {
+      "name": "decimal-exponent",
+      "input": {
+        "amount": "1.5e2"
+      },
+      "decimalPaths": [
+        "amount"
+      ],
+      "canonical": "{\"amount\":150}",
+      "hash": "2ac8e048f14f5c51d0d7c7b76d17155b8166d1adffa80132dad580ac2b5a5870"
+    },
+    {
+      "name": "decimal-array-wildcard",
+      "input": {
+        "applicants": [
+          {
+            "income": "5000.00"
+          },
+          {
+            "income": "6000.0"
+          }
+        ]
+      },
+      "decimalPaths": [
+        "applicants[].income"
+      ],
+      "canonical": "{\"applicants\":[{\"income\":5000},{\"income\":6000}]}",
+      "hash": "1162ce8575c9ba9c1f8b963c71841f4cd3bc9409cf6b2e06fa13338e374f35c8"
+    },
+    {
+      "name": "credit-application",
+      "input": {
+        "requestedAmount": "50000.00",
+        "income": "120000.0",
+        "creditScore": 680,
+        "applicantName": "Alice"
+      },
+      "decimalPaths": [
+        "requestedAmount",
+        "income"
+      ],
+      "canonical": "{\"applicantName\":\"Alice\",\"creditScore\":680,\"income\":120000,\"requestedAmount\":50000}",
+      "hash": "85ab63de9c3cde48b3d4e5882c33ea6b0c8b4e9fc32edffa271915eb8db32c23"
+    },
+    {
+      "name": "credit-boundary-679",
+      "input": {
+        "creditScore": 679
+      },
+      "decimalPaths": [],
+      "canonical": "{\"creditScore\":679}",
+      "hash": "fd8c1ff1da5776d50e8658c19630954e0a77f5ceeb2fc13b3e31e0f9f976b40a"
+    },
+    {
+      "name": "credit-boundary-680",
+      "input": {
+        "creditScore": 680
+      },
+      "decimalPaths": [],
+      "canonical": "{\"creditScore\":680}",
+      "hash": "9f2a3d35c80e5fbbb25a8d03623e6b49f5a0733391261eccfc84f67150510cdf"
+    },
+    {
+      "name": "del-char-0x7f",
+      "input": {
+        "s": "ab"
+      },
+      "decimalPaths": [],
+      "canonical": "{\"s\":\"ab\"}",
+      "hash": "863d10f24b7ba7daa1b55e3b5d84a59f8e5e1872607598f733cc70f3dabfad0e"
+    },
+    {
+      "name": "u2028-u2029-not-escaped",
+      "input": {
+        "s": "a  b"
+      },
+      "decimalPaths": [],
+      "canonical": "{\"s\":\"a  b\"}",
+      "hash": "92b75b770df7fed04f14493522389c0e890fe8b6df8bb23e876121a4af98f0da"
+    },
+    {
+      "name": "valid-surrogate-pair-in-value",
+      "input": {
+        "s": "😀 emoji 💰"
+      },
+      "decimalPaths": [],
+      "canonical": "{\"s\":\"😀 emoji 💰\"}",
+      "hash": "8a35a9976d31b2679a0b6d1a56ca83a9469cd3991754ca2ed7741f6b6c7ef440"
+    },
+    {
+      "name": "control-chars-escaped",
+      "input": {
+        "s": "\u0001\u001f"
+      },
+      "decimalPaths": [],
+      "canonical": "{\"s\":\"\\u0001\\u001f\"}",
+      "hash": "c24341fa26b6f4ecd4d6d94c130110f787a0564fe38a4f9989c06f259e917dea"
+    },
+    {
+      "name": "decimal-large-int-string",
+      "input": {
+        "x": "9007199254740993"
+      },
+      "decimalPaths": [
+        "x"
+      ],
+      "canonical": "{\"x\":9007199254740993}",
+      "hash": "ae599608cbe67fd15c63a300a2ce29fe25c76f1d64eb8d5b49ad7f3f04480c39"
+    },
+    {
+      "name": "decimal-many-frac-digits",
+      "input": {
+        "x": "0.123456789012345"
+      },
+      "decimalPaths": [
+        "x"
+      ],
+      "canonical": "{\"x\":0.123456789012345}",
+      "hash": "55dcbc7d18567e4c990654b2405bde7ce7480e3f957a14939b8a90e49655a0a2"
+    },
+    {
+      "name": "lone-high-surrogate-value",
+      "input": {
+        "s": "x\ud800y"
+      },
+      "decimalPaths": [],
+      "canonical": "{\"s\":\"x\\ud800y\"}",
+      "hash": "bf256e8f3bffea20b376d3713f6f1aaf5b18e648d393236ca95cef4c1e9f182c"
+    },
+    {
+      "name": "lone-low-surrogate-value",
+      "input": {
+        "s": "x\udc00y"
+      },
+      "decimalPaths": [],
+      "canonical": "{\"s\":\"x\\udc00y\"}",
+      "hash": "0aa3701bf7b9795743de70bd7568a36a1097d5612f5d2ef88c70a87e754c23f5"
+    },
+    {
+      "name": "lone-surrogate-key",
+      "input": {
+        "\ud800": 1,
+        "a": 2
+      },
+      "decimalPaths": [],
+      "canonical": "{\"a\":2,\"\\ud800\":1}",
+      "hash": "dc9356effd594f7bc600846a38ae59b1441a6801a3799378aac00c0baee7429f"
+    },
+    {
+      "name": "mixed-surrogate-key-ordering",
+      "input": {
+        "\ud800": 1,
+        "\udc00": 2,
+        "😀": 3,
+        "￿": 4
+      },
+      "decimalPaths": [],
+      "canonical": "{\"\\ud800\":1,\"\\udc00\":2,\"￿\":4,\"😀\":3}",
+      "hash": "bd0fbadc7a05622cb27750a0c9d4aad94889c4b334aac1c91e77ef02df55c02d"
+    }
+  ],
+  "negativeCases": [
+    {
+      "name": "neg-non-decimal-float",
+      "input": {
+        "n": 1.5
+      },
+      "decimalPaths": [],
+      "expectedReason": "NON_INTEGER_NUMBER"
+    },
+    {
+      "name": "neg-decimal-path-float",
+      "input": {
+        "x": 100.5
+      },
+      "decimalPaths": [
+        "x"
+      ],
+      "expectedReason": "NON_INTEGER_NUMBER"
+    },
+    {
+      "name": "neg-decimal-whitespace",
+      "input": {
+        "x": " 1.5 "
+      },
+      "decimalPaths": [
+        "x"
+      ],
+      "expectedReason": "NON_CANONICAL_NUMBER"
+    },
+    {
+      "name": "neg-decimal-huge-exponent",
+      "input": {
+        "x": "1e+0000000001"
+      },
+      "decimalPaths": [
+        "x"
+      ],
+      "expectedReason": "DECIMAL_TOO_LARGE"
+    },
+    {
+      "name": "neg-decimal-illegal",
+      "input": {
+        "x": "abc"
+      },
+      "decimalPaths": [
+        "x"
+      ],
+      "expectedReason": "NON_CANONICAL_NUMBER"
+    },
+    {
+      "name": "neg-decimal-exp-int-overflow",
+      "input": {
+        "x": "1e9999999999"
+      },
+      "decimalPaths": [
+        "x"
+      ],
+      "expectedReason": "DECIMAL_TOO_LARGE"
+    }
+  ]
+}


### PR DESCRIPTION
## 背景
P0-A 规则集升级回归工具（ADR 0030）漂移检测地基的**双引擎权威侧**。配对 aster-cloud PR#239（TS 侧）。Java 必须与 TS 产出**字节级一致** —— 否则 old（Java 权威引擎）↔ new toolchain 的 hash 比对会因表示差异误报 regression 或碰撞漏报。

## 机制
共享 fixture `canonical-json-fixtures.json`（37 正向 + 6 负向）由 TS 参考实现生成。`CanonicalJsonParityTest` 断言 Java 产出 == fixture（字节级 canonical + hash + 拒绝原因）；TS 侧断言 TS 产出 == 同一 fixture。**传递：TS==fixture ∧ Java==fixture ⟹ TS==Java**。负向证明：扰动 `CANONICALIZATION_VERSION` → 27 fail（门真守，非假绿）。

## ★Codex 三轮审 72→88→95 抓 5 个 Java≠TS 分歧
fixture 全绿也没自动暴露这些——靠对抗式交叉审：
1. Decimal 路径 number 未施 safe-integer 铁律（`{x:100.5}` Java 接受 / TS 拒 `NON_INTEGER_NUMBER`）。
2. lone surrogate 转义（`\ud800` Java 输出裸代理 / JSON.stringify 转义）。
3. Decimal exponent 长度判断含符号对齐 TS。
4. 10 位无符号指数 `Integer.parseInt` 溢出抛 `NumberFormatException` 而非 `DECIMAL_TOO_LARGE` → 改 `Long.parseLong`。
5. 负向拒绝原因跨引擎一致（负向 parity fixture 锁）。

## 实现
key 排序用 `String.codePoints()`（非 UTF-16 code unit 序）；`jsonEscape` 手写复刻 JS `JSON.stringify` 策略（短转义 + 控制字符 `\u00xx` 小写 + 孤立代理转义 + 合法对/U+2028/2029 原样）；Pattern 缓存。

## 验证
- **44 parity 测全绿**（37 正向 + 6 负向 + 1 非空守门），含孤立代理/混合排序/指数溢出/信贷边界 679≠680。
- Codex 95/100 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)