### PR TITLE
feat(p0c): Java 权威侧 StabilityGate + TS↔Java parity gate（ADR 0031）

### DIFF
--- a/src/main/java/aster/core/stability/StabilityGate.java
+++ b/src/main/java/aster/core/stability/StabilityGate.java
@@ -1,0 +1,386 @@
+package aster.core.stability;
+
+import aster.core.ir.CoreModel;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * StabilityGate — 编译器强制 Stable/Experimental 边界（ADR 0031，P0-C）——权威（Java）侧。
+ *
+ * 必须与 aster-lang-ts 的 {@code src/stability/stability_gate.ts} 产出**同一 featureId 集**
+ * （M1 exit 硬门：TS↔Java parity fixture）。扫 **Core IR** 找 5 类 Experimental 特性产 W600
+ * 诊断，warn 默认 + strict surface 可拒。
+ *
+ * <p>为何扫 Core IR：aster-api 生产路径不走 typecheck，gate 挂 typecheck=假门禁。用显式
+ * switch（sealed interface 穷尽），与 TS 的 DefaultCoreVisitor 显式遍历对齐。
+ *
+ * <p>5 类检测（与 TS 逐字对齐）：
+ * <ul>
+ *   <li>Workflow：Stmt Start/Wait/Workflow + Expr Await</li>
+ *   <li>version-import：Import.version != null</li>
+ *   <li>effect-capabilities：Func.effectCapsExplicit == true</li>
+ *   <li>PII：PiiType 节点（递归类型树）+ Func.piiLevel 非空兜底</li>
+ *   <li>deprecated-annotation：annotation.name ∈ {example, deprecated}（大小写不敏感）</li>
+ * </ul>
+ */
+public final class StabilityGate {
+
+    /** W600 诊断码（monorepo shared/error_codes.json 单源；本类用常量对齐 TS 本地常量）。 */
+    public static final String STABILITY_EXPERIMENTAL_CODE = "W600";
+
+    private StabilityGate() {}
+
+    /** 机器可读特性标识（与 TS StabilityFeatureId 逐字一致）。 */
+    public enum FeatureId {
+        WORKFLOW("workflow"),
+        VERSION_IMPORT("version-import"),
+        EFFECT_CAPABILITIES("effect-capabilities"),
+        PII("pii"),
+        DEPRECATED_ANNOTATION("deprecated-annotation");
+
+        private final String id;
+
+        FeatureId(String id) {
+            this.id = id;
+        }
+
+        public String id() {
+            return id;
+        }
+    }
+
+    public record Options(boolean strict, boolean allowExperimental) {
+        public static Options warnMode() {
+            return new Options(false, false);
+        }
+
+        public static Options strictMode() {
+            return new Options(true, false);
+        }
+    }
+
+    /** 稳定性诊断（W600）。severity 恒 warning；strict 语义走 blocking。 */
+    public record Diagnostic(
+            String code,
+            String severity,
+            FeatureId featureId,
+            String moduleName,
+            boolean strict,
+            boolean blocking,
+            String nodeKind,
+            CoreModel.Origin origin) {}
+
+    /** 遍历状态：收集诊断 + 去重（有 origin 用位置，无 origin 用递增序号）。 */
+    private static final class ScanState {
+        final boolean strict;
+        final String moduleName;
+        final List<Diagnostic> diagnostics = new ArrayList<>();
+        final Set<String> seen = new HashSet<>();
+        int seq = 0;
+
+        ScanState(boolean strict, String moduleName) {
+            this.strict = strict;
+            this.moduleName = moduleName;
+        }
+    }
+
+    /**
+     * 扫 Core Module 找 5 类 Experimental 特性。每个触发节点一条诊断。
+     * 返回按 decls 顺序 + 每 decl 内 DFS 顺序（与 TS 一致，parity 稳定）。
+     */
+    public static List<Diagnostic> scan(CoreModel.Module module, Options options) {
+        if (options.allowExperimental()) {
+            return List.of();
+        }
+        ScanState st = new ScanState(options.strict(), module == null ? null : module.name);
+        if (module != null && module.decls != null) {
+            for (CoreModel.Decl decl : module.decls) {
+                scanDecl(st, decl);
+            }
+        }
+        return st.diagnostics;
+    }
+
+    /** strict surface 判断是否应拒绝（有 W600 且 strict）。 */
+    public static boolean shouldReject(List<Diagnostic> diagnostics, boolean strict) {
+        return strict && diagnostics.stream().anyMatch(d -> STABILITY_EXPERIMENTAL_CODE.equals(d.code()));
+    }
+
+    private static void emit(ScanState st, FeatureId featureId, CoreModel.Origin origin, String nodeKind) {
+        String posKey;
+        if (origin != null && origin.start != null && origin.end != null) {
+            posKey = origin.start.line + ":" + origin.start.col + "-" + origin.end.line + ":" + origin.end.col;
+        } else {
+            posKey = "seq" + (st.seq++);
+        }
+        String key = featureId.id() + "|" + nodeKind + "|" + posKey;
+        if (!st.seen.add(key)) {
+            return;
+        }
+        st.diagnostics.add(new Diagnostic(
+                STABILITY_EXPERIMENTAL_CODE,
+                "warning",
+                featureId,
+                st.moduleName,
+                st.strict,
+                st.strict,
+                nodeKind,
+                origin));
+    }
+
+    private static void scanDecl(ScanState st, CoreModel.Decl decl) {
+        switch (decl) {
+            case CoreModel.Import imp -> {
+                // 2. version-import：Import.version != null。
+                if (imp.version != null) {
+                    emit(st, FeatureId.VERSION_IMPORT, imp.origin, "Import");
+                }
+            }
+            case CoreModel.Data data -> {
+                // 4. PII：字段类型树。
+                if (data.fields != null) {
+                    for (CoreModel.Field f : data.fields) {
+                        scanType(st, f.type);
+                    }
+                }
+            }
+            case CoreModel.Func func -> scanFunc(st, func);
+            case CoreModel.Enum ignored -> {
+                // Enum 无 Experimental 信号。
+            }
+        }
+    }
+
+    private static void scanFunc(ScanState st, CoreModel.Func func) {
+        // 3. effect-capabilities：effectCapsExplicit == true（裸 @io 是 false）。
+        if (func.effectCapsExplicit) {
+            emit(st, FeatureId.EFFECT_CAPABILITIES, func.origin, "Func");
+        }
+
+        // 5. deprecated-annotation：annotation.name ∈ {example, deprecated}（大小写不敏感）。
+        // ★严格镜像 TS：只扫 Func.annotations，不扫 retAnnotations（TS 无 retAnnotations 概念，
+        // 扫它会 Java-only 误报；@pii 返回值走 ret 的 PiiType 不受影响，Codex 复审）。
+        for (CoreModel.Annotation anno : func.annotations) {
+            if (isExperimentalAnnotation(anno.name)) {
+                emit(st, FeatureId.DEPRECATED_ANNOTATION, func.origin, "Annotation");
+            }
+        }
+
+        // 4. PII 源信号：params/ret 类型树里的 PiiType。
+        if (func.params != null) {
+            for (CoreModel.Param p : func.params) {
+                scanType(st, p.type);
+            }
+        }
+        scanType(st, func.ret);
+        // 兜底：签名类型树无 PiiType 但 piiLevel 非空 → 报一条（Java piiLevel 默认 ""）。
+        if (!signatureHasPii(func) && func.piiLevel != null && !func.piiLevel.isEmpty()) {
+            emit(st, FeatureId.PII, func.origin, "Func");
+        }
+
+        // 1. Workflow：函数体递归。
+        scanBlock(st, func.body);
+    }
+
+    private static boolean isExperimentalAnnotation(String name) {
+        if (name == null) {
+            return false;
+        }
+        String lower = name.toLowerCase();
+        return lower.equals("example") || lower.equals("deprecated");
+    }
+
+    /** 4. PII：递归类型树找 PiiType，命中即 emit。 */
+    private static void scanType(ScanState st, CoreModel.Type type) {
+        if (type == null) {
+            return;
+        }
+        if (type instanceof CoreModel.PiiType pii) {
+            emit(st, FeatureId.PII, pii.origin, "PiiType");
+        }
+        for (CoreModel.Type child : childTypes(type)) {
+            scanType(st, child);
+        }
+    }
+
+    /** Func 签名（params + ret，不含 body）类型树是否含 PiiType（与 TS funcSignatureHasPii 对齐）。 */
+    private static boolean signatureHasPii(CoreModel.Func func) {
+        if (func.params != null) {
+            for (CoreModel.Param p : func.params) {
+                if (containsPii(p.type)) {
+                    return true;
+                }
+            }
+        }
+        return containsPii(func.ret);
+    }
+
+    private static boolean containsPii(CoreModel.Type type) {
+        if (type == null) {
+            return false;
+        }
+        if (type instanceof CoreModel.PiiType) {
+            return true;
+        }
+        for (CoreModel.Type child : childTypes(type)) {
+            if (containsPii(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** 取类型节点的直接子类型（字段名与 TS childTypes 逐字对齐）。 */
+    private static List<CoreModel.Type> childTypes(CoreModel.Type t) {
+        List<CoreModel.Type> out = new ArrayList<>();
+        switch (t) {
+            case CoreModel.PiiType pii -> add(out, pii.baseType);
+            case CoreModel.Maybe m -> add(out, m.type);
+            case CoreModel.Option o -> add(out, o.type);
+            case CoreModel.ListT l -> add(out, l.type);
+            case CoreModel.Result r -> {
+                add(out, r.ok);
+                add(out, r.err);
+            }
+            case CoreModel.MapT mp -> {
+                add(out, mp.key);
+                add(out, mp.val);
+            }
+            case CoreModel.TypeApp app -> {
+                if (app.args != null) {
+                    out.addAll(app.args);
+                }
+            }
+            case CoreModel.FuncType ft -> {
+                if (ft.params != null) {
+                    out.addAll(ft.params);
+                }
+                add(out, ft.ret);
+            }
+            // TypeName / TypeVar 是叶子。
+            default -> {
+            }
+        }
+        return out;
+    }
+
+    private static void add(List<CoreModel.Type> out, CoreModel.Type t) {
+        if (t != null) {
+            out.add(t);
+        }
+    }
+
+    /** 递归扫语句块找 Workflow 信号。 */
+    private static void scanBlock(ScanState st, CoreModel.Block block) {
+        if (block == null || block.statements == null) {
+            return;
+        }
+        for (CoreModel.Stmt stmt : block.statements) {
+            scanStatement(st, stmt);
+        }
+    }
+
+    private static void scanStatement(ScanState st, CoreModel.Stmt stmt) {
+        switch (stmt) {
+            case CoreModel.Start start -> {
+                emit(st, FeatureId.WORKFLOW, start.origin, "Start");
+                // ★递归 Start.expr（与 TS super.visitStatement 一致）——内嵌 Await 等须检出，
+                // 否则 Start(expr=Await) 时 Java 只报 Start、TS 报 Start+Await（Codex 复审）。
+                scanExpression(st, start.expr);
+            }
+            case CoreModel.Wait wait -> emit(st, FeatureId.WORKFLOW, wait.origin, "Wait");
+            case CoreModel.Workflow wf -> {
+                emit(st, FeatureId.WORKFLOW, wf.origin, "workflow");
+                if (wf.steps != null) {
+                    for (CoreModel.Step step : wf.steps) {
+                        scanBlock(st, step.body);
+                        scanBlock(st, step.compensate);
+                    }
+                }
+            }
+            case CoreModel.If iff -> {
+                scanExpression(st, iff.cond);
+                scanBlock(st, iff.thenBlock);
+                scanBlock(st, iff.elseBlock);
+            }
+            case CoreModel.Match match -> {
+                scanExpression(st, match.expr);
+                if (match.cases != null) {
+                    for (CoreModel.Case c : match.cases) {
+                        // Java Case.body 是 Stmt（可能是 Return / Block / 其它语句）。
+                        scanStatement(st, c.body);
+                    }
+                }
+            }
+            case CoreModel.Scope scope -> {
+                if (scope.statements != null) {
+                    for (CoreModel.Stmt s : scope.statements) {
+                        scanStatement(st, s);
+                    }
+                }
+            }
+            case CoreModel.Block block -> scanBlock(st, block);
+            case CoreModel.Let let -> scanExpression(st, let.expr);
+            case CoreModel.Set set -> scanExpression(st, set.expr);
+            case CoreModel.Return ret -> scanExpression(st, ret.expr);
+        }
+    }
+
+    private static void scanExpression(ScanState st, CoreModel.Expr expr) {
+        if (expr == null) {
+            return;
+        }
+        switch (expr) {
+            case CoreModel.Await await -> {
+                emit(st, FeatureId.WORKFLOW, await.origin, "Await");
+                scanExpression(st, await.expr);
+            }
+            case CoreModel.Call call -> {
+                scanExpression(st, call.target);
+                if (call.args != null) {
+                    for (CoreModel.Expr a : call.args) {
+                        scanExpression(st, a);
+                    }
+                }
+            }
+            case CoreModel.Construct ctor -> {
+                if (ctor.fields != null) {
+                    for (CoreModel.FieldInit f : ctor.fields) {
+                        scanExpression(st, f.expr);
+                    }
+                }
+            }
+            case CoreModel.Ok ok -> scanExpression(st, ok.expr);
+            case CoreModel.Err err -> scanExpression(st, err.expr);
+            case CoreModel.Some some -> scanExpression(st, some.expr);
+            case CoreModel.Lambda lam -> {
+                // Lambda 参数/返回类型可能含 PiiType。
+                if (lam.params != null) {
+                    for (CoreModel.Param p : lam.params) {
+                        scanType(st, p.type);
+                    }
+                }
+                scanType(st, lam.ret);
+                scanBlock(st, lam.body);
+            }
+            case CoreModel.IfE ife -> {
+                scanExpression(st, ife.cond);
+                scanExpression(st, ife.thenE);
+                scanExpression(st, ife.elseE);
+            }
+            case CoreModel.ListE lit -> {
+                if (lit.elements != null) {
+                    for (CoreModel.Expr el : lit.elements) {
+                        scanExpression(st, el);
+                    }
+                }
+            }
+            // 叶子表达式（Name/Bool/IntE/StringE/NullE/NoneE/Err 等）无子节点或无 Experimental 信号。
+            default -> {
+            }
+        }
+    }
+}

--- a/src/test/java/aster/core/stability/StabilityGateParityTest.java
+++ b/src/test/java/aster/core/stability/StabilityGateParityTest.java
@@ -1,0 +1,159 @@
+package aster.core.stability;
+
+import aster.core.canonicalizer.Canonicalizer;
+import aster.core.ir.CoreModel;
+import aster.core.lowering.CoreLowering;
+import aster.core.parser.AstBuilder;
+import aster.core.parser.AsterCustomLexer;
+import aster.core.parser.AsterParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * TS↔Java StabilityGate parity gate（P0-C，ADR 0031 M1 exit 硬门）。
+ *
+ * <p>共享 fixture {@code stability-gate-fixtures.json} 由 aster-lang-ts 的 TS 参考实现
+ * （{@code src/stability/stability_gate.ts}，18 测）生成，含每个 {@code .aster} 源码 +
+ * 期望 featureId multiset + nodeKind multiset。本测试把同一源码经 Java 完整管线
+ * （Canonicalize → ANTLR → AstBuilder → CoreLowering）lower 到 CoreModel，跑 Java
+ * {@link StabilityGate}，断言产出的 featureId/nodeKind 集与 fixture 一致 —— 证明两引擎
+ * 对同一源码检出同一组 Experimental 特性（Experimental 边界跨引擎一致，才是可信门禁）。
+ */
+@DisplayName("StabilityGate TS↔Java parity")
+class StabilityGateParityTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    record Fixture(String name, String src, List<String> features, List<String> nodeKinds) {}
+
+    static Stream<Fixture> fixtures() throws Exception {
+        try (InputStream in = StabilityGateParityTest.class.getResourceAsStream(
+                "/stability/stability-gate-fixtures.json")) {
+            assertNotNull(in, "共享 fixture 缺失: /stability/stability-gate-fixtures.json");
+            JsonNode root = MAPPER.readTree(in);
+            assertEquals("stability-gate/v1", root.get("version").asText());
+            List<Fixture> out = new ArrayList<>();
+            for (JsonNode c : root.get("cases")) {
+                out.add(new Fixture(
+                        c.get("name").asText(),
+                        c.get("src").asText(),
+                        jsonArrayToSortedList(c.get("features")),
+                        jsonArrayToSortedList(c.get("nodeKinds"))));
+            }
+            return out.stream();
+        }
+    }
+
+    private static List<String> jsonArrayToSortedList(JsonNode arr) {
+        List<String> out = new ArrayList<>();
+        arr.forEach(n -> out.add(n.asText()));
+        Collections.sort(out);
+        return out;
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fixtures")
+    @DisplayName("Java StabilityGate 检出的 feature/nodeKind 集与 TS fixture 一致")
+    void javaMatchesTsFixture(Fixture f) {
+        CoreModel.Module core = compileToCore(f.src());
+        List<StabilityGate.Diagnostic> diags = StabilityGate.scan(core, StabilityGate.Options.warnMode());
+
+        List<String> features = new ArrayList<>();
+        List<String> nodeKinds = new ArrayList<>();
+        for (StabilityGate.Diagnostic d : diags) {
+            features.add(d.featureId().id());
+            nodeKinds.add(d.nodeKind());
+        }
+        Collections.sort(features);
+        Collections.sort(nodeKinds);
+
+        assertEquals(f.features(), features,
+                "featureId 集不一致（TS vs Java）用例=" + f.name());
+        assertEquals(f.nodeKinds(), nodeKinds,
+                "nodeKind 集不一致（TS vs Java）用例=" + f.name());
+    }
+
+    @Test
+    @DisplayName("fixture 非空（防 corpus 删除后假通过）")
+    void fixtureNotEmpty() throws Exception {
+        long n = fixtures().count();
+        assertTrue(n >= 8, "fixture 用例数异常偏少(" + n + ")");
+    }
+
+    @Test
+    @DisplayName("strict 语义：severity 恒 warning，strict 走 blocking")
+    void strictSemantics() {
+        CoreModel.Module core = compileToCore("""
+                Module test.strict.
+
+                @deprecated
+                Rule oldRule, produce Text:
+                  Return "x".
+                """);
+        List<StabilityGate.Diagnostic> warn = StabilityGate.scan(core, StabilityGate.Options.warnMode());
+        List<StabilityGate.Diagnostic> strict = StabilityGate.scan(core, StabilityGate.Options.strictMode());
+
+        assertTrue(warn.stream().allMatch(d -> "warning".equals(d.severity())));
+        assertTrue(strict.stream().allMatch(d -> "warning".equals(d.severity())), "strict 也是 warning severity");
+        assertTrue(strict.stream().allMatch(StabilityGate.Diagnostic::blocking), "strict 时 blocking=true");
+        assertTrue(warn.stream().noneMatch(StabilityGate.Diagnostic::blocking), "warn 时 blocking=false");
+        assertTrue(StabilityGate.shouldReject(strict, true));
+        assertEquals(false, StabilityGate.shouldReject(strict, false));
+        assertEquals(false, StabilityGate.shouldReject(List.of(), true));
+    }
+
+    @Test
+    @DisplayName("allowExperimental=true 返回空")
+    void allowExperimental() {
+        CoreModel.Module core = compileToCore("""
+                Module test.allow.
+
+                @deprecated
+                Rule oldRule, produce Text:
+                  Return "x".
+                """);
+        List<StabilityGate.Diagnostic> diags = StabilityGate.scan(core, new StabilityGate.Options(true, true));
+        assertTrue(diags.isEmpty(), "allowExperimental 应返回空");
+    }
+
+    /** Java 完整编译管线：源码 → CoreModel（Canonicalize → ANTLR → AstBuilder → CoreLowering）。 */
+    private static CoreModel.Module compileToCore(String source) {
+        String canonicalized = new Canonicalizer().canonicalize(source);
+        var charStream = CharStreams.fromString(canonicalized);
+        var lexer = new AsterCustomLexer(charStream);
+        var tokens = new CommonTokenStream(lexer);
+        var parser = new AsterParser(tokens);
+        parser.removeErrorListeners();
+        parser.addErrorListener(new FailFastErrorListener());
+        AsterParser.ModuleContext moduleCtx = parser.module();
+        aster.core.ast.Module ast = new AstBuilder().visitModule(moduleCtx);
+        return new CoreLowering().lowerModule(ast);
+    }
+
+    private static final class FailFastErrorListener extends BaseErrorListener {
+        @Override
+        public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol,
+                                int line, int charPositionInLine, String msg, RecognitionException e) {
+            throw new IllegalStateException("解析错误 @" + line + ":" + charPositionInLine + " " + msg);
+        }
+    }
+}

--- a/src/test/resources/stability/stability-gate-fixtures.json
+++ b/src/test/resources/stability/stability-gate-fixtures.json
@@ -1,0 +1,127 @@
+{
+  "version": "stability-gate/v1",
+  "cases": [
+    {
+      "name": "workflow",
+      "src": "Module test.wf.\n\nRule process, produce Text:\n  Start task as async fetch().\n  Wait for task.\n  Return \"done\".\n",
+      "features": [
+        "workflow",
+        "workflow"
+      ],
+      "nodeKinds": [
+        "Start",
+        "Wait"
+      ]
+    },
+    {
+      "name": "version-import",
+      "src": "Module test.vi.\n\nUse risk.Scoring version 2 as Score.\nUse Http as H.\n\nRule greet, produce Text:\n  Return \"hi\".\n",
+      "features": [
+        "version-import"
+      ],
+      "nodeKinds": [
+        "Import"
+      ]
+    },
+    {
+      "name": "effect-capabilities",
+      "src": "Module test.eff.\n\nRule fetch, produce Text. It performs io [Http]:\n  Return Http.get(\"/x\").\n",
+      "features": [
+        "effect-capabilities"
+      ],
+      "nodeKinds": [
+        "Func"
+      ]
+    },
+    {
+      "name": "pii",
+      "src": "Module test.pii.\n\nRule secure given field as @pii(L2, email) Text, produce Text:\n  Return field.\n",
+      "features": [
+        "pii"
+      ],
+      "nodeKinds": [
+        "PiiType"
+      ]
+    },
+    {
+      "name": "pii-nested-list",
+      "src": "Module test.pii_nested.\n\nRule collect given items as List of @pii(L2, email) Text, produce Text:\n  Return \"ok\".\n",
+      "features": [
+        "pii"
+      ],
+      "nodeKinds": [
+        "PiiType"
+      ]
+    },
+    {
+      "name": "deprecated-annotation",
+      "src": "Module test.anno.\n\n@deprecated\nRule oldRule, produce Text:\n  Return \"x\".\n",
+      "features": [
+        "deprecated-annotation"
+      ],
+      "nodeKinds": [
+        "Annotation"
+      ]
+    },
+    {
+      "name": "example-annotation",
+      "src": "Module test.anno2.\n\n@example\nRule demo, produce Text:\n  Return \"x\".\n",
+      "features": [
+        "deprecated-annotation"
+      ],
+      "nodeKinds": [
+        "Annotation"
+      ]
+    },
+    {
+      "name": "nested-workflow-in-if",
+      "src": "Module test.nested_wf.\n\nRule process given flag as Bool, produce Text:\n  If flag:\n    Start task as async fetch().\n    Return \"async\".\n  Otherwise:\n    Return \"sync\".\n",
+      "features": [
+        "workflow"
+      ],
+      "nodeKinds": [
+        "Start"
+      ]
+    },
+    {
+      "name": "stable-bare-io",
+      "src": "Module test.stable_io.\n\nRule fetch, produce Text. It performs io:\n  Return Http.get(\"/x\").\n",
+      "features": [],
+      "nodeKinds": []
+    },
+    {
+      "name": "stable-entry",
+      "src": "Module test.stable_entry.\n\n@entry\nRule main, produce Text:\n  Return \"x\".\n",
+      "features": [],
+      "nodeKinds": []
+    },
+    {
+      "name": "stable-plain",
+      "src": "Module test.pure_stable.\n\nRule greet given name as Text, produce Text. It performs io:\n  Return name.\n",
+      "features": [],
+      "nodeKinds": []
+    },
+    {
+      "name": "pii-return-type",
+      "src": "Module test.ret_pii.\n\nRule getEmail, produce @pii(L2, email) Text:\n  Return \"user@example.com\".\n",
+      "features": [
+        "pii"
+      ],
+      "nodeKinds": [
+        "PiiType"
+      ]
+    },
+    {
+      "name": "pii-param-and-return",
+      "src": "Module test.pii_both.\n\nRule process given raw as @pii(L1, name) Text, produce @pii(L2, email) Text:\n  Return raw.\n",
+      "features": [
+        "pii",
+        "pii"
+      ],
+      "nodeKinds": [
+        "PiiType",
+        "PiiType"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 背景
P0-C 编译器强制 Stable/Experimental 边界的**双引擎权威侧**。配对 aster-lang-ts#73（TS 侧）。Java 须与 TS 对同一源码检出**同一组 Experimental 特性**（featureId + nodeKind 集），否则 Experimental 边界跨引擎不一致，门禁不可信。

## 机制
共享 fixture（13 `.aster` 源 + 期望 featureId/nodeKind 集，TS 生成）。`StabilityGateParityTest` 把同源码经 Java 完整管线（Canonicalize→ANTLR→AstBuilder→CoreLowering）lower 到 CoreModel，跑 Java StabilityGate，断言 featureId+nodeKind 多重集与 fixture 一致。TS 侧断言 TS 产出 == 同一 fixture。**传递 TS==Java**。负向证明：禁 Java effectCapsExplicit 检测 → 1 fail（门真守）。

## 实现（显式 sealed switch，与 TS DefaultCoreVisitor 对齐，非反射）
5 类检测 + childTypes 字段名实证对齐 Java CoreModel。Java 差异处理：`piiLevel` 默认 `""`（非 null）→兜底 `!isEmpty()`；Expr 是 `IfE`/`ListE`（非 TS IfExpr/ListLit）；`Case.body` 是 `Stmt`。

## ★Codex 三轮审 86→93 抓 Java≠TS 分歧
- **Start.expr 未递归**（TS super 递归，Java 漏内嵌 Await）→ 补 `scanExpression(start.expr)`
- **retAnnotations @deprecated Java-only 误报**（TS 无 retAnnotations）→ 删，严格镜像；`@pii` 返回值走 `ret` PiiType 不受影响
- 补 fixture 锁 return PII + multi-PiiType multiset 数量

## 验证
**16 parity 测全绿**（13 用例 + strict/allow/非空）。Codex 93/100 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)