### PR TITLE
feat(canonical): CanonicalJson.canonicalWithHash → {canonical, hash}（M2 回放 payload）

### DIFF
--- a/src/main/java/aster/core/canonical/CanonicalJson.java
+++ b/src/main/java/aster/core/canonical/CanonicalJson.java
@@ -127,7 +127,34 @@ public final class CanonicalJson {
      * 与 TS canonicalHash 同算法同前缀 → 同输入产同 hash。
      */
     public static String canonicalHash(JsonNode value, TypeContext ctx) {
+        return hashCanonical(canonicalJson(value, ctx));
+    }
+
+    public static String canonicalHash(JsonNode value) {
+        return canonicalHash(value, TypeContext.empty());
+    }
+
+    /**
+     * canonical 字符串 + 其 hash 的配对（M2 回放 payload）。一次序列化同时拿到 canonical 串与其 hash，
+     * 避免 canonicalJson + canonicalHash 各序列化一次的重复开销。
+     *
+     * <p>返回的 {@link #canonical} 就是被 hash 的那个串（{@code hash == sha256(version + "\n" + canonical)}）——
+     * cloud 收到后 <b>直接 re-hash 校验即可，无需 re-canonicalize</b>（绕开 liftDecimals 的 TS↔Java parity gap，
+     * 见 docs/m2-replay-payload-contract.md）。
+     */
+    public record CanonicalPair(String canonical, String hash) {}
+
+    public static CanonicalPair canonicalWithHash(JsonNode value, TypeContext ctx) {
         String canonical = canonicalJson(value, ctx);
+        return new CanonicalPair(canonical, hashCanonical(canonical));
+    }
+
+    public static CanonicalPair canonicalWithHash(JsonNode value) {
+        return canonicalWithHash(value, TypeContext.empty());
+    }
+
+    /** 对已 canonical 化的字符串算 hash（sha256(version + "\n" + canonical)，hex）。单一构造点。 */
+    private static String hashCanonical(String canonical) {
         String payload = CANONICALIZATION_VERSION + "\n" + canonical;
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-256");
@@ -136,10 +163,6 @@ public final class CanonicalJson {
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("SHA-256 不可用", e);
         }
-    }
-
-    public static String canonicalHash(JsonNode value) {
-        return canonicalHash(value, TypeContext.empty());
     }
 
     private static void write(JsonNode node, String path, TypeContext ctx, StringBuilder sb) {

--- a/src/test/java/aster/core/canonical/CanonicalWithHashTest.java
+++ b/src/test/java/aster/core/canonical/CanonicalWithHashTest.java
@@ -1,0 +1,48 @@
+package aster.core.canonical;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * CanonicalJson.canonicalWithHash 单元测试（M2 回放 payload）：
+ * 一次序列化同时拿 canonical 串 + hash，二者必须与分别调用 canonicalJson / canonicalHash 完全一致，
+ * 且 hash(串) == 返回的 hash（cloud 直接 re-hash 校验的前提）。
+ */
+class CanonicalWithHashTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    @DisplayName("canonicalWithHash 的串 == canonicalJson，hash == canonicalHash（一次序列化等价两次）")
+    void pairEqualsSeparateCalls() throws Exception {
+        var node = MAPPER.readTree("{\"b\":2,\"a\":1,\"nested\":{\"z\":true}}");
+        var ctx = CanonicalJson.TypeContext.empty();
+
+        CanonicalJson.CanonicalPair pair = CanonicalJson.canonicalWithHash(node, ctx);
+
+        assertEquals(CanonicalJson.canonicalJson(node, ctx), pair.canonical(),
+                "pair.canonical 必须与 canonicalJson 逐字节一致");
+        assertEquals(CanonicalJson.canonicalHash(node, ctx), pair.hash(),
+                "pair.hash 必须与 canonicalHash 一致");
+    }
+
+    @Test
+    @DisplayName("★hash(返回串) == 返回 hash（cloud 侧 sha256(version+\\n+串) 校验的核心契约）")
+    void hashOfReturnedStringMatchesReturnedHash() throws Exception {
+        var node = MAPPER.readTree("[1,\"two\",{\"k\":null}]");
+        CanonicalJson.CanonicalPair pair = CanonicalJson.canonicalWithHash(node);
+
+        String recomputed = sha256Hex(CanonicalJson.CANONICALIZATION_VERSION + "\n" + pair.canonical());
+        assertEquals(pair.hash(), recomputed,
+                "对返回的 canonical 串直接 sha256(version+\\n+串) 必须等于返回的 hash——cloud 不 re-canonicalize 也能校验");
+    }
+
+    private static String sha256Hex(String s) throws Exception {
+        byte[] d = java.security.MessageDigest.getInstance("SHA-256")
+                .digest(s.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        return java.util.HexFormat.of().formatHex(d);
+    }
+}


### PR DESCRIPTION
## 背景
M2 真回放需 aster-api 返回完整 canonical **串**（非只哈希），cloud 加密持久化后可解密重跑复现历史决策。`canonicalJson` 早已产出被 hash 的那个 canonical 串，但 `canonicalHash` 算完就丢弃了它。

## 改动
- 新增 `record CanonicalPair(String canonical, String hash)` + `canonicalWithHash(node, ctx)`：一次序列化同时拿串+哈希，避免 `canonicalJson` + `canonicalHash` 各序列化一次。
- 抽私有 `hashCanonical(String)` 单一 hash 构造点；`canonicalHash` 复用它——**行为不变**（parity 测试全绿）。

## ★关键契约
返回的 `canonical` 就是被 hash 的那个串（`hash == sha256(CANONICALIZATION_VERSION + "\n" + canonical)`）。cloud 收到后**直接 re-hash 校验即可，无需 re-canonicalize**——绕开 `liftDecimals` 的 TS↔Java parity gap（见 aster-api `docs/m2-replay-payload-contract.md`）。

## 验证
- `compileJava` 绿；`CanonicalJsonParityTest` 全绿（hash 行为未变）
- 新增 `CanonicalWithHashTest`：`pair.canonical==canonicalJson`、`pair.hash==canonicalHash`、`hash(返回串)==返回hash`
- **Codex 交叉审查 88**（正确性/parity 论证通过）

> 下游：aster-api PR `feat/m2-replay-payload-fields` 依赖此方法，需本 PR 先合并 + core 发版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)