### PR TITLE
chore: pin platform catalog 1.0.14→1.0.15（M2.1a 发版）

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.14")
+            from("cloud.aster-lang:aster-lang-platform:1.0.15")
         }
     }
 }


### PR DESCRIPTION
配合 aster-lang-platform bump（生态 1.0.14→1.0.15，asterLang 1.0.12→1.0.13）——见 platform PR #40。pin-consistency gate 要求本仓 platform pin==platformVersion，故随 platform 一并合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)