### PR TITLE
fix(release): publish 步 build -x test，解 core:test→hi 发版死锁

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,8 +152,13 @@ jobs:
       - name: Publish test corpus locally
         run: cd aster-lang-test/packages/jvm && ./gradlew publishToMavenLocal
 
-      - name: Build & Test
-        run: ./gradlew build
+      # 发布时只 assemble 制品，**不跑 test**（-x test）。原因：core:test 有 testRuntimeOnly(hi) +
+      # langPacks(hi) 的**前向依赖**——hi 在 release-train DAG 里晚于 core 一层（hi impl(core)），
+      # lockstep bump 后 core:test 会要 hi:<新版>，而该版本此刻尚未发布 → 解析 401，卡住级联。
+      # 测试已在 PR CI 阶段跑过（发布前门），发布步骤无须重测。与上面依赖 publishToMavenLocal 步骤
+      # 已用的 -x test 一致。
+      - name: Build (assemble only, tests ran in PR CI)
+        run: ./gradlew build -x test
 
       - name: Publish to GitHub Packages
         run: ./gradlew publish


### PR DESCRIPTION
M2.1a lockstep 发版 Layer 1(core) 卡住：release.yml Build & Test 跑全测，core:test 前向依赖 hi:<新版>（hi 在 DAG 晚 core 一层），未发布→401。改 `build -x test`（测试已在 PR CI 门跑过）。★绕过非根治，循环仍在（tech-debt 已记 commit）。Codex 审 82，实证 build -x test 无 hi 时 SUCCESSFUL。

🤖 Generated with [Claude Code](https://claude.com/claude-code)