### PR TITLE
fix(capability): Crypto 归 cpu-class（对齐 TS）

### DIFF
--- a/src/main/java/aster/core/capability/CapabilityKind.java
+++ b/src/main/java/aster/core/capability/CapabilityKind.java
@@ -9,25 +9,41 @@ import java.util.Optional;
  * 该枚举与 TypeScript 端保持一致，便于后续在 effectCaps 字段中序列化。
  */
 public enum CapabilityKind {
-  HTTP("Http"),
+  HTTP("Http", EffectClass.IO),
   // 与 TS 端 capability taxonomy 对齐（shared/capabilities.json 单源）：
   // NETWORK/CRYPTO/PROCESS 为 TS 后加（commit 063ff6d），Java 补齐消除双引擎枚举 drift。
-  NETWORK("Network"),
-  SQL("Sql"),
-  TIME("Time"),
-  FILES("Files"),
-  SECRETS("Secrets"),
-  CRYPTO("Crypto"),
-  PROCESS("Process"),
-  AI_MODEL("AiModel"),
-  CPU("Cpu"),
-  PAYMENT("Payment"),
-  INVENTORY("Inventory");
+  NETWORK("Network", EffectClass.IO),
+  SQL("Sql", EffectClass.IO),
+  TIME("Time", EffectClass.IO),
+  FILES("Files", EffectClass.IO),
+  SECRETS("Secrets", EffectClass.IO),
+  // CRYPTO 是 cpu-class：本地哈希/签名/加密常为 CPU 密集（与 TS CAPABILITY_EFFECT_CLASS 对齐）；
+  // 远程 KMS 应额外用 Network/Secrets 或显式 IO 表达。缺声明报 MISSING_CPU 非 MISSING_IO。
+  CRYPTO("Crypto", EffectClass.CPU),
+  PROCESS("Process", EffectClass.IO),
+  AI_MODEL("AiModel", EffectClass.IO),
+  CPU("Cpu", EffectClass.CPU),
+  PAYMENT("Payment", EffectClass.IO),
+  INVENTORY("Inventory", EffectClass.IO);
+
+  /**
+   * Capability 的 effect 分类，是 capability taxonomy 的一部分（单源 shared/capabilities.json
+   * 的 class 字段），由 CapabilityParityTest 守门。放进枚举而非 CapabilityChecker 局部 set，
+   * 避免 workflow/manifest/runtime 等多处需要分类时各自复制导致 drift。
+   */
+  public enum EffectClass {
+    /** 外部交互，需 @io。 */
+    IO,
+    /** 本地计算密集，需 @cpu 或 @io（如 CRYPTO 本地密码学）。 */
+    CPU
+  }
 
   private final String displayName;
+  private final EffectClass effectClass;
 
-  CapabilityKind(String displayName) {
+  CapabilityKind(String displayName, EffectClass effectClass) {
     this.displayName = displayName;
+    this.effectClass = effectClass;
   }
 
   /**
@@ -35,6 +51,21 @@ public enum CapabilityKind {
    */
   public String displayName() {
     return displayName;
+  }
+
+  /** capability 的 effect 分类（io/cpu）。 */
+  public EffectClass effectClass() {
+    return effectClass;
+  }
+
+  /** 是否 cpu-class（本地计算密集，需 @cpu 不强制 @io）。 */
+  public boolean isCpuClass() {
+    return effectClass == EffectClass.CPU;
+  }
+
+  /** 是否 io-class（外部交互，需 @io）。 */
+  public boolean isIoClass() {
+    return effectClass == EffectClass.IO;
   }
 
   /**

--- a/src/main/java/aster/core/typecheck/checkers/CapabilityChecker.java
+++ b/src/main/java/aster/core/typecheck/checkers/CapabilityChecker.java
@@ -75,9 +75,14 @@ public final class CapabilityChecker {
     var capabilities = collectCapabilities(func.body);
     checkDeclaredCapabilities(func, capabilities);
     if (!capabilities.isEmpty()) {
+      // capability 的 effect 分类走 CapabilityKind.effectClass 单源（shared/capabilities.json）：
+      // io-class 需 @io；cpu-class（CPU/CRYPTO，本地计算密集）需 @cpu 或 @io。与 TS 对齐。
       var ioCaps = new LinkedHashSet<CapabilityKind>();
+      var cpuCaps = new LinkedHashSet<CapabilityKind>();
       for (var cap : capabilities.keySet()) {
-        if (cap != CapabilityKind.CPU) {
+        if (cap.isCpuClass()) {
+          cpuCaps.add(cap);
+        } else {
           ioCaps.add(cap);
         }
       }
@@ -98,8 +103,8 @@ public final class CapabilityChecker {
         );
       }
 
-      if (capabilities.containsKey(CapabilityKind.CPU) && !(declaredEffects.contains("cpu") || declaredEffects.contains("io"))) {
-        var sampleCalls = summarizeCalls(capabilities, List.of(CapabilityKind.CPU));
+      if (!cpuCaps.isEmpty() && !(declaredEffects.contains("cpu") || declaredEffects.contains("io"))) {
+        var sampleCalls = summarizeCalls(capabilities, new java.util.ArrayList<>(cpuCaps));
         emit(
           ErrorCode.CAPABILITY_INFER_MISSING_CPU,
           func.origin,

--- a/src/test/java/aster/core/capability/CapabilityParityTest.java
+++ b/src/test/java/aster/core/capability/CapabilityParityTest.java
@@ -81,6 +81,38 @@ class CapabilityParityTest {
     }
 
     @Test
+    void effectClassMatchesJson() throws Exception {
+        // A3: capability 的 effect 分类（io/cpu）双引擎一致 —— Java effectClass() ↔ json class。
+        List<String> mismatches = new ArrayList<>();
+        var jsonCpuSet = new TreeSet<String>();
+        for (JsonNode c : loadCapabilities()) {
+            String enumName = c.get("enumName").asText();
+            String jsonClass = c.get("class").asText();
+            if ("cpu".equals(jsonClass)) {
+                jsonCpuSet.add(enumName);
+            }
+            CapabilityKind kind = CapabilityKind.valueOf(enumName);
+            String javaClass = kind.effectClass().name().toLowerCase();
+            if (!jsonClass.equals(javaClass)) {
+                mismatches.add(enumName + ".class: json=" + jsonClass + " java=" + javaClass);
+            }
+        }
+        assertTrue(mismatches.isEmpty(),
+                "effect class 与 json 不一致:\n" + String.join("\n", mismatches));
+
+        // 钉死 cpu-class 集合 = {CPU, CRYPTO}（本地计算密集），防未来 drift。
+        var expectedCpu = new TreeSet<>(java.util.Set.of("CPU", "CRYPTO"));
+        assertEquals(expectedCpu, jsonCpuSet, "json cpu-class 集合应为 {CPU, CRYPTO}");
+        var javaCpuSet = new TreeSet<String>();
+        for (CapabilityKind k : CapabilityKind.values()) {
+            if (k.isCpuClass()) {
+                javaCpuSet.add(k.name());
+            }
+        }
+        assertEquals(expectedCpu, javaCpuSet, "Java cpu-class 集合应为 {CPU, CRYPTO}");
+    }
+
+    @Test
     void fromLabelResolvesEveryDisplayName() throws Exception {
         List<String> failures = new ArrayList<>();
         for (JsonNode c : loadCapabilities()) {

--- a/src/test/java/aster/core/typecheck/checkers/CapabilityCheckerTest.java
+++ b/src/test/java/aster/core/typecheck/checkers/CapabilityCheckerTest.java
@@ -76,6 +76,50 @@ class CapabilityCheckerTest {
     assertEquals(ErrorCode.CAPABILITY_INFER_MISSING_IO, diagnostics.get(0).code());
   }
 
+  // ===== A3: Crypto 是 cpu-class（与 TS 对齐），缺声明报 MISSING_CPU 非 MISSING_IO =====
+
+  @Test
+  void cryptoHashReportsMissingCpuNotIo() {
+    // Hash.sha256（Crypto，cpu-class）无 effect → CAPABILITY_INFER_MISSING_CPU。
+    var func = createFunc("digest", List.of(), blockWithStatements(returnCall("Hash.sha256")));
+
+    var diagnostics = checker.checkModule(List.of(func));
+
+    assertEquals(1, diagnostics.size());
+    assertEquals(ErrorCode.CAPABILITY_INFER_MISSING_CPU, diagnostics.get(0).code());
+  }
+
+  @Test
+  void cryptoKmsReportsMissingCpuNotIo() {
+    // Kms.encrypt（Crypto，cpu-class）无 effect → MISSING_CPU（远程 KMS 应另加 Network/Secrets）。
+    var func = createFunc("encrypt", List.of(), blockWithStatements(returnCall("Kms.encrypt")));
+
+    var diagnostics = checker.checkModule(List.of(func));
+
+    assertEquals(1, diagnostics.size());
+    assertEquals(ErrorCode.CAPABILITY_INFER_MISSING_CPU, diagnostics.get(0).code());
+  }
+
+  @Test
+  void cryptoWithCpuEffectIsClean() {
+    // Crypto + 声明 cpu → 无诊断（cpu-class 需 @cpu 或 @io）。
+    var func = createFunc("digest", List.of("cpu"), blockWithStatements(returnCall("Hash.sha256")));
+
+    var diagnostics = checker.checkModule(List.of(func));
+
+    assertTrue(diagnostics.isEmpty());
+  }
+
+  @Test
+  void cryptoWithIoEffectIsClean() {
+    // Crypto + 声明 io → 无诊断（io 隐含可计算，覆盖 cpu-class）。
+    var func = createFunc("digest", List.of("io"), blockWithStatements(returnCall("Hash.sha256")));
+
+    var diagnostics = checker.checkModule(List.of(func));
+
+    assertTrue(diagnostics.isEmpty());
+  }
+
   @Test
   void checkModuleIgnoresNullBody() {
     var func = createFunc("noop", List.of(), null);

--- a/src/test/resources/capability/capabilities.json
+++ b/src/test/resources/capability/capabilities.json
@@ -1,64 +1,76 @@
 {
-  "$comment": "Capability 能力表单源真值 (双引擎共享契约, 类比 error_codes.json)。ts CapabilityKind (src/config/semantic.ts) 与 Java CapabilityKind (aster-lang-core/.../capability/CapabilityKind.java) 均以此为准, 由 parity 测试守门。displayName 为 CNL 表面名, prefixes 为调用前缀推断表 (CapabilityInference / CAPABILITY_PREFIXES)。注: capability 的 effect 分类 (io/cpu) 双引擎当前存在 drift (ts effects.ts CPU_CLASS 含 Crypto, Java CapabilityChecker 纯 cap!=CPU=>io), 待独立组 A3 统一后再纳入本单源, 本文件暂不固化 class 以免'看似单源实际漂移'。",
+  "$comment": "Capability 能力表单源真值 (双引擎共享契约, 类比 error_codes.json)。ts CapabilityKind (src/config/semantic.ts) 与 Java CapabilityKind (aster-lang-core/.../capability/CapabilityKind.java) 均以此为准, 由 parity 测试守门。displayName 为 CNL 表面名, prefixes 为调用前缀推断表 (CapabilityInference / CAPABILITY_PREFIXES)。class 为 effect 分类 (io/cpu): CPU/CRYPTO=cpu (本地密码学 CPU 密集, 需 @cpu 或 @io), 其余皆 io。双引擎按此统一分类 (ts CAPABILITY_EFFECT_CLASS + isCpuClassCapability, Java CapabilityKind.effectClass, A3 消除 ts effects.ts/workflow.ts 与 Java CapabilityChecker 的分类 drift)。",
   "capabilities": [
     {
       "enumName": "HTTP",
       "displayName": "Http",
+      "class": "io",
       "prefixes": ["Http."]
     },
     {
       "enumName": "NETWORK",
       "displayName": "Network",
+      "class": "io",
       "prefixes": ["Net.", "Network.", "Tcp.", "Udp.", "Socket.", "Ws.", "WebSocket.", "Sse."]
     },
     {
       "enumName": "SQL",
       "displayName": "Sql",
+      "class": "io",
       "prefixes": ["Db.", "Sql."]
     },
     {
       "enumName": "TIME",
       "displayName": "Time",
+      "class": "io",
       "prefixes": ["Time.", "Clock."]
     },
     {
       "enumName": "FILES",
       "displayName": "Files",
+      "class": "io",
       "prefixes": ["Files.", "Fs."]
     },
     {
       "enumName": "SECRETS",
       "displayName": "Secrets",
+      "class": "io",
       "prefixes": ["Secrets."]
     },
     {
       "enumName": "CRYPTO",
       "displayName": "Crypto",
+      "class": "cpu",
       "prefixes": ["Crypto.", "Hash.", "Cipher.", "Sign.", "Kms.", "Jwt."]
     },
     {
       "enumName": "PROCESS",
       "displayName": "Process",
+      "class": "io",
       "prefixes": ["Process.", "Proc.", "Exec.", "Shell.", "Env.", "Os."]
     },
     {
       "enumName": "AI_MODEL",
       "displayName": "AiModel",
+      "class": "io",
       "prefixes": ["Ai."]
     },
     {
       "enumName": "CPU",
       "displayName": "Cpu",
+      "class": "cpu",
       "prefixes": []
     },
     {
       "enumName": "PAYMENT",
       "displayName": "Payment",
+      "class": "io",
       "prefixes": ["Payment."]
     },
     {
       "enumName": "INVENTORY",
       "displayName": "Inventory",
+      "class": "io",
       "prefixes": ["Inventory."]
     }
   ]


### PR DESCRIPTION
配合 aster-lang-ts A3（capability effect class drift）。**原 #69 因组 A base 分支删除被自动关闭，本 PR 重建（rebase 到 main）**。

CapabilityKind 加 nested `EffectClass{IO,CPU}`（CRYPTO/CPU=CPU 其余 IO）；CapabilityChecker `cap!=CPU` 改 `isCpuClass()`（Crypto MISSING_IO→MISSING_CPU）；CapabilityParityTest 加 effectClass↔json class 断言。本地实测: CapabilityParity 7 + CapabilityChecker 17 全绿。Codex 审 94。truffle 无 capability class 分类无需改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)