### PR TITLE
build(p0a): jar MANIFEST stamp Implementation-Version（S0：core=dev→真值）

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -236,6 +236,17 @@ application {
 // （两份 source 内容一致：都从 src/main/resources/ 复制而来）。
 tasks.jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    // ★S0 / m1.5 层1：把 catalog 派生的引擎版本写进 jar MANIFEST 的 Implementation-Version，
+    // 供 aster-api ToolchainIdentityProvider.coreEngineVersion()（读 Canonicalizer 包 ImplementationVersion）
+    // 拿到真值。原本 jar 无此属性 → 各消费路径（本地/CI/发布产物/部署 fast-jar）恒读 null → toolchainId
+    // 的 core= 段退化 "dev"。此处一处修复覆盖全部路径（版本单源=catalog，见上 version 派生）。
+    manifest {
+        attributes(
+            "Implementation-Title" to "aster-lang-core",
+            "Implementation-Version" to project.version.toString(),
+            "Implementation-Vendor" to "cloud.aster-lang"
+        )
+    }
 }
 
 // 语言包配置（exportLexicons 任务需要通过 SPI 发现语言包）


### PR DESCRIPTION
## 背景

aster-api `ToolchainIdentityProvider.coreEngineVersion()` 读 `Canonicalizer` 包的 `Implementation-Version` 决定 toolchainId 的 `core=` 段。原本 core 的 `jar` 任务**从不设 manifest 属性** → 各消费路径（本地 / CI / 发布产物 / 部署 fast-jar）恒读 `null` → `core=` 退化 `dev`，丢失引擎版本信息（回放地基缺一维）。

★根因是 `jar` 任务缺 manifest，**非** composite 源码模式——发布到 GitHub Packages 的产物 MANIFEST 同样只有 `Manifest-Version`。

## 改动

`tasks.jar` 加 `manifest { attributes("Implementation-Version" to project.version.toString(), ...) }`。版本源 = catalog 派生的 `project.version`（单源，与 Maven 坐标一致）。一处修复覆盖全部消费路径。

## 验证（本地实测）

- `./gradlew jar` → `aster-lang-core-1.0.14.jar` MANIFEST 含 `Implementation-Version: 1.0.14`（原仅 `Manifest-Version: 1.0`）
- aster-api `quarkusBuild` → bundled `cloud.aster-lang.aster-lang-core-1.0.14.jar` 同样含 `1.0.14`
- 直接跑 `Canonicalizer.class.getPackage().getImplementationVersion()`（provider 的确切读取逻辑）→ **`1.0.14`**（非 dev）
- `./gradlew properties` → `version: 1.0.14`（jar 配置时点已解析，非 unspecified）

## 配套

aster-api 侧 PR（同 S0）：Part 1 toolchain 身份串单源化 + Part 2 build=dev→真值（镜像 ENV 烘 github.sha）+ `ToolchainIdentityProviderTest`（含断言 `core != dev`，联动本 PR）。

## 范围外（诚实标注）

- **native image 路径**（非当前部署路径，deploy 用 `Dockerfile.jvm` fast-jar）若日后启用，需在 aster-api 额外注册 `META-INF/MANIFEST.MF` 为 native resource，否则 native 下仍读 `null`。
- **不解锁签字**：`core` 真值是信任层1（可观测），`isSignablePass` 仍恒 false（层3 runtime provenance 待 m1.5）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)