### PR TITLE
chore(gradle): wrapper → 9.6.1（生态统一）

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,9 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
+retries=0
+retryBackOffMs=500
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## chore(gradle): wrapper 统一到 9.6.1

技术债扫描发现生态 Gradle wrapper 漂移:aster-api 已在 **9.6.1**(Dependabot 驱动),其余仓落后——platform/core/truffle/hi=9.5.1、locales=9.4.0。本 PR 把本仓拉齐到 9.6.1,消除工具链漂移([[toolchain-consistency]] 类债)。

- `./gradlew wrapper --gradle-version 9.6.1` 正规升级(regen properties)。
- 验证:`gradlew --version`=9.6.1、本仓 build/parity gate 绿。

纯 wrapper bump,无源码改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)