### PR TITLE
docs: 补齐开源治理文件（SECURITY / COC / CONTRIBUTING）

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# 行为准则 · Code of Conduct
+
+本项目采用 [Contributor Covenant](https://www.contributor-covenant.org) v2.1 作为社区行为准则。
+
+This project adopts the [Contributor Covenant](https://www.contributor-covenant.org)
+v2.1 as its community Code of Conduct.
+
+## 我们的承诺 · Our Pledge
+
+为营造开放、友好的环境，我们承诺让每个人参与项目和社区的体验不受骚扰，无论其年龄、
+体型、可见或不可见的残障、族裔、性别认同与表达、经验水平、教育程度、社会经济地位、
+国籍、外貌、种族、宗教或性取向。
+
+We pledge to make participation in our community a harassment-free experience for
+everyone, regardless of age, body size, visible or invisible disability, ethnicity,
+gender identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## 我们的准则 · Our Standards
+
+有助于营造积极环境的行为包括：表达善意与同理、尊重不同观点、优雅地接受建设性批评、
+以社区整体利益为重。
+
+不可接受的行为包括：性化的言语或图像、挑衅与人身/政治攻击、公开或私下骚扰、未经许可
+发布他人隐私信息，以及任何在专业场合下明显不当的行为。
+
+Examples of positive behavior include showing empathy and kindness, respecting
+differing opinions, gracefully accepting constructive feedback, and focusing on what
+is best for the community. Unacceptable behavior includes sexualized language or
+imagery, trolling, insulting or derogatory comments, personal or political attacks,
+public or private harassment, and publishing others' private information without
+permission.
+
+## 执行 · Enforcement
+
+违规行为可通过本仓库 **Security** 标签页的私密报告，或联系项目维护者举报。所有投诉都会
+被及时、公正地审查与处理。
+
+Instances of unacceptable behavior may be reported to the project maintainers via the
+repository's **Security** tab (private report) or by contacting the maintainers. All
+complaints will be reviewed and investigated promptly and fairly.
+
+完整条款见 [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)。
+Full text at [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# 贡献指南 · Contributing to aster-lang-core
+
+感谢你有意为 Aster 语言核心编译器贡献力量！
+
+Thanks for your interest in contributing to the Aster core compiler.
+
+## 开始之前 · Before You Start
+
+- 阅读 [README](README.md) 了解编译管线与核心模块。
+- 遵守 [行为准则](CODE_OF_CONDUCT.md)。
+- 安全问题请走 [SECURITY.md](SECURITY.md)（**不要**开公开 issue）。
+
+## 环境 · Prerequisites
+
+见 README 的「环境要求」一节（JDK 版本、Gradle）。本仓被 `aster-lang-truffle`、
+`aster-lang-runtime` 等依赖；跨仓构建时需先把本仓发布到 mavenLocal（`./gradlew publishToMavenLocal`）。
+
+## 本地验证 · Local Verification
+
+```bash
+./gradlew build              # 构建
+./gradlew test               # 单元测试
+./gradlew goldenTest         # 黄金测试（Java ↔ TypeScript 编译器输出对比）
+```
+
+改动**必须**在本地跑通 `build` + `test` + `goldenTest` 后再提 PR。改到跨引擎行为时
+（词法/语法/IR），`goldenTest` 是 parity 的硬门槛——双引擎输出必须一致。
+
+## 提交流程 · Pull Request Flow
+
+1. 从 `main` 切分支（`fix/…`、`feat/…`、`docs/…`）。
+2. 小步提交，保持每次可编译。
+3. 提交信息用祈使语气，说明「做了什么 + 为什么」。
+4. PR 描述里附本地验证结果（哪些命令跑过、结果如何）。
+5. 等 CI 全绿（`.github/workflows/`）后再请求合并。
+
+## 代码风格 · Code Style
+
+沿用仓内既有风格（导入顺序、命名、格式化）。新实现前先找 2–3 处相似实现参照，复用既有
+模式与工具函数，不要另起炉灶。
+
+## 许可证 · License
+
+贡献即表示你同意你的贡献按本仓 [LICENSE](LICENSE)（Apache-2.0）授权。
+
+By contributing, you agree that your contributions are licensed under the repository's
+[LICENSE](LICENSE) (Apache-2.0).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# 安全策略 · Security Policy
+
+## 报告漏洞 · Reporting a Vulnerability
+
+请**不要**通过公开 issue 报告安全漏洞。
+
+请使用 GitHub 的**私密漏洞报告**（Private Vulnerability Reporting）：
+
+1. 打开本仓库的 **Security** 标签页；
+2. 点击 **Report a vulnerability**；
+3. 填写漏洞详情（复现步骤、影响范围、受影响版本）。
+
+我们会在 **5 个工作日内**确认收到，并在评估后与你协调修复与披露时间线。
+
+---
+
+Please do **not** report security vulnerabilities through public issues.
+
+Use GitHub's **Private Vulnerability Reporting**:
+
+1. Go to the **Security** tab of this repository;
+2. Click **Report a vulnerability**;
+3. Provide details (reproduction steps, impact, affected versions).
+
+We aim to acknowledge reports within **5 business days** and will coordinate a fix
+and disclosure timeline after assessment.
+
+## 受支持的版本 · Supported Versions
+
+安全修复针对**最新的已发布版本**。旧版本请先升级到最新版。
+
+Security fixes target the **latest released version**. Please upgrade to the latest
+release before reporting against older versions.


### PR DESCRIPTION
## 概述
补齐开源发布标配的治理文件（此前缺失）。

- **SECURITY.md** — 漏洞上报走 GitHub Private Vulnerability Reporting。
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1，中英双语。
- **CONTRIBUTING.md** — 真实构建命令（gradle build/test/goldenTest）+ PR 流程 + 跨仓依赖提示。

纯新增文档，无代码/CI 改动。生态其余开源仓同步补齐（逐仓独立 PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)