### PR TITLE
fix(capability): manifest 对 body 实际使用的能力生效（#84）

### DIFF
--- a/src/main/java/aster/core/typecheck/TypeChecker.java
+++ b/src/main/java/aster/core/typecheck/TypeChecker.java
@@ -115,6 +115,8 @@ public final class TypeChecker {
         .filter(CoreModel.Func.class::isInstance)
         .map(CoreModel.Func.class::cast)
         .toList();
+      // 模块名仅用于 CAPABILITY_NOT_ALLOWED 的消息文案（对齐 TS 的 {module} 参数）
+      capabilityChecker.setModuleName(module.name);
       baseDiagnostics.addAll(capabilityChecker.checkModule(funcs));
       // P0-1 (ADR-0009): PII flow 分析永远启用，不再依赖 env var。
       // 与 TypeScript 端 typecheckModule / typecheckBrowser 保持一致语义。

--- a/src/main/java/aster/core/typecheck/checkers/CapabilityChecker.java
+++ b/src/main/java/aster/core/typecheck/checkers/CapabilityChecker.java
@@ -28,9 +28,16 @@ public final class CapabilityChecker {
 
   private final List<Diagnostic> diagnostics = new ArrayList<>();
   private ManifestConfig manifest;
+  /** 当前模块名，仅用于 CAPABILITY_NOT_ALLOWED 的消息文案（与 TS 的 {module} 参数对齐）。 */
+  private String moduleName;
 
   public void setManifest(ManifestConfig manifest) {
     this.manifest = manifest;
+  }
+
+  /** 设置当前模块名（可选；未设置时消息中的模块字段为空串）。 */
+  public void setModuleName(String moduleName) {
+    this.moduleName = moduleName;
   }
 
   /**
@@ -119,7 +126,8 @@ public final class CapabilityChecker {
     }
 
     checkWorkflowConstraints(func, declaredEffects);
-    checkManifestConstraints(func);
+    // 复用上面已算好的 capabilities（body 实际用到的能力），避免二次遍历函数体。
+    checkManifestConstraints(func, capabilities);
   }
 
   private void checkDeclaredCapabilities(CoreModel.Func func, Map<CapabilityKind, List<String>> usedCaps) {
@@ -365,32 +373,49 @@ public final class CapabilityChecker {
     ));
   }
 
-  private void checkManifestConstraints(CoreModel.Func func) {
-    if (manifest == null || func == null || !func.effectCapsExplicit) {
+  /**
+   * Manifest 能力约束校验。
+   * <p>
+   * ★校验对象是「**声明的** ∪ **body 实际用到的**」能力（issue #84）。此前只查声明集合，
+   * 且在 {@code !effectCapsExplicit} 时整体早退，于是裸 {@code @io}（未显式列 effectCaps）
+   * 的函数即便真的调用了被 manifest deny 的能力也毫无诊断——沙箱被完全绕过。
+   * TS 侧 {@code typecheck/module.ts} 本就把 {@code collectCapabilities(body)} 并入待查集合，
+   * 本方法与之对齐。
+   *
+   * @param usedCaps {@code checkFunction} 已算好的 body 实际能力，避免重复遍历函数体
+   */
+  private void checkManifestConstraints(CoreModel.Func func, Map<CapabilityKind, List<String>> usedCaps) {
+    if (manifest == null || func == null) {
       return;
     }
-    var declaredCaps = normalizeEffectCaps(func.effectCaps);
-    if (declaredCaps.isEmpty()) {
-      return;
-    }
-    for (var capLabel : declaredCaps) {
-      var kind = CapabilityKind.fromLabel(capLabel);
-      if (kind.isEmpty()) {
-        continue;
+    var caps = new LinkedHashSet<CapabilityKind>();
+    // 声明的能力（仅在显式声明时才有意义）
+    if (func.effectCapsExplicit) {
+      for (var capLabel : normalizeEffectCaps(func.effectCaps)) {
+        CapabilityKind.fromLabel(capLabel).ifPresent(caps::add);
       }
-      var cap = kind.get();
+    }
+    // body 中实际用到的能力——绕过的关键补丁
+    if (usedCaps != null) {
+      caps.addAll(usedCaps.keySet());
+    }
+    for (var cap : caps) {
       if (!manifest.isAllowed(cap)) {
         emit(
-          ErrorCode.WORKFLOW_UNDECLARED_CAPABILITY,
+          // 与 TS 一致用 CAPABILITY_NOT_ALLOWED(E300)：manifest 拒绝 ≠ 未声明能力。
+          // 此前误用 WORKFLOW_UNDECLARED_CAPABILITY(E027)，而 E300 在 Java 侧从未被发出过。
+          ErrorCode.CAPABILITY_NOT_ALLOWED,
           func.origin,
+          // data 键与 TS builder.error(..., {func, module, cap}) 对齐
           Map.of(
             "func", func.name,
-            "capability", cap.displayName(),
-            "manifest", "not allowed"
+            "module", moduleName == null ? "" : moduleName,
+            "cap", cap.displayName()
           ),
+          // 格式串顺序：Function '%s' requires %s capability but manifest for module '%s' denies it.
           func.name,
-          "manifest",
-          cap.displayName()
+          cap.displayName(),
+          moduleName == null ? "" : moduleName
         );
       }
     }

--- a/src/test/java/aster/core/typecheck/checkers/CapabilityCheckerTest.java
+++ b/src/test/java/aster/core/typecheck/checkers/CapabilityCheckerTest.java
@@ -167,8 +167,12 @@ class CapabilityCheckerTest {
     var diagnostics = checker.checkModule(List.of(func));
 
     assertTrue(
-      diagnostics.stream().anyMatch(d -> d.code() == ErrorCode.WORKFLOW_UNDECLARED_CAPABILITY),
-      "Manifest 拒绝的能力应产生 WORKFLOW_UNDECLARED_CAPABILITY 诊断"
+      // issue #84：manifest 拒绝应报 CAPABILITY_NOT_ALLOWED(E300)，与 TS 一致。
+      // 此前误用 WORKFLOW_UNDECLARED_CAPABILITY(E027)——那是「workflow 用了未声明能力」
+      // 的语义，与「manifest 明令拒绝」不是一回事（E027 仍用于前者，见 checkWorkflowConstraints）。
+      diagnostics.stream().anyMatch(d -> d.code() == ErrorCode.CAPABILITY_NOT_ALLOWED),
+      "Manifest 拒绝的能力应产生 CAPABILITY_NOT_ALLOWED 诊断；实际="
+        + diagnostics.stream().map(d -> d.code().toString()).toList()
     );
   }
 
@@ -202,7 +206,91 @@ class CapabilityCheckerTest {
 
     var diagnostics = checker.checkModule(List.of(func));
 
-    assertTrue(diagnostics.isEmpty(), "未显式声明 effectCaps 时应跳过能力核对");
+    // 未显式声明 effectCaps 时跳过「声明 vs 实际」的核对（本用例未配置 manifest）。
+    // 注意这不代表跳过 manifest 校验——manifest 必须对 body 实际用到的能力生效，
+    // 见 manifestDeniesCapabilityUsedInBodyWithoutExplicitCaps。
+    assertTrue(diagnostics.isEmpty(), "未显式声明 effectCaps 时应跳过声明核对");
+  }
+
+  @Test
+  void manifestDeniesCapabilityUsedInBodyWithoutExplicitCaps() {
+    // issue #84：manifest 此前只对**声明的**能力生效，裸 @io（未显式列 effectCaps）
+    // 的函数即便 body 里真的调用了被 deny 的能力，也完全不产生诊断——沙箱被绕过。
+    // TS 侧 typecheck/module.ts 早已把 collectCapabilities(body) 并入待查集合。
+    var manifest = new ManifestConfig(
+      Set.of(CapabilityKind.HTTP),
+      Set.of(CapabilityKind.PROCESS)
+    );
+    checker.setManifest(manifest);
+
+    var func = createFunc(
+      "runJob",
+      List.of("io"),
+      blockWithStatements(returnCall("Process.exec"))
+    );
+    func.effectCaps = List.of();
+    func.effectCapsExplicit = false;
+
+    var diagnostics = checker.checkModule(List.of(func));
+
+    assertTrue(
+      diagnostics.stream().anyMatch(d -> d.code() == ErrorCode.CAPABILITY_NOT_ALLOWED),
+      "manifest 拒绝的能力即便未显式声明，只要 body 用到就必须报 CAPABILITY_NOT_ALLOWED；"
+        + "实际诊断=" + diagnostics.stream().map(d -> d.code().toString()).toList()
+    );
+  }
+
+  @Test
+  void manifestDeniesCapabilityUsedInBodyWhenDeclaringSomethingElse() {
+    // 变体：显式声明了 Http（合规），但 body 里另外调用了被 deny 的 Process。
+    // 此前只核对声明集合，故 Process 从不过 manifest。
+    var manifest = new ManifestConfig(
+      Set.of(CapabilityKind.HTTP),
+      Set.of(CapabilityKind.PROCESS)
+    );
+    checker.setManifest(manifest);
+
+    var func = createFunc(
+      "mixed",
+      List.of("io"),
+      blockWithStatements(returnCall("Http.get"), returnCall("Process.exec"))
+    );
+    func.effectCaps = List.of("Http");
+    func.effectCapsExplicit = true;
+
+    var diagnostics = checker.checkModule(List.of(func));
+
+    assertTrue(
+      diagnostics.stream().anyMatch(d -> d.code() == ErrorCode.CAPABILITY_NOT_ALLOWED),
+      "body 中被 deny 的能力必须报 CAPABILITY_NOT_ALLOWED；实际诊断="
+        + diagnostics.stream().map(d -> d.code().toString()).toList()
+    );
+  }
+
+  @Test
+  void manifestAllowedCapabilityInBodyProducesNoManifestDiagnostic() {
+    // 反向守卫：body 用到的能力在 allow 列表内时，不得因本次收紧而误报。
+    var manifest = new ManifestConfig(
+      Set.of(CapabilityKind.HTTP),
+      Set.of(CapabilityKind.PROCESS)
+    );
+    checker.setManifest(manifest);
+
+    var func = createFunc(
+      "fetch",
+      List.of("io"),
+      blockWithStatements(returnCall("Http.get"))
+    );
+    func.effectCaps = List.of();
+    func.effectCapsExplicit = false;
+
+    var diagnostics = checker.checkModule(List.of(func));
+
+    assertTrue(
+      diagnostics.stream().noneMatch(d -> d.code() == ErrorCode.CAPABILITY_NOT_ALLOWED),
+      "allow 列表内的能力不应报 manifest 诊断；实际诊断="
+        + diagnostics.stream().map(d -> d.code().toString()).toList()
+    );
   }
 
   @Test


### PR DESCRIPTION
Closes #84.

## 绕过是真的，已实测复现

manifest 此前只校验**声明的**能力，且在 `!effectCapsExplicit` 时整体早退。
一个裸 `@io`、未显式列 effectCaps 的函数，即使 body 里真的调用了被 deny 的能力，
也**完全不产生诊断**。

manifest: `allow=[HTTP], deny=[PROCESS]`：

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 裸 `@io` + body 调 `Process.exec` | **0 条诊断** ⚠️ | E300 |
| 声明 `Http` + body 另调 `Process.exec` | 仅声明不匹配类诊断，PROCESS 从不过 manifest | E300 |
| 裸 `@io` + body 调 `Http.get`（allow 内） | 0 条 | 0 条（**不误报**） |

前两行的用例在修复前**实测失败**、修复后通过——不是「写完就绿」的装饰性测试。

## TS 是对的，Java 是分歧方

`aster-lang-ts/src/typecheck/module.ts:228-229` 本就把 `collectCapabilities(d.body)`
并入待查集合，且没有 `effectCapsExplicit` 早退。所以这是**可在 core 内单仓修复**的
parity bug，不需要动 TS。

## 改动

1. `checkManifestConstraints` 校验「**声明的** ∪ **body 实际用到的**」能力。
   复用 `checkFunction` 已算好的 `capabilities`，不额外遍历函数体。
2. 错误码 `WORKFLOW_UNDECLARED_CAPABILITY`(E027) → **`CAPABILITY_NOT_ALLOWED`(E300)**，
   与 TS 一致。这是 issue 未提及的**第二处分歧**：E300 在 Java 侧 `ErrorCode.java:73`
   声明了，却**从未被任何代码发出过**。E027 仍用于它本来的语义（workflow 使用未声明
   能力，见 `checkWorkflowConstraints`），未受影响。
3. 消息参数顺序与 data 键对齐 TS 的 `{func, module, cap}`。为此加了可选的
   `setModuleName`（未设置时模块字段为空串，不破坏既有调用方）。

## ⚠️ 行为收紧，请评估影响面

manifest 现在会对 body 推断出的能力生效，因此原先「声明干净但 body 里偷用能力」的
函数会**开始报错**——这正是本 issue 的目的，但属于行为变更。

两点值得注意：

- `ManifestConfig.isAllowed` 在 `allowedCaps` 为空时返回 `false`（deny-by-default）。
  我核对过 TS 的 `isAllowed`（`effects/capabilities.ts:95-107`）同样是 deny-by-default，
  语义一致。但这意味着**只配 deny、未配 allow 的 manifest 会拒绝一切能力**。
- **未配置 manifest 的模块完全不受影响**（`manifest == null` 直接返回）。仓内仅
  `CapabilityCheckerTest` 与 `ManifestReaderTest` 两处用到 manifest，故全量测试无回归；
  但这也说明**仓内测试覆盖不到真实 manifest 用户**，上线前值得对实际策略仓库跑一遍。

## 验证

- 新增 3 条用例，含**反向守卫**（allow 列表内的能力不得因本次收紧而误报）
- 修复前：2 条失败（绕过被复现）；修复后：全过
- `CapabilityCheckerTest` **20 tests / 0 failures**
- **全量 core suite 1412 tests / 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)