### PR TITLE
fix(parser): 数值字面量超限硬拒，两引擎对齐（#81 #85 #86）

### DIFF
--- a/src/main/java/aster/core/lexer/Lexer.java
+++ b/src/main/java/aster/core/lexer/Lexer.java
@@ -605,6 +605,12 @@ public final class Lexer {
                 num.append(next());
             }
             double val = Double.parseDouble(num.toString());
+            // 溢出成 ±Infinity 的字面量拒收：否则超限值被当作合法 Float 继续参与运算。
+            if (!Double.isFinite(val)) {
+                throw new LexerException(
+                    "Float literal " + num + " overflows to Infinity and is not a finite Float. "
+                        + "Use a Decimal literal for values beyond the double range.", start);
+            }
             push(TokenKind.FLOAT, val, start, null);
             return;
         }
@@ -612,12 +618,42 @@ public final class Lexer {
         // Look for long suffix 'L' or 'l'
         if (Character.toLowerCase(peek()) == 'l') {
             next();
-            long val = Long.parseLong(num.toString());
-            push(TokenKind.LONG, val, start, null);
+            push(TokenKind.LONG, parseBounded(num.toString(), start, true), start, null);
             return;
         }
 
-        int val = Integer.parseInt(num.toString());
-        push(TokenKind.INT, val, start, null);
+        push(TokenKind.INT, (int) parseBounded(num.toString(), start, false), start, null);
+    }
+
+    /**
+     * 解析整数字面量并校验范围，超限抛 {@link LexerException} 而非未捕获的
+     * {@link NumberFormatException}。与 ANTLR 路径的 {@code LiteralParsing}、
+     * 以及 TS 侧 L006/L007 保持同一约定：**两引擎一律硬拒**超限字面量。
+     *
+     * @param isLong true 走 Long 范围，false 走 Int 范围
+     */
+    private long parseBounded(String raw, Position start, boolean isLong) {
+        java.math.BigInteger value;
+        try {
+            value = new java.math.BigInteger(raw);
+        } catch (NumberFormatException ex) {
+            throw new LexerException("Malformed numeric literal " + raw + ".", start);
+        }
+        java.math.BigInteger min = isLong
+            ? java.math.BigInteger.valueOf(Long.MIN_VALUE)
+            : java.math.BigInteger.valueOf(Integer.MIN_VALUE);
+        java.math.BigInteger max = isLong
+            ? java.math.BigInteger.valueOf(Long.MAX_VALUE)
+            : java.math.BigInteger.valueOf(Integer.MAX_VALUE);
+        if (value.compareTo(min) < 0 || value.compareTo(max) > 0) {
+            throw new LexerException(
+                (isLong ? "Long" : "Integer") + " literal " + raw + " is out of range for "
+                    + (isLong ? "Long" : "Int") + " (" + min + ".." + max + "). "
+                    + (isLong
+                        ? "Use a Decimal literal instead."
+                        : "Add the 'L' suffix for a 64-bit Long, or use a Decimal literal."),
+                start);
+        }
+        return value.longValue();
     }
 }

--- a/src/main/java/aster/core/parser/AstBuilder.java
+++ b/src/main/java/aster/core/parser/AstBuilder.java
@@ -546,15 +546,15 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
             return StringEscapes.unescape(inner);
         }
         if (ctx.INT_LITERAL() != null) {
-            return Integer.parseInt(ctx.INT_LITERAL().getText());
+            return LiteralParsing.parseInt(ctx.INT_LITERAL().getText());
         }
         if (ctx.FLOAT_LITERAL() != null) {
-            return Double.parseDouble(ctx.FLOAT_LITERAL().getText());
+            return LiteralParsing.parseDouble(ctx.FLOAT_LITERAL().getText());
         }
         if (ctx.LONG_LITERAL() != null) {
             String text = ctx.LONG_LITERAL().getText();
             String digits = text.substring(0, text.length() - 1);
-            return Long.parseLong(digits);
+            return LiteralParsing.parseLong(digits);
         }
         if (ctx.BOOL_LITERAL() != null) {
             return Boolean.parseBoolean(ctx.BOOL_LITERAL().getText());
@@ -581,7 +581,7 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
         String path = visitQualifiedName(ctx.qualifiedName());
         Integer version = ctx.INT_LITERAL() == null
             ? null
-            : Integer.parseInt(ctx.INT_LITERAL().getText());
+            : LiteralParsing.parseInt(ctx.INT_LITERAL().getText());
         String alias = null;
         if (ctx.importAlias() != null) {
             AsterParser.ImportAliasContext aliasCtx = ctx.importAlias();
@@ -868,7 +868,7 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
         String backoff = null;
         for (var directive : ctx.retryDirective()) {
             if (directive.MAX() != null) {
-                int attempts = Integer.parseInt(directive.INT_LITERAL().getText());
+                int attempts = LiteralParsing.parseInt(directive.INT_LITERAL().getText());
                 if (attempts <= 0) {
                     throw new IllegalStateException("Retry `max attempts` 必须大于 0");
                 }
@@ -895,7 +895,7 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
 
     @Override
     public Stmt.Timeout visitTimeoutSection(AsterParser.TimeoutSectionContext ctx) {
-        long seconds = Long.parseLong(ctx.INT_LITERAL().getText());
+        long seconds = LiteralParsing.parseLong(ctx.INT_LITERAL().getText());
         if (seconds < 0) {
             throw new IllegalStateException("timeout 数值必须为非负整数");
         }
@@ -1016,7 +1016,7 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
 
     @Override
     public Pattern visitPatternInt(AsterParser.PatternIntContext ctx) {
-        int value = Integer.parseInt(ctx.INT_LITERAL().getText());
+        int value = LiteralParsing.parseInt(ctx.INT_LITERAL().getText());
         return new Pattern.PatternInt(value, spanFrom(ctx));
     }
 
@@ -1515,13 +1515,13 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
 
     @Override
     public Expr visitIntExpr(AsterParser.IntExprContext ctx) {
-        int value = Integer.parseInt(ctx.INT_LITERAL().getText());
+        int value = LiteralParsing.parseInt(ctx.INT_LITERAL().getText());
         return new Expr.Int(value, spanFrom(ctx));
     }
 
     @Override
     public Expr visitFloatExpr(AsterParser.FloatExprContext ctx) {
-        double value = Double.parseDouble(ctx.FLOAT_LITERAL().getText());
+        double value = LiteralParsing.parseDouble(ctx.FLOAT_LITERAL().getText());
         return new Expr.Double(value, spanFrom(ctx));
     }
 
@@ -1559,7 +1559,7 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
     public Expr visitLongExpr(AsterParser.LongExprContext ctx) {
         String text = ctx.LONG_LITERAL().getText();
         // 移除 'L' 或 'l' 后缀
-        long value = Long.parseLong(text.substring(0, text.length() - 1));
+        long value = LiteralParsing.parseLong(text.substring(0, text.length() - 1));
         return new Expr.Long(value, spanFrom(ctx));
     }
 

--- a/src/main/java/aster/core/parser/LiteralParsing.java
+++ b/src/main/java/aster/core/parser/LiteralParsing.java
@@ -1,0 +1,80 @@
+package aster.core.parser;
+
+import java.math.BigInteger;
+
+/**
+ * 数值字面量解析（带范围校验）。
+ *
+ * <p>存在的理由是**双引擎 parity**。裸用 {@code Integer.parseInt} /
+ * {@code Long.parseLong} 时，超限字面量会抛出未捕获的 {@link NumberFormatException}——
+ * 它不是 Aster 的诊断类型，会穿透 AstBuilder 直接冒泡给下游调用方（truffle / api），
+ * 表现为硬崩溃而非可读的编译错误；而 TS 引擎那侧 {@code parseInt} / {@code BigInt}
+ * 反倒**静默接受**（前者在 20 位以上还会丢精度）。同一份源码于是一个引擎崩、一个引擎跑。
+ *
+ * <p>处理方式沿用 Decimal 有效位上限（ADR 0025）确立的约定：**两侧一律硬拒**，
+ * 而不是把 Java 放宽成 BigInteger。抛出的 {@link IllegalStateException} 与
+ * AstBuilder 现有的 Decimal 超限路径同型，消息与 TS 侧 L006/L007/L008 对齐。
+ */
+final class LiteralParsing {
+
+    private static final BigInteger INT_MIN = BigInteger.valueOf(Integer.MIN_VALUE);
+    private static final BigInteger INT_MAX = BigInteger.valueOf(Integer.MAX_VALUE);
+    private static final BigInteger LONG_MIN = BigInteger.valueOf(Long.MIN_VALUE);
+    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
+
+    private LiteralParsing() {
+    }
+
+    /** 解析 Int 字面量；超出 int 范围时抛出结构化错误而非 NumberFormatException。 */
+    static int parseInt(String raw) {
+        BigInteger value = toBigInteger(raw, "Integer");
+        if (value.compareTo(INT_MIN) < 0 || value.compareTo(INT_MAX) > 0) {
+            throw new IllegalStateException(
+                "Integer literal " + raw + " is out of range for Int "
+                    + "(-2147483648..2147483647). "
+                    + "Add the 'L' suffix for a 64-bit Long, or use a Decimal literal.");
+        }
+        return value.intValue();
+    }
+
+    /** 解析 Long 字面量（调用方需先去掉 L/l 后缀）。 */
+    static long parseLong(String raw) {
+        BigInteger value = toBigInteger(raw, "Long");
+        if (value.compareTo(LONG_MIN) < 0 || value.compareTo(LONG_MAX) > 0) {
+            throw new IllegalStateException(
+                "Long literal " + raw + " is out of range for Long "
+                    + "(-9223372036854775808..9223372036854775807). "
+                    + "Use a Decimal literal instead.");
+        }
+        return value.longValue();
+    }
+
+    /**
+     * 解析 Float 字面量；溢出成 ±Infinity 时硬拒。
+     *
+     * <p>两引擎的 IEEE 754 都会把超限字面量静默变成 Infinity，让明显不合法的数值继续
+     * 参与运算、产出"看起来算出来了"的结果。这里拒掉，与 TS 的 L008 一致。
+     */
+    static double parseDouble(String raw) {
+        double value;
+        try {
+            value = Double.parseDouble(raw);
+        } catch (NumberFormatException ex) {
+            throw new IllegalStateException("Malformed float literal " + raw + ".", ex);
+        }
+        if (!Double.isFinite(value)) {
+            throw new IllegalStateException(
+                "Float literal " + raw + " overflows to Infinity and is not a finite Float. "
+                    + "Use a Decimal literal for values beyond the double range.");
+        }
+        return value;
+    }
+
+    private static BigInteger toBigInteger(String raw, String kind) {
+        try {
+            return new BigInteger(raw);
+        } catch (NumberFormatException ex) {
+            throw new IllegalStateException("Malformed " + kind + " literal " + raw + ".", ex);
+        }
+    }
+}

--- a/src/test/java/aster/core/parser/AstBuilderTest.java
+++ b/src/test/java/aster/core/parser/AstBuilderTest.java
@@ -5,6 +5,7 @@ import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
 import java.util.List;
 
@@ -1186,6 +1187,53 @@ class AstBuilderTest {
         Decl.Func f = (Decl.Func) module.decls().get(0);
         assertEquals(3, f.params().size());
         assertEquals("max", f.params().get(2).name());
+    }
+
+    // ── 字面量范围（issue #81 / #85 / #86）─────────────────────────────
+    // 超限字面量必须抛结构化 IllegalStateException（AstBuilder 既有 Decimal 超限同型），
+    // 而非未捕获的 NumberFormatException / 静默 Infinity。两引擎一律硬拒，与 TS 的
+    // L006/L007/L008 对齐——放宽任一侧都会让同一份源码在两引擎行为分歧。
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @org.junit.jupiter.params.provider.ValueSource(strings = {
+        "3000000000",            // > Int32
+        "99999999999999999999",  // 20 位，TS 侧曾静默丢精度
+    })
+    void intLiteralOutOfRangeIsRejected(String literal) {
+        var ex = assertThrows(IllegalStateException.class, () -> parseAndBuild("""
+            Rule f produce:
+              Return %s.
+            """.formatted(literal)));
+        assertTrue(ex.getMessage().contains("out of range for Int"),
+            "应为 Int 范围错误，实际：" + ex.getMessage());
+    }
+
+    @Test
+    void longLiteralOutOfRangeIsRejected() {
+        var ex = assertThrows(IllegalStateException.class, () -> parseAndBuild("""
+            Rule f produce:
+              Return 99999999999999999999L.
+            """));
+        assertTrue(ex.getMessage().contains("out of range for Long"),
+            "应为 Long 范围错误，实际：" + ex.getMessage());
+    }
+
+    @Test
+    void floatLiteralOverflowingToInfinityIsRejected() {
+        var ex = assertThrows(IllegalStateException.class, () -> parseAndBuild("""
+            Rule f produce:
+              Return %s.0.
+            """.formatted("9".repeat(400))));
+        assertTrue(ex.getMessage().contains("Infinity"),
+            "应为 Float 溢出错误，实际：" + ex.getMessage());
+    }
+
+    @Test
+    void inRangeLiteralsStillParse() {
+        // 反向守卫：边界内的字面量不得因本次收紧而被误拒
+        assertNotNull(firstReturnExpr("Rule f produce:\n  Return 2147483647.\n"));
+        assertNotNull(firstReturnExpr("Rule f produce:\n  Return 9223372036854775807L.\n"));
+        assertNotNull(firstReturnExpr("Rule f produce:\n  Return 1.5.\n"));
     }
 
     /**


### PR DESCRIPTION
Closes #81, closes #85, closes #86.

**配套 PR：aster-cloud/aster-lang-ts 同名分支 `fix/literal-overflow`（关 ts#83 / ts#86）。两仓需一同合并。**

## 修复前的实测分歧

| 输入 | Java | TS |
|---|---|---|
| `3000000000`（超 int32） | `NumberFormatException` 💥 | 静默 `Int(3000000000)` |
| `99999999999999999999` | `NumberFormatException` 💥 | `Int(1e20)` —— **静默丢精度** |
| `…L` 超 int64 | `NumberFormatException` 💥 | 静默接受 |
| 400 位浮点 | `Double(Infinity)` | `Double(Infinity)` —— **两侧共有缺陷** |

`NumberFormatException` 不是 Aster 的诊断类型，会穿透 AstBuilder 直接冒泡给下游
（truffle / api），表现为**硬崩溃**而非可读的编译错误。

## 处理方式：沿用既有约定，而非各修各的

仓里对 Decimal 有效位上限（ADR 0025）早有定论，注释写得很清楚：

> 超限会让 TS decimal.js 静默舍入、BigDecimal 精确 → 双引擎分歧。**硬拒**以保 parity 与确定性。

本 PR 照搬该约定：**两侧一律硬拒**，而不是把 Java 放宽成 BigInteger。修复后两引擎
接受/拒绝完全一致，消息互相对齐。

## 改动

- 新增 `LiteralParsing`（`parseInt` / `parseLong` / `parseDouble`）：BigInteger 预检范围、
  `Double.isFinite` 拒 Infinity，抛与既有 Decimal 超限**同型**的 `IllegalStateException`。
- AstBuilder **全部 10 处**裸解析点改走该 helper。issue 只点了 `visitIntExpr` / `visitLongExpr`，
  但同样的坑还在注解值、`import` 版本号、`retry attempts`、`wait seconds` 等路径上——
  一并修掉，否则换个语法位置就复现。
- `aster/core/lexer/Lexer.java`（#86）加同样的范围校验，抛 `LexerException`。

  ⚠️ 诚实说明：该手写 Lexer **当前无生产调用方**（生产走 ANTLR → AstBuilder），
  只有 `LexerTest` / `DevanagariLexerTest` 在用。我核实过 issue 里引用的行号确实在
  这个文件，但**真正的生产路径是 AstBuilder**。既然 `LexerException` 已存在、改动也只有
  几行，就一并修正，免得日后它被启用时踩同一个坑。

## 验证

- 新增 4 组用例，含**反向守卫**：边界值 `2147483647` / `9223372036854775807L` / `1.5` 仍正常解析
- `AstBuilderTest` **66 tests / 0 failures**
- **全量 core suite 1414 tests / 0 failures**
- 两引擎逐例对拍：接受与拒绝完全一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)