### PR TITLE
fix(vocab): 检出触发词映射到不同规范名的歧义（#88）

### DIFF
--- a/src/main/java/aster/core/identifier/DomainVocabulary.java
+++ b/src/main/java/aster/core/identifier/DomainVocabulary.java
@@ -78,8 +78,13 @@ public record DomainVocabulary(
     public ValidationResult validate() {
         List<String> errors = new ArrayList<>();
         List<String> warnings = new ArrayList<>();
-        // 触发词（localized + aliases，小写）→ 是否字面量宏。字面量宏触发词须全局唯一（Codex 复审 P0）。
-        java.util.Map<String, Boolean> seenTrigger = new java.util.HashMap<>();
+        // 触发词（localized + aliases，小写）→ (是否字面量宏, 规范名)。
+        // 字面量宏触发词须全局唯一（Codex 复审 P0）；此外**非字面量**触发词若映射到
+        // 不同 canonical 也必须报错（issue #88）——IdentifierIndex.build 用
+        // toCanonical.put 无条件覆盖，两条冲突映射的胜者取决于 allMappings() 的迭代
+        // 顺序，同一份词汇集合换个合并次序就会得到不同的编译结果。
+        record TriggerInfo(boolean isLiteral, String canonical) {}
+        java.util.Map<String, TriggerInfo> seenTrigger = new java.util.HashMap<>();
 
         // 验证所有映射
         for (IdentifierMapping mapping : allMappings()) {
@@ -105,11 +110,26 @@ public record DomainVocabulary(
             if (mapping.aliases() != null) triggers.addAll(mapping.aliases());
             for (String t : triggers) {
                 String key = t.toLowerCase(java.util.Locale.ROOT); // 与 IdentifierIndex.build 一致
-                Boolean prev = seenTrigger.get(key);
-                if (prev != null && (prev || isLit)) {
+                TriggerInfo prev = seenTrigger.get(key);
+                if (prev != null && (prev.isLiteral() || isLit)) {
                     errors.add("触发词 '" + t + "' 与另一条映射冲突（字面量宏触发词须全局唯一，防\"字符串 vs 标识符\"替换歧义）");
+                } else if (prev != null && !prev.canonical().equals(mapping.canonical())) {
+                    // 同一触发词映射到不同 canonical：IdentifierIndex.build 的
+                    // toCanonical.put 无条件覆盖，胜者取决于 allMappings() 的迭代顺序
+                    // ——同一份词汇集合换个合并次序就得到不同的编译结果（issue #88）。
+                    //
+                    // ★定为 warning 而非 error：现网词汇表（含内置 SPI 插件）里已存在
+                    // 这类重叠声明，直接报 error 会让 VocabularyRegistry.register 抛异常、
+                    // 整个词汇体系无法注册（实测 29 个测试挂、注册数归零）。既有数据的
+                    // 合法性不该由一次缺陷修复单方面推翻，故先让歧义**可见**：
+                    // 调用方能从 warnings 里看到并逐个消解，待现网清理干净后再升级为 error。
+                    warnings.add("触发词 '" + t + "' 被映射到两个不同的规范名（'"
+                        + prev.canonical() + "' 与 '" + mapping.canonical()
+                        + "'）；实际生效者取决于合并顺序，建议消除歧义");
                 }
-                seenTrigger.put(key, (prev != null && prev) || isLit);
+                seenTrigger.put(key, new TriggerInfo(
+                    (prev != null && prev.isLiteral()) || isLit,
+                    prev != null && prev.isLiteral() ? prev.canonical() : mapping.canonical()));
             }
 
             // 检查字段是否有父结构体

--- a/src/test/java/aster/core/identifier/VocabularyTriggerCollisionTest.java
+++ b/src/test/java/aster/core/identifier/VocabularyTriggerCollisionTest.java
@@ -1,0 +1,93 @@
+package aster.core.identifier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 触发词冲突检测（issue #88）。
+ *
+ * <p>{@link IdentifierIndex#build} 用 {@code toCanonical.put} 无条件覆盖，两条触发词
+ * 相同但 canonical 不同的映射，胜者取决于 {@code allMappings()} 的迭代顺序——同一份
+ * 词汇集合换个合并次序就得到不同的编译结果，且 {@code validate()} 此前认为完全合法。
+ */
+@DisplayName("领域词汇触发词冲突")
+class VocabularyTriggerCollisionTest {
+
+    @Test
+    @DisplayName("同一触发词映射到不同规范名 → 校验失败")
+    void conflictingCanonicalsAreRejected() {
+        DomainVocabulary vocab = DomainVocabulary.builder("dom", "冲突域", "zh-CN")
+            .addField("status", "状态", "Applicant")
+            .addField("state", "状态", "Order")
+            .build();
+
+        var result = vocab.validate();
+
+        // 定为 warning 而非 error：现网词汇表已存在此类重叠，报 error 会让整个词汇
+        // 体系无法注册。先让歧义可见，待现网清理后再升级。
+        assertTrue(
+            result.warnings().stream().anyMatch(w -> w.contains("两个不同的规范名")),
+            "应给出歧义警告，实际 warnings=" + result.warnings());
+    }
+
+    @Test
+    @DisplayName("同一触发词映射到相同规范名 → 放行（跨域重复声明同一术语无害）")
+    void identicalCanonicalsAreAllowed() {
+        DomainVocabulary vocab = DomainVocabulary.builder("dom", "重复域", "zh-CN")
+            .addField("status", "状态", "Applicant")
+            .addField("status", "状态", "Order")
+            .build();
+
+        var r = vocab.validate();
+        assertTrue(r.valid(), "指向同一 canonical 的重复声明应放行，实际：" + r.errors());
+        assertTrue(r.warnings().stream().noneMatch(w -> w.contains("两个不同的规范名")),
+            "canonical 相同则不应有歧义警告，实际 warnings=" + r.warnings());
+    }
+
+    @Test
+    @DisplayName("别名与另一条映射的本地名冲突 → 给出警告")
+    void aliasCollidingWithAnotherLocalizedWarns() {
+        DomainVocabulary vocab = DomainVocabulary.builder("dom", "别名域", "zh-CN")
+            .addFunction("computeScore", "计算分数")
+            .addFunction("computeRating", "计算评级", "计算分数")
+            .build();
+
+        assertTrue(
+            vocab.validate().warnings().stream().anyMatch(w -> w.contains("两个不同的规范名")),
+            "别名撞上他条本地名且 canonical 不同，应给出歧义警告");
+    }
+
+    @Test
+    @DisplayName("字面量宏触发词唯一性检查不受本次改动影响")
+    void literalTriggerUniquenessStillEnforced() {
+        DomainVocabulary vocab = DomainVocabulary.builder("dom", "字面量域", "zh-CN")
+            .addLiteral("静夜思", "思故乡")
+            .addFunction("someFunc", "思故乡")
+            .build();
+
+        var result = vocab.validate();
+
+        assertFalse(result.valid(), "字面量宏触发词须全局唯一");
+        assertTrue(
+            result.errors().stream().anyMatch(e -> e.contains("字面量宏触发词须全局唯一")),
+            "应命中字面量宏专属错误而非通用冲突错误，实际：" + result.errors());
+    }
+
+    @Test
+    @DisplayName("无冲突的正常词汇表仍然通过")
+    void cleanVocabularyStillValidates() {
+        DomainVocabulary vocab = DomainVocabulary.builder("dom", "正常域", "zh-CN")
+            .addStruct("Applicant", "申请人")
+            .addField("age", "年龄", "Applicant")
+            .addFunction("approve", "批准")
+            .build();
+
+        var result = vocab.validate();
+        assertTrue(result.valid(), "无冲突词汇表不应被误拒，实际：" + result.errors());
+        assertEquals(0, result.errors().size());
+    }
+}


### PR DESCRIPTION
Closes #88.

## 问题

`IdentifierIndex.build` 用 `toCanonical.put` **无条件覆盖**。两条触发词相同、
canonical 不同的映射，胜者取决于 `allMappings()` 的迭代顺序——同一份词汇集合
**换个合并次序就得到不同的编译结果**，而 `validate()` 此前认为完全合法
（`seenTrigger` 只记 `isLiteral` 布尔，不记 canonical）。

修法：把 `seenTrigger` 的值扩成 `(isLiteral, canonical)`，触发词重复且 canonical
不同即报出歧义。canonical 相同的重复（跨域重叠声明同一术语）无害，仍放行。

## ⚠️ 关键取舍：warning 而非 error

我**先按 error 实现**，结果全量测试 **29 个失败、注册词汇表数归零**。

原因：`VocabularyRegistry.register` 对 invalid 直接抛 `IllegalArgumentException`，
而现网词汇表（含内置 SPI 插件）里**本就存在**这类重叠声明。按 error 走，整个词汇
体系无法注册——等于用一次缺陷修复推翻既有数据的合法性。

所以改为 warning：让歧义**可见**，调用方能从 `warnings` 里逐个消解，待现网清理干净
后再升级为 error。这也正对上 issue 标题的核心诉求——问题在于 **silently**
last-write-wins，"静默"才是要害。

字面量宏触发词的全局唯一性检查（Codex 复审 P0）语义不变，**仍是 error**。

> 如果你希望直接上 error，我可以另开 PR，但需要先清理内置 SPI 词汇表里的重叠声明，
> 那是一次独立的数据整改，不适合塞进本次修复。

## 验证

- 新增 5 条用例：歧义警告 / 同 canonical 放行**且不误报** / 别名撞本地名 /
  字面量宏唯一性不受影响 / 干净词汇表不误拒
- **全量 core suite 1414 tests / 0 failures**
- 变异测试确认检测 load-bearing：去掉该分支 → 2 条用例失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)