### PR TITLE
fix(test): golden sanity 接受 expectError 用例（aster-lang-test#69）

### DIFF
--- a/src/test/java/aster/core/dualengine/DualEngineGoldenTest.java
+++ b/src/test/java/aster/core/dualengine/DualEngineGoldenTest.java
@@ -64,11 +64,22 @@ class DualEngineGoldenTest {
                 DynamicTest.dynamicTest("cases array non-empty", () -> {
                     assertThat(cases.path("cases").size()).isGreaterThan(0);
                 }),
-                DynamicTest.dynamicTest("every case has name/input/expectedOutput", () -> {
+                DynamicTest.dynamicTest("every case has name/input + expectedOutput 或 expectError", () -> {
                     for (JsonNode c : cases.path("cases")) {
                         assertThat(c.has("name")).isTrue();
                         assertThat(c.has("input")).isTrue();
-                        assertThat(c.has("expectedOutput")).isTrue();
+                        // 错误路径用例（aster-lang-test#69）用 expectError:true 断言
+                        // "两个引擎都必须拒绝该输入"，此时刻意**不写** expectedOutput
+                        // （没有正常返回值可断言）。两者二选一，且互斥——与 JS 侧
+                        // scripts/lib/eval-cases.mjs 的 validateEvalCasesDocument 同一约定。
+                        boolean hasOutput = c.has("expectedOutput");
+                        boolean expectsError = c.path("expectError").asBoolean(false);
+                        assertThat(hasOutput || expectsError)
+                            .as("case '%s' 必须有 expectedOutput 或 expectError:true", c.path("name").asText())
+                            .isTrue();
+                        assertThat(hasOutput && expectsError)
+                            .as("case '%s' 不得同时有 expectedOutput 与 expectError（互斥）", c.path("name").asText())
+                            .isFalse();
                     }
                 })
             )));


### PR DESCRIPTION
修复由 aster-lang-test#69（PR aster-cloud/aster-lang-test#74）引入的红灯——**是我漏改的下游消费者**。

## 症状

```
Dual-engine golden corpus (sanity) > 08-arithmetic-divide.aster
  > every case has name/input/expectedOutput FAILED
Dual-engine golden corpus (sanity) > 09-arithmetic-modulo.aster  > ... FAILED
Dual-engine golden corpus (sanity) > stdlib_date.aster           > ... FAILED
```

## 原因

test#69 给 `.cases.json` 引入了 `expectError: true` 用例形态——断言「两个引擎都必须
拒绝该输入」，此时**刻意不写** `expectedOutput`（没有正常返回值可断言）。

`DualEngineGoldenTest` 的 sanity 断言早于该形态，硬性要求每个 case 都有
`expectedOutput`，于是新语料一发布就红。我在 test 仓侧改了 JS 校验器
（`scripts/lib/eval-cases.mjs`），却漏了 Java 侧这个消费者。

## 修改

改为二选一 + 互斥校验，与 JS 侧 `validateEvalCasesDocument` **同一约定**：

- 必须有 `expectedOutput` **或** `expectError: true`
- **不得同时出现**（同时写时 `expectedOutput` 必被忽略，留着只会误导读者）

断言失败信息带上 case 名，便于定位是哪一条。

## ★复现要点（值得记）

该测试读的是**已发布的 corpus 制品**，而不是 aster-lang-test 工作树。

我第一次跑本地**全绿**、连变异测试都抓不到——因为 mavenLocal 里还是旧 corpus
（`grep -c expectError` = 0，而源文件是 2）。先在 `packages/jvm` 跑
`publishToMavenLocal` 拉到含 `expectError` 的语料，才复现出这 3 条失败。

也就是说：**改 aster-lang-test 的语料后，验证 core 侧影响必须先发布 corpus**，
否则本地绿灯是假象。

## 验证

| 检查 | 结果 |
|---|---|
| 复现（修复前，真语料） | **3 failures** ✓ 与报告一致 |
| 修复后 | **0 failures** |
| `DualEngineGoldenTest` | 581 tests 全过 |
| 全量 core suite | **1489 tests / 0 failures** |

变异测试确认 load-bearing：把 `expectError` 读取写死成 `false` → **恰好 3 条失败**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)