### PR TITLE
chore(release): bump platform pin 1.0.16→1.0.17（生态 lockstep）

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.16")
+            from("cloud.aster-lang:aster-lang-platform:1.0.17")
         }
     }
 }


### PR DESCRIPTION
release-plan 的 preflight drift gate 要求 `expectedPlatformPin == plan.platformVersion`。
platform 已 bump 到 **1.0.17**（aster-cloud/aster-lang-platform#46），本仓同步 pin。

这是 release train 的前置条件——首次 dryRun 实测拦下：13 个 artifact 中 11 个因
pin 仍是 1.0.16 而 preflight 失败。

本次发布内容：2026-07 全量审计 **28 项发现全部处理完毕**（跨 core / ts / truffle /
test / aster-api 五仓）。

合并后统一重跑 `release-train.yml`（先 dryRun 确认 preflight 全绿，再实跑五层发布）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)