### PR TITLE
ci: 为 aster-lang-test checkout 补 CROSS_REPO_TOKEN

### DIFF
--- a/.github/workflows/corpus-regression.yml
+++ b/.github/workflows/corpus-regression.yml
@@ -35,6 +35,7 @@ jobs:
           repository: aster-cloud/aster-lang-test
           path: aster-lang-test
           ref: ${{ github.event.client_payload.sha || 'main' }}
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
 
       # Lexicon siblings（与 ci.yml 一致）
       - uses: actions/checkout@v6


### PR DESCRIPTION
## 为什么

`aster-lang-test` 即将转为**私有仓**。本仓 `corpus-regression.yml:35` 的 checkout **未带 token**，走默认 `GITHUB_TOKEN`——它读不到私有的兄弟仓，转私后该 workflow 会在 checkout 步直接失败。

同文件内其余跨仓 checkout（`aster-lang-platform`、各 lexicon）本就带 `CROSS_REPO_TOKEN`，此处属遗漏。

## 改了什么

`corpus-regression.yml` 的 aster-lang-test checkout 加一行 `token: ${{ secrets.CROSS_REPO_TOKEN }}`，与本仓 `ci.yml:162` 写法一致。

## 影响面

**行为不变。** token 仅提供私有仓读取权限，不改变该 gate 的任何判定逻辑——转私前后跑的是同一套 parity 校验。

全仓扫描确认：改完后 6 处 `aster-lang-test` checkout 全部带 token，无遗漏。

🤖 Generated with [Claude Code](https://claude.com/claude-code)