### PR TITLE
ci: corpus-regression 就地构建 test corpus 制品（修转私后失败）

### DIFF
--- a/.github/workflows/corpus-regression.yml
+++ b/.github/workflows/corpus-regression.yml
@@ -57,6 +57,14 @@ jobs:
         working-directory: aster-lang-platform
         run: ./gradlew publishToMavenLocal
 
+      # 发布测试 corpus 到 Maven Local（core test 的 testImplementation 依赖）。
+      # aster-lang-test 转私后 GH Packages 上的 cloud.aster-lang:aster-lang-test
+      # 也随之私有，远程解析会失败；改为从上面已 checkout 的源码就地构建。
+      # 与 ci.yml 的 Phase 2b 同范式。
+      - name: Publish test corpus to Maven Local
+        working-directory: aster-lang-test/packages/jvm
+        run: ./gradlew publishToMavenLocal -x test
+
       - name: Run corpus regression tests
         working-directory: aster-lang-core
         env:

--- a/.github/workflows/corpus-regression.yml
+++ b/.github/workflows/corpus-regression.yml
@@ -35,6 +35,7 @@ jobs:
           repository: aster-cloud/aster-lang-test
           path: aster-lang-test
           ref: ${{ github.event.client_payload.sha || 'main' }}
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
 
       # Lexicon siblings（与 ci.yml 一致）
       - uses: actions/checkout@v6


### PR DESCRIPTION
## 症状

`aster-lang-test` 转为私有后，本仓 `corpus-regression` 立即失败：

```
> Could not resolve all dependencies for configuration ':testCompileClasspath'.
   > Could not find cloud.aster-lang:aster-lang-test:1.0.17.
```

历史记录印证：转私前 4 次连续 success，转私后首跑 failure。

## 根因

core 的 `testImplementation(asterLibs.test)` 依赖 Maven 制品 `cloud.aster-lang:aster-lang-test`。**GH Packages 的包可见性跟随所属仓库**——仓库转私，包一并转私，匿名解析随即失败。

此前该 workflow 一直「白嫖」这个包可以公开解析，从未自建。

`ci.yml` 早就有 Phase 2b 从 sibling 源码 `publishToMavenLocal`，其注释甚至明写「缺这步会让 `:testCompileClasspath` 解析 `aster-lang-test:<ver>` 失败」——`corpus-regression.yml` 只是遗漏了同一步。

## 改了什么

在已有的 "Publish version catalog" 之后、跑测试之前，补一步从**已 checkout 的源码**构建 corpus 制品：

```yaml
- name: Publish test corpus to Maven Local
  working-directory: aster-lang-test/packages/jvm
  run: ./gradlew publishToMavenLocal -x test
```

与 `ci.yml` Phase 2b 完全同范式。此后 corpus 制品一律就地构建，不再依赖远程包可见性。

## 影响面

**测试内容不变**，只改制品来源（远程 → 就地构建）。就地构建的还更准：跑的是本次 checkout 的那个 sha 的 corpus，而非 GH Packages 上的已发布版本。

`aster-lang-ts` 侧**不受影响**——它经 `ASTER_LANG_TEST_PATH` 直读源码，不解析 Maven 制品，转私后已实测 success。

## 验证

合并后触发 `workflow_dispatch` 复跑确认转绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)