### PR TITLE
chore(renovate): 移除本地 enabledManagers 覆盖，改由 preset 统一提供

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>aster-cloud/aster-lang-platform"],
-  "enabledManagers": ["custom.regex"],
+  "extends": [
+    "github>aster-cloud/aster-lang-platform"
+  ],
   "dependencyDashboard": true
 }


### PR DESCRIPTION
## 问题

平台 preset（aster-lang-platform#47）已启用 `github-actions` manager + digest pin，但**对本仓无效**。

★ Renovate 的 `enabledManagers` 是**非可合并**字段——仓库级的数组会**整体覆盖** preset 的同名字段，这是官方明确的设计选择（[renovate#37059](https://github.com/renovatebot/renovate/discussions/37059)：*"`enabledManagers` is non-mergeable, which was a design choice"*）。

本仓的 `renovate.json` 写死了 `"enabledManagers": ["custom.regex"]`，于是 preset 里新增的 `github-actions` 被吞掉，**约 60 处第三方 action 仍是可变 tag**。

## 改动

删掉本地 `enabledManagers` 覆盖，交由 preset 统一提供（`["custom.regex", "github-actions"]`）。

- `custom.regex`（platform version catalog pin）**行为不变**——它现在来自 preset
- 新增 `github-actions`：Renovate 会开 PR 把 action pin 成 `owner/action@<sha> # vX`

## 为什么不是在本仓加回完整数组

那等于把治理配置重新复制 15 份，正是 ADR 0023 阶段1 建立共享 preset 要消除的东西。单点维护才能保证后续新增 manager 不用再逐仓改。