### PR TITLE
chore(release): bump platform pin 1.0.17→1.0.18（生态 lockstep 1.0.18）

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.17")
+            from("cloud.aster-lang:aster-lang-platform:1.0.18")
         }
     }
 }


### PR DESCRIPTION
release-plan.json 的 `platformVersion` 已升至 **1.0.18**（aster-lang-platform#52），本仓同步 catalog import pin。

不改会被 release-train 的 preflight drift gate 拒：
```
::error::[<artifact>] platform pin '1.0.17' != expected '1.0.18'
```

本仓版本号本身是 `catalog-derived`（从 `asterLibs.findVersion("asterLang")` 派生），无需手工改 —— 只需这一处 pin。

🤖 Generated with [Claude Code](https://claude.com/claude-code)