### PR TITLE
chore(release): 生态 lockstep 1.0.19

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.18")
+            from("cloud.aster-lang:aster-lang-platform:1.0.19")
         }
     }
 }


### PR DESCRIPTION
生态 lockstep bump **1.0.18 → 1.0.19**。

起因：aster-api #222 —— `/evaluate-source` 并发闸门可被取消绕过。
许可原挂 `Uni.onTermination`，HTTP 取消会**立刻**归还而同步 worker 仍在跑，
反复「发起再取消」即可让实际并发远超闸门上限。归还已收敛为 `PermitLease`
里 CAS 保护的一次性租约。

本仓随生态对齐（无功能改动）。

★ 合并顺序有硬依赖：**platform 必须先合**，其余仓的版本由 catalog 派生。

🤖 Generated with [Claude Code](https://claude.com/claude-code)