### PR TITLE
chore(release): platform pin 1.0.19 → 1.0.20（生态 lockstep）

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.19")
+            from("cloud.aster-lang:aster-lang-platform:1.0.20")
         }
     }
 }


### PR DESCRIPTION
随 aster-lang-platform **1.0.20** 发布（aster-cloud/aster-lang-platform#59 已合）。

本仓 `version` 由 catalog 派生（`VersionCatalogsExtension`），故只需改 pin，不必改 version。

## 本次发布内容

truffle 三个已合未发的提交：

| commit | 内容 |
|---|---|
| `077b08d` | 步骤级 trace 带源码行号（truffle#64） |
| `be1a66b` | 成员访问失败列出可用键名（truffle#65 / api#244） |
| `93e3b3a` | GraalVM 25.0.1 → 25.0.4（truffle#66 / api#193） |

其中 `077b08d` 是 aster-api traceHash golden 的依赖 —— 发版后才能把兄弟仓 pin 到 tag（api#247 方案 A）。