### PR TITLE
test(lowering): 补嵌套构造器模式用例，锁住 patternBindings 的 args 递归

### DIFF
--- a/src/test/java/aster/core/lowering/LambdaCaptureParityTest.java
+++ b/src/test/java/aster/core/lowering/LambdaCaptureParityTest.java
@@ -221,7 +221,29 @@ class LambdaCaptureParityTest {
     assertTrue(ctor.get(0).contains("prefix"),
         "case 体里的 prefix 是自由变量、必须捕获，实际=" + ctor.get(0));
 
-    // ④ 各 case 独立作用域：前一个 case 的绑定不得泄漏到后一个
+    // ④ **嵌套**构造器模式 —— 锁住 patternBindings 里对 args 的递归。
+    //
+    //    ★终审复核给出了比我原判更精确的结论：`names` 与 `args` 之所以等价，
+    //      根因是 AstBuilder:1024-1034 里 `names` **由 args 过滤派生**
+    //      （filter 出 PatternName 再取名），故 names ⊆ args 递归结果，
+    //      数学上不可能提供额外绑定 —— 这才是 JG 无法证伪的原因。
+    //
+    //      而真正**承重**的是 args 递归（变异 JI）：删掉它后
+    //      `When Ok(Some(inner))` 产出 [inner, outer]（正确为 [outer]），
+    //      而上面 ③ 用的 `User(id, name)` 是 names == args 的**平坦**形态，
+    //      锁不住嵌套递归。此处用嵌套形态补上。
+    var nested = allCapturesOf("Module probe.\n\nRule r given outer, produce:\n"
+        + "  Let f be function with value, produce:\n"
+        + "    Match value:\n"
+        + "      When Ok(Some(inner)), Return inner.\n"
+        + "      When other, Return outer.\n"
+        + "  Return f(outer).\n");
+    assertTrue(!nested.get(0).contains("inner"),
+        "嵌套构造器模式绑定的 inner 不得计入 captures（需 args 递归），实际=" + nested.get(0));
+    assertTrue(nested.get(0).contains("outer"),
+        "另一 case 里的 outer 仍须捕获，实际=" + nested.get(0));
+
+    // ⑤ 各 case 独立作用域：前一个 case 的绑定不得泄漏到后一个
     var leak = allCapturesOf("Module probe.\n\nRule r given bound, produce:\n"
         + "  Let f be function with x, produce:\n"
         + "    Match x:\n"


### PR DESCRIPTION
## 背景

对抗性终审（ts#106 得 96 分）的**发现 A**：`patternBindings` 里对 `args` 的递归**无用例覆盖**。

删掉它后：

```
When Ok(Some(inner))  →  [inner, outer]     ← inner 被误当成自由变量
正确                   →  [outer]
```

而 #106 刚补的 8 条用例**全绿**（逃逸）。

## 顺带订正我上一轮的判断依据

我在 #106 里写「`names` 与 `args` 携带同一组名字、互为冗余」。审查者给出了**更精确的根因**：

`names` 是**由 `args` 过滤派生**的（`AstBuilder.java:1024-1034` —— filter 出 `PatternName` 再取名），所以 `names ⊆ args 递归结果`，**数学上不可能提供额外绑定**。

这才是变异 JG（删 `names`）无法证伪的真正原因，也直接给出了失效条件：**只要 `names` 仍由该 filter 派生，等价性就成立**。

方向也随之明确：冗余的是 `names`，**承重的是 `args` 递归**。#106 那条用例用的 `User(id, name)` 是 `names == args` 的**平坦**形态，锁不住嵌套递归。

## 验证

- 新增嵌套形态用例 `When Ok(Some(inner))`，断言 `inner` 不入 captures、`outer` 仍捕获
- **变异验证**：删掉 args 递归 → **1 红**（此前 8 绿逃逸）
- 全量 `./gradlew test` 绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)