### PR TITLE
fix(test): parse 清单按 meta.lexicon 规范化，基线 4→1（issue #107 元缺陷）

### DIFF
--- a/src/test/java/aster/core/dualengine/TsSampleParseInventoryTest.java
+++ b/src/test/java/aster/core/dualengine/TsSampleParseInventoryTest.java
@@ -20,6 +20,9 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import aster.core.canonicalizer.Canonicalizer;
+import aster.core.lexicon.Lexicon;
+import aster.core.lexicon.LexiconRegistry;
 
 /**
  * Phase 3E follow-up: feed every sample that claims engine support for "ts"
@@ -58,7 +61,19 @@ class TsSampleParseInventoryTest {
         List<Map.Entry<String, String>> failures = new ArrayList<>();
 
         for (CorpusLoader.Sample sample : samples) {
-            String source = sample.readSource();
+            String rawSource = sample.readSource();
+            // ★按样本声明的 lexicon 规范化（2026-08-19 修复 issue #107 的元缺陷）。
+            //
+            //   此前这里直接把**原始源码**喂给英语词法器，完全不看 meta.lexicon。
+            //   后果：非英语样本（zh-CN 的「模块 …」等）本该由对应词法表翻译成
+            //   canonical 英语后再解析，却被当英语硬解 —— 于是这份「清单」对
+            //   非英语样本给出的通过/失败结论**与真实解析能力无关**。
+            //   实测加一个 zh-CN 样本后 parse parity 报 220/220 通过，
+            //   而 Java 侧根本没能解析它。
+            //
+            //   现改为 fail-closed：声明了 lexicon 就必须能取到，取不到即失败，
+            //   而不是静默退回英语（静默退回正是这个缺口长期存在的原因）。
+            String source = canonicalizeFor(sample, rawSource);
             CollectingErrorListener listener = new CollectingErrorListener();
             try {
                 AsterCustomLexer lexer = new AsterCustomLexer(CharStreams.fromString(source));
@@ -130,12 +145,20 @@ class TsSampleParseInventoryTest {
     }
 
     /**
-     * 已知的 Java 解析失败数基线（2026-07-29 实测 222 样本中 4 例失败，通过率 98.2%）。
+     * 已知的 Java 解析失败数基线。
      *
-     * <p>这些是 TS PEG 接受而 Java ANTLR 尚不支持的语法特性，属已知差距而非回归。
-     * ★本数字只应随着差距消解而**下降**。
+     * <p>2026-07-29：222 样本中 4 例失败（98.2%）。
+     * <p>2026-08-19：**降到 1**（223 样本，99.6%）。
+     *
+     * <p>★这次下降不是新增了语法支持，而是修掉了本测试自己的缺陷：
+     * 此前它把原始源码直接喂英语词法器、不看 {@code meta.lexicon}，
+     * 于是 4 个 zh-CN 样本必然失败——而它们恰好占满了这个基线，
+     * 把「测试没按词法表规范化」伪装成了「Java 语法能力不足」。
+     * 按词法表规范化后实测：219/223 → 222/223，Java **本来就能解析**中文样本。
+     *
+     * <p>本数字只应随着差距消解而**下降**。
      */
-    private static final int MAX_KNOWN_PARSE_FAILURES = 4;
+    private static final int MAX_KNOWN_PARSE_FAILURES = 1;
 
     private static final class CollectingErrorListener extends BaseErrorListener {
         final List<String> errors = new ArrayList<>();
@@ -146,5 +169,25 @@ class TsSampleParseInventoryTest {
                                 RecognitionException e) {
             errors.add("L" + line + ":" + charPositionInLine + " " + msg);
         }
+    }
+
+    /**
+     * 按样本声明的 {@code meta.lexicon} 规范化源码。
+     *
+     * <p>未声明或声明为 en-US → 用默认（英语）Canonicalizer；
+     * 声明了其它词法表 → 必须能从 {@link LexiconRegistry} 取到，**取不到即失败**。
+     * 绝不静默退回英语——那正是「非英语样本假通过」这个元缺陷的成因。
+     */
+    private static String canonicalizeFor(CorpusLoader.Sample sample, String rawSource) {
+        String id = sample.meta.lexicon;
+        if (id == null || id.isBlank() || "en-US".equals(id)) {
+            return new Canonicalizer().canonicalize(rawSource);
+        }
+        Lexicon lexicon = LexiconRegistry.getInstance().get(id).orElseThrow(
+            () -> new AssertionError(
+                "样本 " + sample.resourcePath + " 声明 lexicon=" + id
+                + "，但 LexiconRegistry 取不到该词法表。"
+                + "不得静默退回英语——那会让本清单对非英语样本给出与真实解析能力无关的结论。"));
+        return new Canonicalizer(lexicon).canonicalize(rawSource);
     }
 }


### PR DESCRIPTION
#107 选项 C 的第一步：根治「parse 门禁对非英语样本假通过」。

## 问题

`TsSampleParseInventoryTest` 把**原始源码**直接喂给英语词法器，**完全不看 `meta.lexicon`**。

非英语样本（zh-CN 的「模块 …」）本该先由对应词法表翻译成 canonical 英语再解析，却被当英语硬解 —— 这份清单对非英语样本给出的通过/失败结论**与真实解析能力无关**。

## 最有说服力的是这个数字

| | 通过 | 失败 |
|---|---|---|
| 旧行为（不看 lexicon） | 219/223 | **4** |
| 新行为（按 lexicon） | 222/223 | **1** |

而已发布语料里**恰好有 4 个 zh-CN 样本**。

也就是说 `MAX_KNOWN_PARSE_FAILURES = 4` 这个号称「TS PEG 接受而 Java ANTLR 尚不支持的语法特性」的基线，**实际装的是本测试自己没按词法表规范化** —— Java 本来就能解析中文样本，只是从没被喂对过。

## 改动

- 新增 `canonicalizeFor(sample, raw)`：未声明或 `en-US` 走默认 `Canonicalizer`；声明了其它词法表则**必须**从 `LexiconRegistry` 取到，**取不到即失败**
  - 绝不静默退回英语 —— 静默退回正是这个缺口长期存在的原因
- 基线 **4 → 1**，注释写明这次下降不是新增语法支持，而是修掉测试自身缺陷

## 验证

**变异验证**：把 `canonicalizeFor` 还原成直接用 `rawSource` → 219/223（4 失败），超过新基线 1 即断言失败。

全量 `./gradlew test` 绿。

## 与 #107 的关系

这条解决的是 #107 里那个**结构性根因的下游症状**（门禁假通过）。#107 本体——「Java 词法器完全不知道 lexicon 存在」以及日韩/假名字符集要不要收窄——仍是产品决策，保持开放。

🤖 Generated with [Claude Code](https://claude.com/claude-code)