### PR TITLE
chore(deps): platform pin 1.0.20 → 1.0.21

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.20")
+            from("cloud.aster-lang:aster-lang-platform:1.0.21")
         }
     }
 }


### PR DESCRIPTION
`aster-lang-platform` 已发版 **1.0.21**（新增 `graalvm` 版本与 7 个组件别名，见 aster-api#193）。

## 为什么每个消费仓都要改

`release-plan` 的 drift gate（`check-artifact.py:141`）把
`expectedPlatformPin != plan.platformVersion` 判为「plan 自相矛盾」——
即**目录发版必然要求全部消费仓的 platform pin 同步**。

这正是它设计来防的那件事：*pin 到旧 platform 会稳定派生错误版本*。

## 本仓改动

仅 `settings` 的一行 pin，**无代码改动**。`compileJava` 绿。

## 上游背景

aster-api 侧查出 `quarkus-bom` 一直在把 `graal-sdk` 降级到 23.1.2，
而 `truffle-api`/`polyglot` 是 25.0.4 —— 生产运行时长期处于混搭状态。
收进目录 + `resolutionStrategy` 强制对齐后已消除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
