### PR TITLE
chore(deps): platform pin 1.0.21 → 1.0.22

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.21")
+            from("cloud.aster-lang:aster-lang-platform:1.0.22")
         }
     }
 }


### PR DESCRIPTION
随 1.0.22 补丁列车同步（platform PR aster-cloud/aster-lang-platform#64 已合）。

该列车唯一实质内容：把 `evidenceExport` 四语文案（issue #260 遗留）带到 tag 上。aster-api 的 sibling parity 门禁比对兄弟仓 **tag**，而 `v1.0.21` 早于文案合并、且制品已发布不可移动，故只能向前发新版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)