### PR TITLE
ci: corpus-regression 删除三个已归档语言包仓的 checkout

### DIFF
--- a/.github/workflows/corpus-regression.yml
+++ b/.github/workflows/corpus-regression.yml
@@ -37,14 +37,6 @@ jobs:
           ref: ${{ github.event.client_payload.sha || 'main' }}
           token: ${{ secrets.CROSS_REPO_TOKEN }}
 
-      # Lexicon siblings（与 ci.yml 一致）
-      - uses: actions/checkout@v6
-        with: { repository: aster-cloud/aster-lang-en, path: aster-lang-en, token: '${{ secrets.CROSS_REPO_TOKEN }}' }
-      - uses: actions/checkout@v6
-        with: { repository: aster-cloud/aster-lang-zh, path: aster-lang-zh, token: '${{ secrets.CROSS_REPO_TOKEN }}' }
-      - uses: actions/checkout@v6
-        with: { repository: aster-cloud/aster-lang-de, path: aster-lang-de, token: '${{ secrets.CROSS_REPO_TOKEN }}' }
-
       - uses: actions/setup-java@v5
         with:
           java-version: '25'


### PR DESCRIPTION
统一 sibling checkout 时的附带发现。

## 事实

`aster-lang-en` / `zh` / `de` 三仓**自 2026-06-17 起已归档**（`gh api` 实测 `archived=true`）。`ci.yml` 早已迁到 `aster-lang-locales`，但 `corpus-regression.yml` 没跟上——每天 `repository_dispatch` 触发一次，白拉三个归档仓。

## 确认是死代码，不是疏漏

- checkout 之后**没有任何 step 引用** `aster-lang-{en,zh,de}` 路径
- 构建脚本（`*.gradle*` / `*.kts`）对三者引用数为 **0**
- 该 workflow 只跑 `TsSampleParseInventoryTest`，其 lexicon 经 `langPacks` 依赖解析，不依赖这三处源码 checkout

## 为什么之前一直绿

这三个 checkout 从不被读取，拉不拉都不影响结果——所以「绿」并不能证明它们有用，只能证明它们无害。归档仓仍可只读 clone，故也不会报错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)