### PR TITLE
chore(deps): platform pin 1.0.22 → 1.0.23

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.22")
+            from("cloud.aster-lang:aster-lang-platform:1.0.23")
         }
     }
 }


### PR DESCRIPTION
随 1.0.23 列车同步（platform PR `aster-cloud/aster-lang-platform#67`）。

该列车唯一实质内容：把 `aster-lang-ts#112` 的 stdlib 补齐（6 个此前仅 JVM 可用的内置函数）送到 npm，好让文档站演练场里照抄文档的用户不再撞 `Undefined function`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)