### PR TITLE
chore(deps): platform pin 1.0.23 → 1.0.24

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.23")
+            from("cloud.aster-lang:aster-lang-platform:1.0.24")
         }
     }
 }


### PR DESCRIPTION
随 **1.0.24 安全补丁列车**同步（platform PR `aster-cloud/aster-lang-platform#68`）。

该列车含一个 **CodeQL 判 high 的 ReDoS 修复**（`scale` 校验正则歧义分支，宿主传入 2 万字符占死线程 101 秒），以及 `#73` 参数隔离、`api#244` 错误信息、`#74` 第 1 项 Map 拒绝 null 键。

🤖 Generated with [Claude Code](https://claude.com/claude-code)