### PR TITLE
chore(deps): platform pin 1.0.24 → 1.0.25

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.24")
+            from("cloud.aster-lang:aster-lang-platform:1.0.25")
         }
     }
 }


### PR DESCRIPTION
随 **1.0.25 列车**同步（platform PR `aster-cloud/aster-lang-platform#69`）。

该列车修两条**双引擎分叉**：

- `is equal to` 对**结构体/列表**两侧结果不同（TS 引用相等 false / Java 结构相等 true）→ 已统一为结构相等
- `List.groupBy` 绕过 `mapKey`，null 分组键与字符串 `"null"` 塌陷同桶

🤖 Generated with [Claude Code](https://claude.com/claude-code)
