### PR TITLE
chore(deps): platform pin 1.0.25 → 1.0.26

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.25")
+            from("cloud.aster-lang:aster-lang-platform:1.0.26")
         }
     }
 }


### PR DESCRIPTION
★**BREAKING**：`Map.get` 不再返回裸值/`null`，改为 `Some(value)` / `None`（ADR 0035 档位 C）。

## 明知破坏 spec-1.0-freeze 承诺

`Map.*` 属 Stable，spec-freeze 承诺「Stable 集 1.x 内语法+语义不变」。本次是对 Stable 的**语义变更**，由用户拍板接受。

依据已逐一核实：真实用量**仅 3 个 corpus 文件**（`aster-cloud` 里那些 `Map.get` 是 **JS 的**、与 Aster 无关）。实施后 corpus 改用 `Maybe.withDefault` 解包，**golden 期望值全部不变**。

## 配套修复：List.* 响亮失败

此前 TS 对非列表输入静默返回 `0/true/null/false/[x]`，Java 一律 throw —— 既是**双引擎分叉**，也是**静默错答案**：`List.length(Some([1,2,3]))` 返回 0，**命中的非空列表被报成空**。

## 档位 B 因此不再必要

其四种目标情形现已全部响亮失败：算术/比较/传 builtin 运行期报错，字段访问编译期拒绝。

## ★ ui-messages npm 前置抬到 1.0.21

1.0.20 已发布；`locales`/`hi` 双制品共用一个 `release.yml`，不抬会在 npm 重复发版时**断层**。

## 验证

13 个 artifact 逐个跑 `check-artifact.py`，**全部通过**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
