### PR TITLE
fix(canonicalizer): 冠词作左操作数 + 裸 `not equal to` 丢失操作数

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.25")
+            from("cloud.aster-lang:aster-lang-platform:1.0.26")
         }
     }
 }

--- a/src/main/java/aster/core/canonicalizer/Canonicalizer.java
+++ b/src/main/java/aster/core/canonicalizer/Canonicalizer.java
@@ -545,9 +545,15 @@ public final class Canonicalizer {
      * 翻译（step 1，plus→+ 等）之后，故多数中缀运算符已是符号；逻辑连接词 and/or、
      * 声明/连接关键字（as be in of）仍是词。列出符号形态 + 残留词形态双保险。
      * 冠词移除仅对 en-US 启用，故此集与 en-US 对齐。
+     *
+     * ★`not` 必须在列（#120）：裸 `not equal to`（不带 `is`）是合法比较运算符，
+     * 漏掉它会让 `a not equal to b` 的左操作数被当冠词删掉，变成 `not equal to b`。
+     * 该式在本引擎**编译通过且恒返回 true**（一元 not 作用于无关表达式），
+     * `5 != 5` 得到 true——静默错答案，比 TS 侧的编译失败更难发现。
+     * 注：`a is not equal to b` 本就正常，因为 `is` 已在列。
      */
     private static final String IDENTIFIER_FOLLOW_WORDS =
-            "as|be|in|of|and|or|equals|is|at|greater|less|more|than|to|plus|minus|times|multiplied|divided|modulo";
+            "as|be|in|of|and|or|not|equals|is|at|greater|less|more|than|to|plus|minus|times|multiplied|divided|modulo";
     /** 运算符翻译后的符号形态（见 OPERATOR_SYMBOL_MAP）：+ - * / < > = 及其复合。 */
     private static final String IDENTIFIER_FOLLOW_SYMBOLS = "[-+*/<>=%]";
 

--- a/src/test/java/aster/core/canonicalizer/CanonicalizerTest.java
+++ b/src/test/java/aster/core/canonicalizer/CanonicalizerTest.java
@@ -492,6 +492,59 @@ class CanonicalizerTest {
     // 审计 #58：段感知 「」 转换 + 伪造 PUA 标记拒绝
     // ============================================================
 
+    /**
+     * #120：冠词作左操作数时被 removeArticles 吞掉。
+     * <p>
+     * 冠词移除仅 en-US 启用，语言特定用例通常在 aster-lang-en；但该仓 pin 的是
+     * aster-lang-core:1.0.2（见 aster-lang-en#? / 本仓 #120 讨论），测不到本仓改动，
+     * 故把回归锁在这里——本仓测试直接跑源码。
+     */
+    @Nested
+    @DisplayName("冠词标识符保护 #120")
+    class ArticleOperandTests {
+
+        /**
+         * 裸 {@code not equal to}（不带 {@code is}）是合法比较运算符，但
+         * IDENTIFIER_FOLLOW_WORDS 曾漏掉 {@code not}，导致左操作数被当冠词删掉：
+         * {@code Return a not equal to b.} → {@code Return not equal to b.}
+         * <p>
+         * ★本引擎的危害高于 TS 侧：该式**编译通过且恒返回 true**（一元 not 作用于
+         * 无关表达式），{@code 5 != 5} 得到 true——静默错答案；TS 侧是编译失败。
+         * <p>
+         * ★三个冠词逐一断言：正则用 {@code (a|an|the)} 交替，只测 {@code a}
+         * 会漏掉 {@code an}/{@code the} 各自的词边界情况。
+         */
+        @Test
+        @DisplayName("冠词作操作数后跟裸 not equal to 不吞")
+        void articleOperandBeforeBareNotEqualTo() {
+            for (String art : new String[] {"a", "an", "the"}) {
+                String out = canonicalizer.canonicalize("Return " + art + " not equal to b.");
+                assertTrue(out.startsWith("Return " + art + " "),
+                    "标识符 " + art + " 被当冠词吞掉了，实际输出: " + out);
+            }
+        }
+
+        /** 对照：{@code is not equal to} 本就正常（被已在列的 {@code is} 保护）。 */
+        @Test
+        @DisplayName("冠词作操作数后跟 is not equal to 保持正常")
+        void articleOperandBeforeIsNotEqualTo() {
+            String out = canonicalizer.canonicalize("Return a is not equal to b.");
+            assertTrue(out.startsWith("Return a "),
+                "标识符 a 被吞掉了，实际输出: " + out);
+        }
+
+        /**
+         * ★反向护栏：加 {@code not} 不能让**真冠词**逃过移除。
+         * 若哪天有人把 follow-set 放得更宽，这条会转红。
+         */
+        @Test
+        @DisplayName("真冠词后跟名词仍被移除（未因加 not 而放宽）")
+        void realArticlesStillRemoved() {
+            assertEquals("define function to return value",
+                canonicalizer.canonicalize("define the function to return a value"));
+        }
+    }
+
     @Nested
     @DisplayName("审计 #58 安全")
     class Audit58SecurityTests {


### PR DESCRIPTION
Fixes #120

## 根因

`IDENTIFIER_FOLLOW_WORDS` 漏了 `not`：

```
IN : Return a not equal to b.
OUT: Return not equal to b.        ← 操作数 a 被当冠词删掉
```

该 follow-set 的用意是「冠词后跟运算符/连接词 → 它其实是标识符，不该删」。`is` / `greater` / `less` / `at` / `equals` / `plus` 全在列，**唯独 `not` 遗漏**。所以 `a is not equal to b` 正常（被 `is` 保护），只有裸形中招。

## ★本引擎的危害高于 TS 侧

| 引擎 | 行为 |
|---|---|
| TypeScript | 编译失败 `Expected '.'`（响亮） |
| **Java（本仓）** | **编译通过，恒返回 `true`** —— `5 != 5` 得到 `true` |

本引擎把 `not equal to b` 当成一元 `not` 作用于无关表达式，结果与输入无关。**静默错答案比编译失败更难发现。**

## 验证：跨真实制品前后对比（非推理）

同一份探针分别跑在两个已发布 jar 上：

| core 版本 | `Return a not equal to b.` |
|---|---|
| 1.0.23（修前） | `Return not equal to b.` ❌ |
| 1.0.26（修后） | `Return a not equal to b.` ✅ |

`an` / `the` 同样保留；两版的 `a is not equal to b` 与真冠词移除行为**完全一致**（无回归）。

**变异验证**：去掉 `not` → 新增用例转红，其余 **39 个保持绿** —— 判据精确，不是过宽的断言。core 全量测试通过。

## 为什么长期没被发现

现有语料（`17-comparison-not-equals` / `cross_compiler_ops`）都用 `x` / `y` 作参数名。用 `a` / `b` 是**极其自然**的写法 —— 补 aster-lang-test 语料时一写就中招，`gen-cases.mjs` 报 13/13 在 TS 编译失败、Java 全过，才暴露出来。

★测试语料的参数命名习惯会**系统性地遮蔽一整类缺陷**。

## ⚠️ 测试落位说明（顺带发现的第二个问题）

冠词移除仅 en-US 启用，语言特定用例本该在 `aster-lang-en`。但该仓 `build.gradle.kts` 硬编码 `implementation("cloud.aster-lang:aster-lang-core:1.0.2")`，而生态 catalog 当前是 **1.0.26**。

实测 `./gradlew dependencies` 确认解析到 **1.0.2** —— 它的 canonicalizer 测试一直在验证一个 24 个版本前的制品，**测不到本仓任何改动**（我先把用例写在那里，跑出来是"失败"，实为跑在旧 jar 上）。

故回归锁在本仓（本仓测试直接跑源码）。该 pin 漂移另行开 issue。

## 配套 PR

`aster-lang-ts` 同名分支 `fix/article-operand-not-equal` 同批修复 —— 避免分叉从「一边炸一边错」变成「一边对一边错」，那样更难发现。