### PR TITLE
chore(deps): platform pin 1.0.26 → 1.0.27

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.26")
+            from("cloud.aster-lang:aster-lang-platform:1.0.27")
         }
     }
 }


### PR DESCRIPTION
生态 1.0.27（aster-lang-platform#73）：**文案同步发版，引擎/语义零改动**。

线上 `/signup` 裸 key 的根因是 aster-api 的 classpath 副本停在旧版，而 cloud 的加载顺序
`KV → 后端 /api/v1/messages → npm 包` 中**后端优先级最高**——发再多 npm 包都盖不过它。

副本（aster-api#290）要与真相源同时上线就必须切新 tag，故七个消费仓 lockstep bump pin。

🤖 Generated with [Claude Code](https://claude.com/claude-code)