### PR TITLE
chore(deps): platform pin 1.0.27 → 1.0.28

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("asterLibs") {
-            from("cloud.aster-lang:aster-lang-platform:1.0.27")
+            from("cloud.aster-lang:aster-lang-platform:1.0.28")
         }
     }
 }


### PR DESCRIPTION
生态 1.0.28（AI 拒绝原因文案同步发版，aster-lang-platform#75）。引擎/语义**零改动**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)