### PR TITLE
fix(typecheck): match 分支绑定变量纳入作用域（issue #132）

### DIFF
--- a/src/test/java/aster/core/typecheck/TypeCheckerIntegrationTest.java
+++ b/src/test/java/aster/core/typecheck/TypeCheckerIntegrationTest.java
@@ -577,6 +577,86 @@ class TypeCheckerIntegrationTest {
   }
 
   @Test
+  void matchPatternBindingIsInScopeInsideBranch() {
+    // ★issue #132：checkMatch 全程不碰 kase.pattern，模式绑定的变量在分支体里
+    //   必然报假 UNDEFINED_VARIABLE —— 模式匹配这条路径实际不可用。
+    //
+    //   func test(x: Int): Int {
+    //     match x {
+    //       case v: return v      // v 由 PatName 绑定
+    //     }
+    //   }
+    var patName = new CoreModel.PatName();
+    patName.name = "v";
+
+    var kase = new CoreModel.Case();
+    kase.pattern = patName;
+    kase.body = createReturnStmt(createNameExpr("v"));   // 引用绑定变量
+
+    var match = new CoreModel.Match();
+    match.expr = createNameExpr("x");
+    match.cases = List.of(kase);
+
+    var module = createModuleWithFunction(
+      "test",
+      List.of(createParam("x", createTypeName("Int"))),
+      createTypeName("Int"),
+      List.of(),
+      match
+    );
+
+    var diagnostics = checker.typecheckModule(module);
+
+    // 断言具体错误码，而不是笼统的 isEmpty()——后者会被任何无关诊断干扰，
+    // 也说不清「到底是不是这个 bug」。
+    var undefined = diagnostics.stream()
+      .filter(d -> d.code() == ErrorCode.UNDEFINED_VARIABLE)
+      .toList();
+    assertTrue(
+      undefined.isEmpty(),
+      "模式绑定的变量 v 必须在分支体作用域内；实际诊断：" + undefined
+    );
+  }
+
+  @Test
+  void matchPatternBindingDoesNotLeakOutsideBranch() {
+    // ★与上一条成对：绑定必须**限定在该分支内**。
+    //   只测「能用」而不测「不外泄」，等于允许实现把绑定定义到外层作用域——
+    //   那样第一条会绿，但作用域语义是错的。
+    //
+    //   func test(x: Int): Int {
+    //     match x { case v: return 1 }
+    //     return v                      // v 在此处不应可见
+    //   }
+    var patName = new CoreModel.PatName();
+    patName.name = "v";
+
+    var kase = new CoreModel.Case();
+    kase.pattern = patName;
+    kase.body = createReturnStmt(createIntLiteral(1));
+
+    var match = new CoreModel.Match();
+    match.expr = createNameExpr("x");
+    match.cases = List.of(kase);
+
+    var module = createModuleWithFunction(
+      "test",
+      List.of(createParam("x", createTypeName("Int"))),
+      createTypeName("Int"),
+      List.of(),
+      match,
+      createReturnStmt(createNameExpr("v"))    // 分支外引用
+    );
+
+    var diagnostics = checker.typecheckModule(module);
+
+    assertTrue(
+      diagnostics.stream().anyMatch(d -> d.code() == ErrorCode.UNDEFINED_VARIABLE),
+      "分支外引用 v 必须报 UNDEFINED_VARIABLE（绑定不得外泄）"
+    );
+  }
+
+  @Test
   void testEffectPropagationThroughCalls() {
     // func ioFunc(): Int [io] { return 42 }
     // Simplified: just test that a function with IO effect is valid

--- a/src/test/java/aster/core/typecheck/TypeCheckerIntegrationTest.java
+++ b/src/test/java/aster/core/typecheck/TypeCheckerIntegrationTest.java
@@ -576,84 +576,147 @@ class TypeCheckerIntegrationTest {
     );
   }
 
+  /** 构造 `case Ctor(names...) -> body` 的分支。 */
+  private CoreModel.Case ctorCase(String typeName, List<String> names, CoreModel.Stmt body) {
+    var ctor = new CoreModel.PatCtor();
+    ctor.typeName = typeName;
+    ctor.names = names;
+    var kase = new CoreModel.Case();
+    kase.pattern = ctor;
+    kase.body = body;
+    return kase;
+  }
+
+  private CoreModel.Match matchOn(String scrutinee, CoreModel.Case... cases) {
+    var match = new CoreModel.Match();
+    match.expr = createNameExpr(scrutinee);
+    match.cases = List.of(cases);
+    return match;
+  }
+
   @Test
-  void matchPatternBindingIsInScopeInsideBranch() {
-    // ★issue #132：checkMatch 全程不碰 kase.pattern，模式绑定的变量在分支体里
-    //   必然报假 UNDEFINED_VARIABLE —— 模式匹配这条路径实际不可用。
-    //
-    //   func test(x: Int): Int {
-    //     match x {
-    //       case v: return v      // v 由 PatName 绑定
-    //     }
-    //   }
-    var patName = new CoreModel.PatName();
-    patName.name = "v";
+  void ctorPatternBindingIsInScope() {
+    // ★issue #132 标题里的原始例子就是 `match x { case Some(v) -> v }`——PatCtor。
+    //   此前两条测试全用 PatName，PatCtor 整条路径零覆盖：
+    //   definePatternBindings 里 ctor.names 循环可以整块删掉而全绿。
+    var match = matchOn("x", ctorCase("Some", List.of("v"), createReturnStmt(createNameExpr("v"))));
+
+    var module = createModuleWithFunction(
+      "test", List.of(createParam("x", createTypeName("Int"))),
+      createTypeName("Int"), List.of(), match
+    );
+
+    var undefined = checker.typecheckModule(module).stream()
+      .filter(d -> d.code() == ErrorCode.UNDEFINED_VARIABLE).toList();
+    assertTrue(undefined.isEmpty(),
+      "PatCtor 绑定的 v 必须在分支体内可见；实际：" + undefined);
+  }
+
+  @Test
+  void nestedCtorPatternBindingIsInScope() {
+    // ★专杀「删掉 ctor.args 递归」这一变异：只有嵌套模式才会走那条路径。
+    //   match x { case Some(Some(inner)) -> inner }
+    var innerCtor = new CoreModel.PatCtor();
+    innerCtor.typeName = "Some";
+    innerCtor.names = List.of("inner");
+
+    var outerCtor = new CoreModel.PatCtor();
+    outerCtor.typeName = "Some";
+    outerCtor.names = List.of();
+    outerCtor.args = List.of(innerCtor);
 
     var kase = new CoreModel.Case();
-    kase.pattern = patName;
-    kase.body = createReturnStmt(createNameExpr("v"));   // 引用绑定变量
+    kase.pattern = outerCtor;
+    kase.body = createReturnStmt(createNameExpr("inner"));
 
     var match = new CoreModel.Match();
     match.expr = createNameExpr("x");
     match.cases = List.of(kase);
 
     var module = createModuleWithFunction(
-      "test",
-      List.of(createParam("x", createTypeName("Int"))),
-      createTypeName("Int"),
-      List.of(),
-      match
+      "test", List.of(createParam("x", createTypeName("Int"))),
+      createTypeName("Int"), List.of(), match
     );
 
-    var diagnostics = checker.typecheckModule(module);
+    var undefined = checker.typecheckModule(module).stream()
+      .filter(d -> d.code() == ErrorCode.UNDEFINED_VARIABLE).toList();
+    assertTrue(undefined.isEmpty(),
+      "嵌套 PatCtor 绑定的 inner 必须可见；实际：" + undefined);
+  }
 
-    // 断言具体错误码，而不是笼统的 isEmpty()——后者会被任何无关诊断干扰，
-    // 也说不清「到底是不是这个 bug」。
-    var undefined = diagnostics.stream()
-      .filter(d -> d.code() == ErrorCode.UNDEFINED_VARIABLE)
-      .toList();
+  @Test
+  void patNameBindingCarriesScrutineeType_notArbitraryType() {
+    // ★锁「绑定的**类型**」，而非仅「名字在不在」。
+    //   UNDEFINED_VARIABLE 只回答「名字在不在」，永远回答不了「类型对不对」——
+    //   把 PatName 绑成 String，前两条测试无一会红。
+    //
+    //   func test(x: Int): Int { match x { case v: return v } }
+    //   v 取被匹配值的类型 Int → return v 与返回类型 Int 相容 → 不得报 RETURN_TYPE_MISMATCH。
+    var patName = new CoreModel.PatName();
+    patName.name = "v";
+    var kase = new CoreModel.Case();
+    kase.pattern = patName;
+    kase.body = createReturnStmt(createNameExpr("v"));
+
+    var match = new CoreModel.Match();
+    match.expr = createNameExpr("x");
+    match.cases = List.of(kase);
+
+    var module = createModuleWithFunction(
+      "test", List.of(createParam("x", createTypeName("Int"))),
+      createTypeName("Int"), List.of(), match
+    );
+
+    var mismatches = checker.typecheckModule(module).stream()
+      .filter(d -> d.code() == ErrorCode.RETURN_TYPE_MISMATCH).toList();
+    assertTrue(mismatches.isEmpty(),
+      "v 应携带被匹配值类型 Int，返回它不得报类型不符；实际：" + mismatches);
+  }
+
+  @Test
+  void patNameBindingTypeIsRejectedWhenIncompatible() {
+    // ★与上一条成对的**正向**断言：只测「不报错」会被「把类型比较整个删掉」骗过。
+    //   func test(x: Int): String { match x { case v: return v } }
+    //   v 是 Int，函数声明返回 String → 必须报 RETURN_TYPE_MISMATCH。
+    //   若绑定类型退化成 unknown，此断言即失效——故它同时锁住了「不是 unknown」。
+    var patName = new CoreModel.PatName();
+    patName.name = "v";
+    var kase = new CoreModel.Case();
+    kase.pattern = patName;
+    kase.body = createReturnStmt(createNameExpr("v"));
+
+    var match = new CoreModel.Match();
+    match.expr = createNameExpr("x");
+    match.cases = List.of(kase);
+
+    var module = createModuleWithFunction(
+      "test", List.of(createParam("x", createTypeName("Int"))),
+      createTypeName("String"), List.of(), match
+    );
+
     assertTrue(
-      undefined.isEmpty(),
-      "模式绑定的变量 v 必须在分支体作用域内；实际诊断：" + undefined
+      checker.typecheckModule(module).stream()
+        .anyMatch(d -> d.code() == ErrorCode.RETURN_TYPE_MISMATCH),
+      "Int 绑定用作 String 返回值必须报 RETURN_TYPE_MISMATCH"
     );
   }
 
   @Test
-  void matchPatternBindingDoesNotLeakOutsideBranch() {
-    // ★与上一条成对：绑定必须**限定在该分支内**。
-    //   只测「能用」而不测「不外泄」，等于允许实现把绑定定义到外层作用域——
-    //   那样第一条会绿，但作用域语义是错的。
-    //
-    //   func test(x: Int): Int {
-    //     match x { case v: return 1 }
-    //     return v                      // v 在此处不应可见
-    //   }
-    var patName = new CoreModel.PatName();
-    patName.name = "v";
-
-    var kase = new CoreModel.Case();
-    kase.pattern = patName;
-    kase.body = createReturnStmt(createIntLiteral(1));
-
-    var match = new CoreModel.Match();
-    match.expr = createNameExpr("x");
-    match.cases = List.of(kase);
+  void multipleCasesEachGetOwnScope() {
+    // ★锁「每分支独立作用域」而非「整个 match 一个作用域」：
+    //   两个分支各自绑同名 v，若共用一个作用域，第二次 define 会撞重复定义。
+    var c1 = ctorCase("Some", List.of("v"), createReturnStmt(createIntLiteral(1)));
+    var c2 = ctorCase("None", List.of("v"), createReturnStmt(createIntLiteral(2)));
 
     var module = createModuleWithFunction(
-      "test",
-      List.of(createParam("x", createTypeName("Int"))),
-      createTypeName("Int"),
-      List.of(),
-      match,
-      createReturnStmt(createNameExpr("v"))    // 分支外引用
+      "test", List.of(createParam("x", createTypeName("Int"))),
+      createTypeName("Int"), List.of(), matchOn("x", c1, c2)
     );
 
-    var diagnostics = checker.typecheckModule(module);
-
-    assertTrue(
-      diagnostics.stream().anyMatch(d -> d.code() == ErrorCode.UNDEFINED_VARIABLE),
-      "分支外引用 v 必须报 UNDEFINED_VARIABLE（绑定不得外泄）"
-    );
+    var undefined = checker.typecheckModule(module).stream()
+      .filter(d -> d.code() == ErrorCode.UNDEFINED_VARIABLE).toList();
+    assertTrue(undefined.isEmpty(),
+      "多分支各自绑同名变量不得互相干扰；实际：" + undefined);
   }
 
   @Test


### PR DESCRIPTION
Closes #132

## 问题

`checkMatch` 全程不碰 `kase.pattern`，直接 `checkStatement(kase.body, ctx)`。于是
`match x { case Some(v) -> v }` 里的 `v` 必然报假 `UNDEFINED_VARIABLE` —— 模式匹配这条
路径在类型检查器下实际不可用。

证据链：`CoreLowering:822` 的 lambda 捕获分析已经调用 `patternBindings(kase.pattern())`，
说明「模式会引入绑定」在 IR 层是既定事实，只是类型检查器没跟上。

## 修法

1. 每个分支在**独立 BLOCK 作用域**内检查；`finally` 保证分支体抛异常时也退栈，
   否则后续所有检查都落在错误的作用域里（毒化全局状态）。
2. 进入分支体前，先把该分支模式引入的绑定定义进去。

## 绑定类型的取值依据

- **PatName** 原样绑定整个被匹配值 → 类型**就是**被匹配表达式的类型。
  这个类型此前算出来后直接丢弃（`var exprType = ...` 从未被使用）。
- **PatCtor** 只能记为 `TypeSystem.unknown()`：`CoreModel.Enum` 仅有
  `List<String> variants`（CoreModel:94），**IR 层不携带变体载荷类型**。
  凭空编造一个类型会让后续类型比较给出错误结论。`unknown()` 是本检查器既有的
  「类型不可确定，不要级联报错」哨兵（`typeOfExpr` 对未知名称、`Ok`/`Err` 的另一侧都用它）。
  精确推导需先给 `Enum` 加载荷类型，属独立的语言层变更，不在本 PR 范围。

绑定名集合与 `CoreLowering.patternBindings` 对齐，避免 lambda 捕获分析与类型检查器
对「哪些绑定存在」产生分叉。

## 验证

变异验证——两条测试**各自独立**杀死一个变异体，说明二者非冗余：

| 变异 | 结果 |
|------|------|
| A：恢复原缺陷（忽略 `kase.pattern`） | `matchPatternBindingIsInScopeInsideBranch` 红 |
| B：去掉 per-branch 作用域 | `matchPatternBindingDoesNotLeakOutsideBranch` 红 |

`aster-lang-core` 全量测试绿。

## 范围声明

TS 引擎侧没有类型检查器（`src/core/` 只有 interpreter），故本缺陷是 Java 独有，
不存在需要同步修的 dual-engine 分叉。