### PR TITLE
fix(typecheck): 预注册全部函数签名，修前向引用/互递归假 UNDEFINED_VARIABLE

### DIFF
--- a/src/main/java/aster/core/typecheck/TypeChecker.java
+++ b/src/main/java/aster/core/typecheck/TypeChecker.java
@@ -113,6 +113,20 @@ public final class TypeChecker {
         dataDecls
       );
 
+      // 第一遍补充：预注册全部函数签名（issue #125 body）。
+      //
+      // ★必须先把**所有**函数签名入表，再检查任何一个函数体。否则符号可见性
+      //   取决于声明顺序：`main` 写在 `helper` 之前 → 检查 main 体时 helper 未入表
+      //   → 假 UNDEFINED_VARIABLE；互递归则无论怎么排序都必有一侧报错。
+      //   与 Data/Enum 的第一遍预扫描同理——签名先行，函数体后检查。
+      if (module.decls != null) {
+        for (var decl : module.decls) {
+          if (decl instanceof CoreModel.Func func) {
+            defineFunctionSignature(func);
+          }
+        }
+      }
+
       // 第二遍：检查所有声明
       if (module.decls != null) {
         for (var decl : module.decls) {
@@ -210,16 +224,21 @@ public final class TypeChecker {
   }
 
   /**
-   * 检查函数声明
+   * 把单个函数的签名注册进**模块作用域**。
+   *
+   * <p>★必须在检查任何函数体**之前**对全部函数跑完一轮，否则前向引用与互递归
+   * 必报假 {@code UNDEFINED_VARIABLE}（issue #125 body）：`main` 写在 `helper`
+   * 之前时，检查 main 体的那一刻 helper 还没入表；互递归则无论怎么排序都必有一侧报错。
+   *
+   * <p>只注册签名，不碰函数体——函数体在第二遍逐个检查。
    */
-  private void checkFunction(CoreModel.Func func, VisitorContext ctx) {
+  private void defineFunctionSignature(CoreModel.Func func) {
     // 构建函数类型
     var funcType = new CoreModel.FuncType();
     funcType.params = func.params.stream().map(p -> p.type).toList();
     funcType.ret = func.ret;
     funcType.origin = func.origin;
 
-    // 【修复】在模块作用域（当前作用域）注册函数符号，确保跨函数调用可见
     // 存储函数声明的最高级别效果，用于后续效果推断
     // 计算所有声明效果中的最大值（PURE < CPU < IO）
     Optional<String> declaredEffect;
@@ -242,6 +261,13 @@ public final class TypeChecker {
       SymbolInfo.SymbolKind.FUNCTION,
       new SymbolTable.DefineOptions(false, Optional.ofNullable(func.origin), false, Optional.empty(), declaredEffect)
     );
+  }
+
+  /**
+   * 检查函数声明
+   */
+  private void checkFunction(CoreModel.Func func, VisitorContext ctx) {
+    // 签名已在 collectFunctionSignatures 预扫描阶段注册，此处只检查函数体。
 
     // 进入函数作用域检查函数体
     symbolTable.enterScope(SymbolTable.ScopeType.FUNCTION);

--- a/src/test/java/aster/core/typecheck/TypeCheckerIntegrationTest.java
+++ b/src/test/java/aster/core/typecheck/TypeCheckerIntegrationTest.java
@@ -429,6 +429,89 @@ class TypeCheckerIntegrationTest {
       "Cross-function call should resolve (Fix #1: function symbols in module scope)");
   }
 
+  /** 构造一个无参、返回 Int、体为 `return <expr>` 的函数。 */
+  private CoreModel.Func intFunc(String name, CoreModel.Expr returned) {
+    var f = new CoreModel.Func();
+    f.name = name;
+    f.params = List.of();
+    f.ret = createTypeName("Int");
+    f.effects = List.of();
+    var body = new CoreModel.Block();
+    body.statements = List.of(createReturnStmt(returned));
+    f.body = body;
+    return f;
+  }
+
+  private CoreModel.Call callOf(String name) {
+    var call = new CoreModel.Call();
+    call.target = createNameExpr(name);
+    call.args = List.of();
+    return call;
+  }
+
+  private List<ErrorCode> undefinedCodes(CoreModel.Module module) {
+    return checker.typecheckModule(module).stream()
+      .map(d -> d.code())
+      .filter(c -> c == ErrorCode.UNDEFINED_VARIABLE)
+      .toList();
+  }
+
+  @Test
+  void forwardReferenceResolves_calleeDeclaredAfterCaller() {
+    // ★testCrossFunctionCall 的盲区：那条测试用 List.of(helperFunc, mainFunc)，
+    //   **被调方永远排在前面**，前向引用路径零覆盖（issue #125 body）。
+    //   这里把顺序反过来——修复前必报假 UNDEFINED_VARIABLE。
+    //
+    //   func main(): Int { return helper() }   // 先声明
+    //   func helper(): Int { return 42 }       // 后声明
+    var mainFunc = intFunc("main", callOf("helper"));
+    var helperFunc = intFunc("helper", createIntLiteral(42));
+
+    var module = new CoreModel.Module();
+    module.decls = List.of(mainFunc, helperFunc);   // 调用方在前
+
+    var undefined = undefinedCodes(module);
+    assertTrue(
+      undefined.isEmpty(),
+      "被调函数声明在调用方之后时仍须可见；实际 UNDEFINED_VARIABLE 数：" + undefined.size()
+    );
+  }
+
+  @Test
+  void mutualRecursionResolves_inBothDirections() {
+    // ★互递归无论怎么排序都必有一侧前向引用——这是「预注册签名」与
+    //   「边声明边检查」最本质的区别，声明顺序再怎么调也绕不过去。
+    //
+    //   func isEven(): Int { return isOdd() }
+    //   func isOdd(): Int { return isEven() }
+    var isEven = intFunc("isEven", callOf("isOdd"));
+    var isOdd = intFunc("isOdd", callOf("isEven"));
+
+    var module = new CoreModel.Module();
+    module.decls = List.of(isEven, isOdd);
+
+    var undefined = undefinedCodes(module);
+    assertTrue(
+      undefined.isEmpty(),
+      "互递归两侧都须解析成功；实际 UNDEFINED_VARIABLE 数：" + undefined.size()
+    );
+  }
+
+  @Test
+  void trulyUndefinedFunctionStillReported() {
+    // ★反向护栏：预注册签名不能退化成「什么名字都认」。
+    //   没有这条，把 undefinedVariable 整个删掉也能让上面两条变绿。
+    var mainFunc = intFunc("main", callOf("noSuchFunction"));
+
+    var module = new CoreModel.Module();
+    module.decls = List.of(mainFunc);
+
+    assertFalse(
+      undefinedCodes(module).isEmpty(),
+      "调用真正不存在的函数仍须报 UNDEFINED_VARIABLE"
+    );
+  }
+
   @Test
   void testEffectInferenceFromDeclaredEffect() {
     // 【修复 #2 验证】调用函数时应该读取声明的效果


### PR DESCRIPTION
Closes #126

> ⚠️ 注意：本仓 #125–#128 的 **issue 标题与正文系统性错位**（每个标题描述的是前一号的正文）。
> 本 PR 修的是 **#126 的正文**所述缺陷（标题「函数前向引用/互递归报假 UNDEFINED_VARIABLE」
> 恰好也对应此内容，故按正文与标题一致的 #126 关闭）。

## 问题

`typecheckModule` 的第一遍 `collectTypeDefinitions` 只收集 Data/Enum；函数符号是在
**第二遍逐个声明顺序处理时**、于 `checkFunction` 内注册的，紧接着就检查该函数体。

于是符号可见性取决于声明顺序：

- `main` 写在 `helper` 之前 → 检查 main 体的那一刻 helper 尚未入表 → 假 `UNDEFINED_VARIABLE`；
- **互递归函数无论怎么排序都必有一侧报错**。

这与 `TypeChecker.java:222` 注释声称的「在模块作用域注册函数符号，确保跨函数调用可见」不符。

## 修法

把签名注册从 `checkFunction` 抽成 `defineFunctionSignature`，在第二遍开始前对全部 `Func`
跑一轮预扫描（与 Data/Enum 的第一遍预扫描同理——签名先行，函数体后检查）。
`checkFunction` 只留函数体检查。

## 测试盲区

issue 已准确指出：既有回归测试 `testCrossFunctionCall` 用 `List.of(helperFunc, mainFunc)`，
**被调方永远排在前面**，前向引用路径零覆盖——这正是缺陷能长期存活的原因。

新增三条：

| 测试 | 锁住什么 |
|------|---------|
| `forwardReferenceResolves_calleeDeclaredAfterCaller` | 调用方在前的顺序 |
| `mutualRecursionResolves_inBothDirections` | 声明顺序绕不过去的情形 |
| `trulyUndefinedFunctionStillReported` | **反向护栏**：预注册不能退化成「什么名字都认」 |

第三条是必要的：没有它，把 `undefinedVariable` 调用整个删掉也能让前两条变绿。

## 验证

变异验证——恢复「边声明边注册」（`defineFunctionSignature` 移回 `checkFunction`）：

- `forwardReferenceResolves_calleeDeclaredAfterCaller` 红
- `mutualRecursionResolves_inBothDirections` 红
- 护栏测试与其余 26 条仍绿（说明变异确实只打中目标行为）

`aster-lang-core` 全量测试绿。

## 与 #133 的关系

与 PR #133（match 模式绑定）**互不依赖**：两者改的是不同文件、不同代码路径，
本分支基于 main 单独跑全量测试为绿。