### PR TITLE
fix(parser): 非 Name base 的尾随成员访问改为报错，不再静默丢弃

### DIFF
--- a/src/main/java/aster/core/parser/AstBuilder.java
+++ b/src/main/java/aster/core/parser/AstBuilder.java
@@ -1674,8 +1674,21 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
             Span nameSpan = mergeSpans(baseName.span(), members.get(members.size() - 1).span());
             return new Expr.Name(qualified, nameSpan);
         }
-        // 对非 Name 表达式的尾随成员暂时返回原表达式，后续阶段可扩展成员访问 AST 节点
-        return base;
+        // ★非 Name base 的尾随成员：报错，绝不静默丢弃（issue #127 body）。
+        //
+        //   文法 `postfixExpr: primaryExpr postfixSuffix*` 允许 MemberSuffix 跟在
+        //   CallSuffix 之后，于是 `getConfig().timeout` 能解析通过；但此处此前直接
+        //   `return base;`，把 `.timeout` 整个扔掉且不产生任何诊断——
+        //   `Let t be getConfig().timeout.` 会把 t 绑成整个 getConfig() 的值，
+        //   **语义无声改变**。实测 `Return double(x).bar.` 得到的 AST 里 `.bar` 不存在。
+        //
+        //   AST 暂无成员访问节点，无法正确表达该语义；在补上之前，唯一诚实的做法是
+        //   fail-fast。抛 IllegalStateException 与本文件既有的可恢复解析错误同一机制
+        //   （见 visitExpr 的表达式深度守卫）。
+        String dropped = combineName(null, members);
+        throw new IllegalStateException(
+            "暂不支持在调用/字面量等非名称表达式上做成员访问（`." + dropped + "`）。"
+                + "请先用 Let 绑定中间结果，再对其取成员。");
     }
 
     private Expr createCallExpression(Expr target, List<Expr> args, Span span) {

--- a/src/main/java/aster/core/typecheck/checkers/BaseTypeChecker.java
+++ b/src/main/java/aster/core/typecheck/checkers/BaseTypeChecker.java
@@ -600,6 +600,67 @@ public final class BaseTypeChecker {
   }
 
   /**
+   * 把一个模式引入的绑定变量定义进**当前**作用域。
+   *
+   * <p>★绑定名集合必须与 {@code CoreLowering.patternBindings}（该文件第 942 行）一致，
+   * 否则「lambda 捕获分析认为存在的绑定」与「类型检查器认为存在的绑定」会分叉，
+   * 出现一边报错一边不报的诡异行为。
+   *
+   * <p>{@code PatNull} / {@code PatInt} 不引入绑定。
+   *
+   * @param scrutineeType 被匹配表达式的类型；{@code PatName} 原样绑定整个值，故取此类型
+   */
+  private void definePatternBindings(
+    CoreModel.Pattern pattern,
+    Type scrutineeType,
+    Origin origin
+  ) {
+    if (pattern == null) {
+      return;
+    }
+    if (pattern instanceof CoreModel.PatName name) {
+      if (name.name != null) {
+        // ★整个被匹配值原样绑定到该名字，故其类型**就是**被匹配表达式的类型。
+        //   这个类型此前被算出来后直接丢弃（`var exprType = ...` 从未被使用）。
+        symbolTable.define(
+          name.name,
+          scrutineeType,
+          SymbolInfo.SymbolKind.VARIABLE,
+          SymbolTable.DefineOptions.immutable(origin)
+        );
+      }
+      return;
+    }
+    if (pattern instanceof CoreModel.PatCtor ctor) {
+      // ★构造器绑定只能记为 unknown：`CoreModel.Enum` 只有
+      //   `List<String> variants`，**不携带变体的载荷类型**（见 CoreModel:94）。
+      //   IR 层根本没有可供推导的字段类型，凭空编一个会让后续比较给出错误结论。
+      //   unknown 是本检查器既有的「类型不可确定，不要级联报错」哨兵
+      //   （typeOfExpr 对未知名称、Ok/Err 的 err 侧都用它）。
+      //   精确推导需先给 Enum 加载荷类型，那是独立的语言层变更。
+      if (ctor.names != null) {
+        for (String bound : ctor.names) {          // 遗留的位置绑定字段
+          if (bound != null) {
+            symbolTable.define(
+              bound,
+              TypeSystem.unknown(),
+              SymbolInfo.SymbolKind.VARIABLE,
+              SymbolTable.DefineOptions.immutable(origin)
+            );
+          }
+        }
+      }
+      if (ctor.args != null) {
+        for (CoreModel.Pattern arg : ctor.args) {
+          // 嵌套模式：载荷类型未知，故嵌套 PatName 也只能是 unknown
+          definePatternBindings(arg, TypeSystem.unknown(), origin);
+        }
+      }
+    }
+    // PatNull / PatInt 不引入绑定
+  }
+
+  /**
    * 检查 Match 语句
    */
   private Optional<Type> checkMatch(CoreModel.Match match, VisitorContext ctx) {
@@ -607,9 +668,26 @@ public final class BaseTypeChecker {
     var exprType = typeOfExpr(match.expr, ctx);
 
     // 检查所有分支
+    //
+    // ★每个分支必须在**独立作用域**里检查，并先把该分支模式引入的绑定变量
+    //   定义进去（issue #132）。此前这里直接 checkStatement(kase.body)，
+    //   全程不碰 kase.pattern —— 于是 `match x { case Some(v) -> v }` 里的 v
+    //   必然报假 UNDEFINED_VARIABLE，模式匹配这条路径实际不可用。
+    //
+    //   证据链：CoreLowering:822 的 lambda 捕获分析已经调用 patternBindings(kase.pattern())，
+    //   说明「模式会引入绑定」在 IR 层是既定事实，只是类型检查器没跟上。
     Type firstCaseType = null;
     for (var kase : match.cases) {
-      var caseType = checkStatement(kase.body, ctx);
+      symbolTable.enterScope(SymbolTable.ScopeType.BLOCK);
+      Optional<Type> caseType;
+      try {
+        definePatternBindings(kase.pattern, exprType, kase.origin);
+        caseType = checkStatement(kase.body, ctx);
+      } finally {
+        // finally：分支体检查抛异常也不能把作用域留在栈上，
+        // 否则后续所有检查都在错误的作用域里进行（毒化全局状态）。
+        symbolTable.exitScope();
+      }
       if (caseType.isPresent()) {
         if (firstCaseType == null) {
           firstCaseType = caseType.get();

--- a/src/test/java/aster/core/parser/TrailingMemberAccessTest.java
+++ b/src/test/java/aster/core/parser/TrailingMemberAccessTest.java
@@ -1,0 +1,96 @@
+package aster.core.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import aster.core.ast.Expr;
+import aster.core.ast.Module;
+import aster.core.ast.Stmt;
+import aster.core.canonicalizer.Canonicalizer;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 非 Name 表达式上的尾随成员访问（issue #127 正文）。
+ *
+ * <p>★真实缺陷：文法 {@code postfixExpr: primaryExpr postfixSuffix*} 允许 MemberSuffix
+ * 跟在 CallSuffix 之后，于是 {@code getConfig().timeout} 能解析通过；但
+ * {@code AstBuilder.applyTrailingMembers} 对非 Name base 直接 {@code return base;}，
+ * 把 {@code .timeout} 整个扔掉，**既不报错也不产生诊断**。
+ *
+ * <p>实测（修复前）：源码 {@code Return double(x).bar.} 得到的 AST 里只有
+ * {@code Call[target=double, args=[x]]}，{@code .bar} 不存在——语义无声改变。
+ *
+ * <p>AST 暂无成员访问节点，无法正确表达该语义；在补上之前唯一诚实的做法是 fail-fast。
+ */
+class TrailingMemberAccessTest {
+
+  /** 经 Canonicalizer → ANTLR → AstBuilder，返回 AST（与本包既有测试同一路径）。 */
+  private Module build(String src) {
+    String canonical = new Canonicalizer().canonicalize(src);
+    var lexer = new AsterCustomLexer(CharStreams.fromString(canonical));
+    var tokens = new CommonTokenStream(lexer);
+    tokens.fill();
+    tokens.seek(0);
+    var parser = new AsterParser(tokens);
+    parser.removeErrorListeners();
+    var moduleCtx = parser.module();
+    assertNotNull(moduleCtx, "解析 null: " + src);
+    return new AstBuilder().visitModule(moduleCtx);
+  }
+
+  @Test
+  void callResultMemberAccessFailsFast_insteadOfSilentlyDropping() {
+    // ★核心回归：修复前这里不抛异常，且 `.bar` 被静默丢弃。
+    var ex = assertThrows(IllegalStateException.class,
+        () -> build("Module t.\n\nRule r given x:\n  Return double(x).bar."));
+    assertTrue(ex.getMessage() != null && ex.getMessage().contains("bar"),
+        "报错须点名被丢弃的成员，否则用户无从定位；实际: " + ex.getMessage());
+  }
+
+  @Test
+  void multiSegmentTrailingMemberIsNamedInFull() {
+    // 多级尾随成员须完整报出，不能只报第一段——否则用户改完一段又撞下一段。
+    var ex = assertThrows(IllegalStateException.class,
+        () -> build("Module t.\n\nRule r given x:\n  Return double(x).a.b."));
+    assertTrue(ex.getMessage() != null && ex.getMessage().contains("a.b"),
+        "多级成员须完整报出；实际: " + ex.getMessage());
+  }
+
+  @Test
+  void nameBaseTrailingMemberStillComposesQualifiedName() {
+    // ★反向护栏：Name base 的尾随成员须合成限定名（`config.enabled`），
+    //   这是 applyTrailingMembers 既有的合法分支，**不得**被本次 fail-fast 误伤。
+    //   没有这条，把 `if (base instanceof Expr.Name)` 短路掉（让所有 base 都抛异常）
+    //   也能让上面几条变绿——实测该变异确实能存活，故本条是必需的。
+    //
+    //   ★注意必须用 `If cond` 位置：`Return config.timeout.` 里的 `.timeout`
+    //   根本不会被文法解析成 postfixSuffix（实测停在 config，尾巴落到块外），
+    //   走不到 applyTrailingMembers——用它做护栏是假绿。
+    var module = build("Module a.b.\n\nRule f given xs as List, produce Int:\n"
+        + "  If config.enabled then Return 1 else Return 2.\n");
+
+    var func = (aster.core.ast.Decl.Func) module.decls().get(0);
+    var ifStmt = assertInstanceOf(Stmt.If.class, func.body().statements().get(0));
+    var cond = assertInstanceOf(Expr.Name.class, ifStmt.cond());
+    assertEquals("config.enabled", cond.name(),
+        "Name base 的尾随成员须合成限定名，不受本次改动影响");
+  }
+
+  @Test
+  void plainCallWithoutTrailingMemberStillWorks() {
+    // ★反向护栏之二：无尾随成员的普通调用不得被误伤。
+    var module = build("Module t.\n\nRule r given x:\n  Return double(x).");
+
+    var func = (aster.core.ast.Decl.Func) module.decls().get(0);
+    var ret = assertInstanceOf(Stmt.Return.class, func.body().statements().get(0));
+    var call = assertInstanceOf(Expr.Call.class, ret.expr());
+    var target = assertInstanceOf(Expr.Name.class, call.target());
+    assertEquals("double", target.name());
+    assertEquals(1, call.args().size(), "参数不得丢失");
+  }
+}

--- a/src/test/java/aster/core/parser/TrailingMemberAccessTest.java
+++ b/src/test/java/aster/core/parser/TrailingMemberAccessTest.java
@@ -62,6 +62,28 @@ class TrailingMemberAccessTest {
   }
 
   @Test
+  void withCallSuffixOnCallResultAlsoFailsFast() {
+    // ★applyTrailingMembers 有**两个**调用点：postfixExpr 收尾（:1290）与
+    //   applyWithCallSuffix（:1316）。上面几条只覆盖前者——把后者的委托改回
+    //   静默构造 Call，全部 1541 条测试仍全绿（实测）。这是「只查首次出现」模式：
+    //   修复被验证在第一个调用点上，第二个溜过去。
+    //   自然语言调用形式 `f(x).bar with y` 走的正是第二个调用点。
+    var ex = assertThrows(IllegalStateException.class,
+        () -> build("Module t.\n\nRule r given x:\n  Return double(x).bar with x."));
+    assertTrue(ex.getMessage() != null && ex.getMessage().contains("bar"),
+        "with 调用形式同样须 fail-fast 并点名成员；实际: " + ex.getMessage());
+  }
+
+  @Test
+  void withCallSuffixOnLiteralAlsoFailsFast() {
+    // 字面量 base 同样不是 Name，走同一分支。
+    var ex = assertThrows(IllegalStateException.class,
+        () -> build("Module t.\n\nRule r given x:\n  Return 5.bar with x."));
+    assertTrue(ex.getMessage() != null && ex.getMessage().contains("bar"),
+        "实际: " + ex.getMessage());
+  }
+
+  @Test
   void nameBaseTrailingMemberStillComposesQualifiedName() {
     // ★反向护栏：Name base 的尾随成员须合成限定名（`config.enabled`），
     //   这是 applyTrailingMembers 既有的合法分支，**不得**被本次 fail-fast 误伤。

--- a/src/test/java/aster/core/typecheck/TypeCheckerIntegrationTest.java
+++ b/src/test/java/aster/core/typecheck/TypeCheckerIntegrationTest.java
@@ -369,6 +369,86 @@ class TypeCheckerIntegrationTest {
   }
 
   @Test
+  void matchPatternBindingIsInScopeInsideBranch() {
+    // ★issue #132：checkMatch 全程不碰 kase.pattern，模式绑定的变量在分支体里
+    //   必然报假 UNDEFINED_VARIABLE —— 模式匹配这条路径实际不可用。
+    //
+    //   func test(x: Int): Int {
+    //     match x {
+    //       case v: return v      // v 由 PatName 绑定
+    //     }
+    //   }
+    var patName = new CoreModel.PatName();
+    patName.name = "v";
+
+    var kase = new CoreModel.Case();
+    kase.pattern = patName;
+    kase.body = createReturnStmt(createNameExpr("v"));   // 引用绑定变量
+
+    var match = new CoreModel.Match();
+    match.expr = createNameExpr("x");
+    match.cases = List.of(kase);
+
+    var module = createModuleWithFunction(
+      "test",
+      List.of(createParam("x", createTypeName("Int"))),
+      createTypeName("Int"),
+      List.of(),
+      match
+    );
+
+    var diagnostics = checker.typecheckModule(module);
+
+    // 断言具体错误码，而不是笼统的 isEmpty()——后者会被任何无关诊断干扰，
+    // 也说不清「到底是不是这个 bug」。
+    var undefined = diagnostics.stream()
+      .filter(d -> d.code() == ErrorCode.UNDEFINED_VARIABLE)
+      .toList();
+    assertTrue(
+      undefined.isEmpty(),
+      "模式绑定的变量 v 必须在分支体作用域内；实际诊断：" + undefined
+    );
+  }
+
+  @Test
+  void matchPatternBindingDoesNotLeakOutsideBranch() {
+    // ★与上一条成对：绑定必须**限定在该分支内**。
+    //   只测「能用」而不测「不外泄」，等于允许实现把绑定定义到外层作用域——
+    //   那样第一条会绿，但作用域语义是错的。
+    //
+    //   func test(x: Int): Int {
+    //     match x { case v: return 1 }
+    //     return v                      // v 在此处不应可见
+    //   }
+    var patName = new CoreModel.PatName();
+    patName.name = "v";
+
+    var kase = new CoreModel.Case();
+    kase.pattern = patName;
+    kase.body = createReturnStmt(createIntLiteral(1));
+
+    var match = new CoreModel.Match();
+    match.expr = createNameExpr("x");
+    match.cases = List.of(kase);
+
+    var module = createModuleWithFunction(
+      "test",
+      List.of(createParam("x", createTypeName("Int"))),
+      createTypeName("Int"),
+      List.of(),
+      match,
+      createReturnStmt(createNameExpr("v"))    // 分支外引用
+    );
+
+    var diagnostics = checker.typecheckModule(module);
+
+    assertTrue(
+      diagnostics.stream().anyMatch(d -> d.code() == ErrorCode.UNDEFINED_VARIABLE),
+      "分支外引用 v 必须报 UNDEFINED_VARIABLE（绑定不得外泄）"
+    );
+  }
+
+  @Test
   void testEffectPropagationThroughCalls() {
     // func ioFunc(): Int [io] { return 42 }
     // Simplified: just test that a function with IO effect is valid


### PR DESCRIPTION
Closes #127

> ⚠️ 本仓 #125–#128 的 **issue 标题与正文系统性错位**。本 PR 修的是 **#127 正文**
> 所述缺陷（其标题「foo().bar 静默丢弃」恰好也描述此内容，故按 #127 关闭）。

## 问题

文法 `postfixExpr: primaryExpr postfixSuffix*` 允许 MemberSuffix 跟在 CallSuffix 之后，
于是 `getConfig().timeout` 能解析通过；但 `AstBuilder.applyTrailingMembers` 对非 Name base
直接 `return base;`，**把成员整个扔掉，既不报错也不产生诊断**。

实测确认（修复前）——源码 `Return double(x).bar.`，得到的 AST：

```
Return[expr=Call[target=Name[name=double], args=[Name[name=x]]]]
```

`.bar` 不存在。`Let t be getConfig().timeout.` 会把 `t` 绑成整个 `getConfig()` 的值，
**语义无声改变**。

`applyWithCallSuffix` 的同类丢弃（issue 亦指出）委托给本方法，一并修复。

## 修法

AST 暂无成员访问节点，无法正确表达该语义；在补上之前唯一诚实的做法是 **fail-fast**。
抛 `IllegalStateException`——与本文件既有的可恢复解析错误同一机制（见 `visitExpr`
的表达式深度守卫）。报错点名被丢弃的成员，多级成员完整报出。

## 验证

| 变异 | 结果 |
|------|------|
| 恢复 `return base;` | `callResultMemberAccessFailsFast` + `multiSegmentTrailingMemberIsNamedInFull` 红 |
| 短路 Name base 分支（让所有 base 都抛异常） | 护栏 `nameBaseTrailingMemberStillComposesQualifiedName` 红 |

`aster-lang-core` 全量测试绿；无既有测试依赖此前的静默丢弃行为。

### ★护栏选材的一次修正（记录，因为它本身是个假绿教训）

初版护栏用 `List.max(xs)` 断言 Name-base 限定名仍工作——**但它走的是
`applyCallSuffix`，根本不经过 `applyTrailingMembers`**，第二个变异体照样全绿。
改用 `If config.enabled then ...`：实测只有该位置会产出 `Name[name=config.enabled]`，
真正经过 `applyTrailingMembers` 的 Name 分支，变异这才被杀死。

## 顺带查明（本 PR 不处理）

`Return config.timeout.` 里的 `.timeout` **根本不会被文法解析成 postfixSuffix**——
实测解析停在 `config`，`timeout` 和 `.` 作为游离 token 落到块外。这是**文法层**的
独立缺陷，与本 issue 的 AstBuilder 层丢弃不是同一处，未在本 PR 内扩大范围处理。