### PR TITLE
fix(diagnostics): 消息模板统一命名占位符，修 23 个码渲染出字面 %s

### DIFF
--- a/src/main/java/aster/core/typecheck/ErrorCode.java
+++ b/src/main/java/aster/core/typecheck/ErrorCode.java
@@ -3,105 +3,104 @@
 
 package aster.core.typecheck;
 
-import java.util.Locale;
 
 /**
  * 错误码与消息模板的枚举定义，由共享 JSON 自动生成，确保 Java 与 TypeScript 行为一致。
  */
 public enum ErrorCode {
-  TYPE_MISMATCH("E001", Category.TYPE, Severity.ERROR, "Type mismatch: expected %s, got %s", "检查类型标注与表达式的推断结果是否一致。"),
-  TYPE_MISMATCH_ASSIGN("E002", Category.TYPE, Severity.ERROR, "Type mismatch assigning to '%s': %s vs %s", "确认变量先前绑定的类型与当前赋值结果一致。"),
-  RETURN_TYPE_MISMATCH("E003", Category.TYPE, Severity.ERROR, "Return type mismatch: expected %s, got %s", "检查函数返回语句与声明的返回类型是否一致。"),
-  TYPE_VAR_UNDECLARED("E004", Category.TYPE, Severity.ERROR, "Type variable '%s' is used in '%s' but not declared in its type parameters.", "在函数签名的 of 子句中显式声明使用到的类型变量。"),
-  TYPE_PARAM_UNUSED("E005", Category.TYPE, Severity.WARNING, "Type parameter '%s' on '%s' is declared but not used.", "移除未使用的类型参数，避免造成误导。"),
-  TYPEVAR_LIKE_UNDECLARED("E006", Category.TYPE, Severity.ERROR, "Type variable-like '%s' is used in '%s' but not declared; declare it with 'of %s'.", "对于看起来像类型变量的名称，务必在 of 子句中声明。"),
-  TYPEVAR_INCONSISTENT("E007", Category.TYPE, Severity.ERROR, "Type variable '%s' inferred inconsistently: %s vs %s", "确认类型推断的多个使用点产出相同的具体类型。"),
-  IF_BRANCH_MISMATCH("E008", Category.TYPE, Severity.ERROR, "If分支返回类型不一致: then分支 %s vs else分支 %s", "确保 if 两个分支返回类型保持一致。"),
-  MATCH_BRANCH_MISMATCH("E009", Category.TYPE, Severity.ERROR, "Match case return types differ: %s vs %s", "检查 match 每个分支的返回类型是否统一。"),
-  INTEGER_PATTERN_TYPE("E010", Category.TYPE, Severity.ERROR, "Integer pattern used on non-Int scrutinee (%s)", "仅在 Int 类型的匹配表达式中使用整数模式。"),
-  UNKNOWN_FIELD("E011", Category.TYPE, Severity.ERROR, "Unknown field '%s' for %s", "检查构造体或数据类型的字段名称是否正确。"),
-  FIELD_TYPE_MISMATCH("E012", Category.TYPE, Severity.ERROR, "Field '%s' expects %s, got %s", "校验字段初始化表达式的类型是否匹配声明。"),
-  MISSING_REQUIRED_FIELD("E013", Category.TYPE, Severity.ERROR, "构造 %s 缺少必需字段 '%s'", "为数据构造提供声明中的所有必需字段。"),
-  NOT_CALL_ARITY("E014", Category.TYPE, Severity.ERROR, "not(...) expects 1 argument", "调整 not 调用的参数数量为 1。"),
-  AWAIT_TYPE("E015", Category.TYPE, Severity.WARNING, "await expects Maybe<T> or Result<T,E>, got %s", "仅对 Maybe 或 Result 类型调用 await。"),
-  DUPLICATE_ENUM_CASE("E016", Category.TYPE, Severity.WARNING, "Duplicate enum case '%s' in match on %s.", "移除重复的枚举分支，保持匹配语句简洁。"),
-  NON_EXHAUSTIVE_MAYBE("E017", Category.TYPE, Severity.WARNING, "Non-exhaustive match on Maybe type; missing %s case.", "为 Maybe 匹配补齐 null 与非 null 分支。"),
-  NON_EXHAUSTIVE_ENUM("E018", Category.TYPE, Severity.WARNING, "Non-exhaustive match on %s; missing: %s", "补充所有未覆盖的枚举分支，或添加通配符。"),
-  AMBIGUOUS_INTEROP_NUMERIC("E019", Category.TYPE, Severity.WARNING, "Ambiguous interop call '%s': mixing numeric kinds (Int=%s, Long=%s, Double=%s). Overload resolution may widen/box implicitly.", "统一互操作调用的参数数值类型，避免隐式装箱与拓宽。"),
-  LIST_ELEMENT_TYPE_MISMATCH("E020", Category.TYPE, Severity.ERROR, "List literal element type mismatch: expected %s, got %s", "确保列表字面量中的所有元素类型一致。"),
-  OPTIONAL_EXPECTED("E021", Category.TYPE, Severity.ERROR, "Optional value required here: expected Maybe or Option, but got %s", "传入 Maybe/Option 类型或显式包装值。"),
-  WORKFLOW_COMPENSATE_TYPE("E022", Category.TYPE, Severity.ERROR, "Compensate block for step '%s' must return Result<Unit, %s>, got %s", "确保补偿块返回 Result<Unit, E>，其中 E 为 step 错误类型。"),
-  WORKFLOW_COMPENSATE_MISSING("E023", Category.EFFECT, Severity.WARNING, "Step '%s' performs side effects but does not define a compensate block.", "为包含 IO 副作用的 step 提供 compensate 块以便回滚。"),
-  WORKFLOW_RETRY_INVALID("E024", Category.TYPE, Severity.ERROR, "Workflow retry max attempts must be greater than zero (actual: %s).", "设置 retry.maxAttempts 为正整数。"),
-  WORKFLOW_TIMEOUT_INVALID("E025", Category.TYPE, Severity.ERROR, "Workflow timeout must be greater than zero milliseconds (actual: %s).", "配置 timeout 秒数为正值，确保补偿逻辑可被触发。"),
-  WORKFLOW_MISSING_IO_EFFECT("E026", Category.EFFECT, Severity.ERROR, "Workflow '%s' must declare @io effect before using a 'workflow' block.", "在函数 '{func}' 的头部添加 `It performs io ...`（可同时声明 capability），否则编译器拒绝 workflow 语句。"),
-  WORKFLOW_UNDECLARED_CAPABILITY("E027", Category.CAPABILITY, Severity.ERROR, "Workflow '%s' step '%s' uses capability %s that is not declared on the function header.", "在 `It performs io with ...` 中列出 {capability}（例如 Http、Sql、Secrets），或调整 step 代码避免调用未授权能力。"),
-  COMPENSATE_NEW_CAPABILITY("E028", Category.CAPABILITY, Severity.ERROR, "Compensate block for step '%s' in function '%s' introduces new capability %s that does not appear in the main step body.", "Compensate 只能重复主体已使用的能力；如需额外调用，请将相同行为移至主体或在主体中声明该 capability。"),
-  WORKFLOW_UNKNOWN_STEP_DEPENDENCY("E029", Category.SCOPE, Severity.ERROR, "Workflow step '%s' depends on undefined step '%s'.", "仅引用当前 workflow 中已声明的步骤名称，或修正依赖拼写。"),
-  WORKFLOW_CIRCULAR_DEPENDENCY("E030", Category.TYPE, Severity.ERROR, "Workflow contains circular step dependency: %s", "移除或重构循环依赖，确保步骤可拓扑排序执行。"),
+  TYPE_MISMATCH("E001", Category.TYPE, Severity.ERROR, "Type mismatch: expected {expected}, got {actual}", "Check that the type annotation matches the inferred expression type."),
+  TYPE_MISMATCH_ASSIGN("E002", Category.TYPE, Severity.ERROR, "Type mismatch assigning to '{name}': {expected} vs {actual}", "Ensure the variable's previous binding type matches the current assignment."),
+  RETURN_TYPE_MISMATCH("E003", Category.TYPE, Severity.ERROR, "Return type mismatch: expected {expected}, got {actual}", "Check that the return statement matches the declared return type."),
+  TYPE_VAR_UNDECLARED("E004", Category.TYPE, Severity.ERROR, "Type variable '{name}' is used in '{func}' but not declared in its type parameters.", "Declare used type variables in the function signature's 'of' clause."),
+  TYPE_PARAM_UNUSED("E005", Category.TYPE, Severity.WARNING, "Type parameter '{name}' on '{func}' is declared but not used.", "Remove unused type parameters to avoid confusion."),
+  TYPEVAR_LIKE_UNDECLARED("E006", Category.TYPE, Severity.ERROR, "Type variable-like '{name}' is used in '{func}' but not declared; declare it with 'of {name}'.", "For names that look like type variables, declare them in the 'of' clause."),
+  TYPEVAR_INCONSISTENT("E007", Category.TYPE, Severity.ERROR, "Type variable '{name}' inferred inconsistently: {previous} vs {actual}", "Ensure all usage sites of a type variable produce the same concrete type."),
+  IF_BRANCH_MISMATCH("E008", Category.TYPE, Severity.ERROR, "If branch type mismatch: then {thenType} vs else {elseType}", "Ensure both branches of an if expression return the same type."),
+  MATCH_BRANCH_MISMATCH("E009", Category.TYPE, Severity.ERROR, "Match case return types differ: {expected} vs {actual}", "Check that all match branches return the same type."),
+  INTEGER_PATTERN_TYPE("E010", Category.TYPE, Severity.ERROR, "Integer pattern used on non-Int scrutinee ({scrutineeType})", "Only use integer patterns on Int-typed match expressions."),
+  UNKNOWN_FIELD("E011", Category.TYPE, Severity.ERROR, "Unknown field '{field}' for {type}", "Check that the field name is correct for the data type."),
+  FIELD_TYPE_MISMATCH("E012", Category.TYPE, Severity.ERROR, "Field '{field}' expects {expected}, got {actual}", "Verify the field initializer expression matches the declared type."),
+  MISSING_REQUIRED_FIELD("E013", Category.TYPE, Severity.ERROR, "Construction of {type} missing required field '{field}'", "Provide all required fields declared in the data type."),
+  NOT_CALL_ARITY("E014", Category.TYPE, Severity.ERROR, "not(...) expects 1 argument", "Adjust the not() call to have exactly 1 argument."),
+  AWAIT_TYPE("E015", Category.TYPE, Severity.WARNING, "await expects Maybe<T> or Result<T,E>, got {type}", "Only use await on Maybe or Result types."),
+  DUPLICATE_ENUM_CASE("E016", Category.TYPE, Severity.WARNING, "Duplicate enum case '{case}' in match on {type}.", "Remove duplicate enum branches to keep the match concise."),
+  NON_EXHAUSTIVE_MAYBE("E017", Category.TYPE, Severity.WARNING, "Non-exhaustive match on Maybe type; missing {missing} case.", "Add both null and non-null branches for Maybe matches."),
+  NON_EXHAUSTIVE_ENUM("E018", Category.TYPE, Severity.WARNING, "Non-exhaustive match on {type}; missing: {missing}", "Add all uncovered enum branches, or add a wildcard."),
+  AMBIGUOUS_INTEROP_NUMERIC("E019", Category.TYPE, Severity.WARNING, "Ambiguous interop call '{target}': mixing numeric kinds (Int={hasInt}, Long={hasLong}, Double={hasDouble}). Overload resolution may widen/box implicitly.", "Unify numeric argument types in interop calls to avoid implicit boxing and widening."),
+  LIST_ELEMENT_TYPE_MISMATCH("E020", Category.TYPE, Severity.ERROR, "List literal element type mismatch: expected {expected}, got {actual}", "Ensure all elements in a list literal have the same type."),
+  OPTIONAL_EXPECTED("E021", Category.TYPE, Severity.ERROR, "Optional value required here: expected Maybe or Option, but got {actual}", "Pass a Maybe/Option type or explicitly wrap the value."),
+  WORKFLOW_COMPENSATE_TYPE("E022", Category.TYPE, Severity.ERROR, "Compensate block for step '{step}' must return Result<Unit, {expectedErr}>, got {actual}", "Ensure the compensate block returns Result<Unit, E> where E is the step error type."),
+  WORKFLOW_COMPENSATE_MISSING("E023", Category.EFFECT, Severity.WARNING, "Step '{step}' performs side effects but does not define a compensate block.", "Provide a compensate block for steps with IO side effects to enable rollback."),
+  WORKFLOW_RETRY_INVALID("E024", Category.TYPE, Severity.ERROR, "Workflow retry max attempts must be greater than zero (actual: {maxAttempts}).", "Set retry.maxAttempts to a positive integer."),
+  WORKFLOW_TIMEOUT_INVALID("E025", Category.TYPE, Severity.ERROR, "Workflow timeout must be greater than zero milliseconds (actual: {milliseconds}).", "Set the timeout to a positive value to ensure compensate logic can be triggered."),
+  WORKFLOW_MISSING_IO_EFFECT("E026", Category.EFFECT, Severity.ERROR, "Workflow '{func}' must declare @io effect before using a 'workflow' block.", "Add @io effect declaration to the function header."),
+  WORKFLOW_UNDECLARED_CAPABILITY("E027", Category.CAPABILITY, Severity.ERROR, "Workflow '{func}' step '{step}' uses capability {capability} that is not declared on the function header.", "Declare {capability} in the function header or adjust the step code."),
+  COMPENSATE_NEW_CAPABILITY("E028", Category.CAPABILITY, Severity.ERROR, "Compensate block for step '{step}' in function '{func}' introduces new capability {capability} that does not appear in the main step body.", "Compensate blocks can only reuse capabilities from the main step body."),
+  WORKFLOW_UNKNOWN_STEP_DEPENDENCY("E029", Category.SCOPE, Severity.ERROR, "Workflow step '{step}' depends on undefined step '{dependency}'.", "Only reference declared step names in the current workflow."),
+  WORKFLOW_CIRCULAR_DEPENDENCY("E030", Category.TYPE, Severity.ERROR, "Workflow contains circular step dependency: {cycle}", "Remove or restructure circular dependencies to enable topological execution."),
   // ADR 0025：Decimal↔Double 混算编译期拦截（与 TS E031 对齐）。Double 是二进制浮点，
   // 与精确 Decimal 混算会注入舍入误差，破坏可证明性；Int/Long→Decimal 精确提升放行。
-  DECIMAL_DOUBLE_MIXING("E031", Category.TYPE, Severity.ERROR, "Cannot combine Decimal and Double in '{operator}'. Double is binary floating-point and would inject rounding error into an exact Decimal. Use Decimal literals (e.g. 1.08m) on both sides, or Int/Long (exact promotion).", "使两侧操作数都为 Decimal（m 后缀），或改用 Int/Long（可精确提升为 Decimal）。"),
+  DECIMAL_DOUBLE_MIXING("E031", Category.TYPE, Severity.ERROR, "Cannot combine Decimal and Double in '{operator}'. Double is binary floating-point and would inject rounding error into an exact Decimal. Use Decimal literals (e.g. 1.08m) on both sides, or Int/Long (exact promotion).", "Make both operands Decimal (suffix m), or use Int/Long which promote exactly to Decimal."),
   // P0-R3 (codex review High #3): 与 TS 端 ERROR_METADATA category 对齐——
   // 5 个核心 PII codes 从 Category.TYPE 改为 Category.PII。之前的 'TYPE'
   // 分类是历史包袱，让任何按 category 派生 PII 集合的代码（如跨语言
   // conformance）必然不一致。
-  PII_ASSIGN_DOWNGRADE("E070", Category.PII, Severity.ERROR, "禁止将 PII 数据赋给较低等级目标: %s -> %s", "使用脱敏函数或为目标变量声明匹配的 @pii 等级。"),
-  PII_SINK_UNSANITIZED("E072", Category.PII, Severity.ERROR, "PII 等级 %s 数据未脱敏即输出到 %s", "在输出前调用 redact() 或 tokenize() 以降低敏感度。"),
-  PII_ARG_VIOLATION("E073", Category.PII, Severity.ERROR, "PII 参数类型不匹配: 期望 %s, 实际 %s", "检查函数签名，确保 PII 等级与类别一致。"),
-  DUPLICATE_IMPORT_ALIAS("E100", Category.SCOPE, Severity.WARNING, "Duplicate import alias '%s'.", "为不同的导入使用唯一别名，避免覆盖。"),
-  UNDEFINED_VARIABLE("E101", Category.SCOPE, Severity.ERROR, "Undefined variable: %s", "在使用变量前先声明并初始化。"),
-  MULTIPLE_ENTRY_RULES("E102", Category.SCOPE, Severity.ERROR, "Multiple @entry rules in module: {rules}", "每个模块最多保留一个 @entry Rule。"),
-  IMPORT_SYMBOL_CONFLICT("E103", Category.SCOPE, Severity.WARNING, "Import symbol conflict: {symbol}", "调整 import alias 或本地顶层声明名称，避免导入符号冲突。"),
+  PII_ASSIGN_DOWNGRADE("E070", Category.PII, Severity.ERROR, "Cannot assign PII data to lower-level target: {source} -> {target}", "Use a sanitization function or declare a matching @pii level on the target."),
+  PII_SINK_UNSANITIZED("E072", Category.PII, Severity.ERROR, "PII level {level} data output to {sinkKind} without sanitization", "Call redact() or tokenize() before output to reduce sensitivity."),
+  PII_ARG_VIOLATION("E073", Category.PII, Severity.ERROR, "PII argument type mismatch: expected {expected}, got {actual}", "Check the function signature to ensure PII levels and categories match."),
+  DUPLICATE_IMPORT_ALIAS("E100", Category.SCOPE, Severity.WARNING, "Duplicate import alias '{alias}'.", "Use unique aliases for different imports to avoid shadowing."),
+  UNDEFINED_VARIABLE("E101", Category.SCOPE, Severity.ERROR, "Undefined variable: {name}", "Declare and initialize the variable before use."),
+  MULTIPLE_ENTRY_RULES("E102", Category.SCOPE, Severity.ERROR, "Multiple @entry rules in module: {rules}", "Keep at most one Rule annotated with @entry in a module."),
+  IMPORT_SYMBOL_CONFLICT("E103", Category.SCOPE, Severity.WARNING, "Import symbol conflict: {symbol}", "Adjust the import alias or the local top-level declaration name to avoid the import symbol conflict."),
   // 与 TS 端 ErrorCode.DUPLICATE_SYMBOL 对齐（原 TS 端占 E102，反向重建 error_codes.json
   // 时按用户裁决迁至 E104，让 E102 归 MULTIPLE_ENTRY_RULES）。
-  DUPLICATE_SYMBOL("E104", Category.SCOPE, Severity.ERROR, "Symbol '{name}' is already defined in this scope.", "选择不同的名称或检查是否存在意外的重复声明。"),
-  EFF_MISSING_IO("E200", Category.EFFECT, Severity.ERROR, "Function '%s' may perform I/O but is missing @io effect.", "为具有 IO 行为的函数声明 @io 效果。"),
-  EFF_MISSING_CPU("E201", Category.EFFECT, Severity.ERROR, "Function '%s' may perform CPU-bound work but is missing @cpu (or @io) effect.", "为 CPU 密集型函数声明 @cpu 或 @io 效果。"),
-  EFF_SUPERFLUOUS_IO_CPU_ONLY("E202", Category.EFFECT, Severity.INFO, "Function '%s' declares @io but only CPU-like work found; @io subsumes @cpu and may be unnecessary.", "若函数仅执行 CPU 工作，可移除多余的 @io 声明。"),
-  EFF_SUPERFLUOUS_IO("E203", Category.EFFECT, Severity.WARNING, "Function '%s' declares @io but no obvious I/O found.", "确认是否需要 @io；若无 IO 行为可移除。"),
-  EFF_SUPERFLUOUS_CPU("E204", Category.EFFECT, Severity.WARNING, "Function '%s' declares @cpu but no obvious CPU-bound work found.", "移除多余的 @cpu 声明或增加相应的 CPU 工作。"),
-  EFF_INFER_MISSING_IO("E205", Category.EFFECT, Severity.ERROR, "函数 '%s' 缺少 @io 效果声明，推断要求 IO。", "根据推断结果为函数添加 @io 效果。"),
-  EFF_INFER_MISSING_CPU("E206", Category.EFFECT, Severity.ERROR, "函数 '%s' 缺少 @cpu 效果声明，推断要求 CPU（或 @io）。", "根据推断结果补齐 @cpu 或 @io 效果。"),
-  EFF_INFER_REDUNDANT_IO("E207", Category.EFFECT, Severity.WARNING, "函数 '%s' 声明了 @io，但推断未发现 IO 副作用。", "确认是否需要保留 @io 声明。"),
-  EFF_INFER_REDUNDANT_CPU("E208", Category.EFFECT, Severity.WARNING, "函数 '%s' 声明了 @cpu，但推断未发现 CPU 副作用。", "若无 CPU 副作用，可删除 @cpu 声明。"),
-  EFF_INFER_REDUNDANT_CPU_WITH_IO("E209", Category.EFFECT, Severity.WARNING, "函数 '%s' 同时声明 @cpu 和 @io；由于需要 @io，@cpu 可移除。", "保留 @io 即可满足需求，移除多余的 @cpu。"),
+  DUPLICATE_SYMBOL("E104", Category.SCOPE, Severity.ERROR, "Symbol '{name}' is already defined in this scope.", "Choose a different name or check for unintended duplicate declarations."),
+  EFF_MISSING_IO("E200", Category.EFFECT, Severity.ERROR, "Function '{func}' may perform I/O but is missing @io effect.", "Declare @io effect for functions that perform I/O."),
+  EFF_MISSING_CPU("E201", Category.EFFECT, Severity.ERROR, "Function '{func}' may perform CPU-bound work but is missing @cpu (or @io) effect.", "Declare @cpu or @io effect for CPU-intensive functions."),
+  EFF_SUPERFLUOUS_IO_CPU_ONLY("E202", Category.EFFECT, Severity.INFO, "Function '{func}' declares @io but only CPU-like work found; @io subsumes @cpu and may be unnecessary.", "If the function only does CPU work, consider removing the redundant @io declaration."),
+  EFF_SUPERFLUOUS_IO("E203", Category.EFFECT, Severity.WARNING, "Function '{func}' declares @io but no obvious I/O found.", "Confirm @io is needed; remove if no I/O behavior exists."),
+  EFF_SUPERFLUOUS_CPU("E204", Category.EFFECT, Severity.WARNING, "Function '{func}' declares @cpu but no obvious CPU-bound work found.", "Remove the redundant @cpu declaration or add corresponding CPU work."),
+  EFF_INFER_MISSING_IO("E205", Category.EFFECT, Severity.ERROR, "Function '{func}' missing @io effect declaration, inference requires IO.", "Add @io effect based on inference results."),
+  EFF_INFER_MISSING_CPU("E206", Category.EFFECT, Severity.ERROR, "Function '{func}' missing @cpu effect declaration, inference requires CPU (or @io).", "Add @cpu or @io effect based on inference results."),
+  EFF_INFER_REDUNDANT_IO("E207", Category.EFFECT, Severity.WARNING, "Function '{func}' declares @io but no IO side effects inferred.", "Confirm whether to keep the @io declaration."),
+  EFF_INFER_REDUNDANT_CPU("E208", Category.EFFECT, Severity.WARNING, "Function '{func}' declares @cpu but no CPU side effects inferred.", "Remove the @cpu declaration if no CPU side effects exist."),
+  EFF_INFER_REDUNDANT_CPU_WITH_IO("E209", Category.EFFECT, Severity.WARNING, "Function '{func}' declares both @cpu and @io; @cpu is redundant since @io is required.", "Keep @io only; remove the redundant @cpu."),
   // 与 TS 端 ErrorCode.EFFECT_VAR_UNDECLARED / EFFECT_VAR_UNRESOLVED 对齐（TS 端已有，
   // 补齐 Java 侧码表使双引擎 error_codes.json 契约一致；Java 引擎实现效果变量检查时可 emit）。
-  EFFECT_VAR_UNDECLARED("E210", Category.TYPE, Severity.ERROR, "Effect variable {var} undeclared", "在函数签名的效果参数列表中添加效果类型参数。"),
-  EFFECT_VAR_UNRESOLVED("E211", Category.TYPE, Severity.ERROR, "Effect variable {vars} could not be resolved to concrete effects", "提供明确效果（pure/cpu/io/workflow）或移除未使用的效果变量。"),
+  EFFECT_VAR_UNDECLARED("E210", Category.TYPE, Severity.ERROR, "Effect variable {var} undeclared", "Add the effect type parameter to the function signature's effect parameter list."),
+  EFFECT_VAR_UNRESOLVED("E211", Category.TYPE, Severity.ERROR, "Effect variable {vars} could not be resolved to concrete effects", "Provide explicit effects (pure/cpu/io/workflow) or remove unused effect variables."),
   // E212（issue aster-lang-ts#90）：调用了效果未知的 builtin。既非本地函数、无导入效果
   // 签名、不匹配任何已知前缀、也不属于已知纯 stdlib 命名空间——此前这类调用被**静默推断
   // 为 pure**，一个真做网络请求但名为 Webhook.post 的 builtin 因此不会触发缺 @io 诊断。
   // 前缀匹配本质不可能完备，故不改判为"不纯"（会大量误报），而是把未知显式暴露成 warning。
   // 目前只有 TS 侧发出该码；此处登记以保持 shared/error_codes.json 单源码表两端一致
   // （generate_error_codes.ts 会校验 drift）。
-  EFF_INFER_UNKNOWN_BUILTIN("E212", Category.EFFECT, Severity.WARNING, "Effect of builtin '{builtin}' called by '{func}' is unknown; it is NOT assumed pure", "通过 ASTER_EFFECT_CONFIG 前缀声明、提供导入效果签名，或改用已知 stdlib 命名空间。"),
-  CAPABILITY_NOT_ALLOWED("E300", Category.CAPABILITY, Severity.ERROR, "Function '%s' requires %s capability but manifest for module '%s' denies it.", "更新能力清单或修改函数实现以符合限制。"),
-  EFF_CAP_MISSING("E301", Category.CAPABILITY, Severity.ERROR, "Function '%s' uses %s capability but header declares [%s].", "在函数头部声明实际使用到的能力。"),
-  EFF_CAP_SUPERFLUOUS("E302", Category.CAPABILITY, Severity.INFO, "Function '%s' declares %s capability but it is not used.", "移除未使用的能力声明以保持清晰。"),
-  CAPABILITY_INFER_MISSING_IO("E303", Category.CAPABILITY, Severity.ERROR, "Function '%s' uses IO capabilities [%s] but is missing @io effect (e.g., %s).", "在函数头部声明 `It performs io ...`，或移除相关调用保持纯度。"),
-  CAPABILITY_INFER_MISSING_CPU("E304", Category.CAPABILITY, Severity.ERROR, "Function '%s' performs CPU capability calls (e.g., %s) but declares neither @cpu nor @io effect.", "为函数添加 @cpu 或 @io 效果以覆盖 CPU 能力。"),
-  PII_HTTP_UNENCRYPTED("E400", Category.PII, Severity.ERROR, "PII data transmitted over HTTP without encryption", "使用加密通道（HTTPS）或脱敏处理后再传输 PII 数据。"),
-  PII_ANNOTATION_MISSING("E401", Category.PII, Severity.ERROR, "PII annotation missing for value flowing into '%s'", "为敏感数据添加 @pii 标注以便跟踪。"),
-  PII_SENSITIVITY_MISMATCH("E402", Category.PII, Severity.WARNING, "PII sensitivity mismatch: required %s, got %s", "调整数据的敏感级别或更新流程要求。"),
+  EFF_INFER_UNKNOWN_BUILTIN("E212", Category.EFFECT, Severity.WARNING, "Effect of builtin '{builtin}' called by '{func}' is unknown; it is NOT assumed pure", "Declare it via ASTER_EFFECT_CONFIG prefixes, supply an imported effect signature, or use a known stdlib namespace."),
+  CAPABILITY_NOT_ALLOWED("E300", Category.CAPABILITY, Severity.ERROR, "Function '{func}' requires {cap} capability but manifest for module '{module}' denies it.", "Update the capability manifest or modify the function to comply."),
+  EFF_CAP_MISSING("E301", Category.CAPABILITY, Severity.ERROR, "Function '{func}' uses {cap} capability but header declares [{declared}].", "Declare the actually used capabilities in the function header."),
+  EFF_CAP_SUPERFLUOUS("E302", Category.CAPABILITY, Severity.INFO, "Function '{func}' declares {cap} capability but it is not used.", "Remove unused capability declarations for clarity."),
+  CAPABILITY_INFER_MISSING_IO("E303", Category.CAPABILITY, Severity.ERROR, "Function '{func}' uses IO capabilities [{capabilities}] but is missing @io effect (e.g., {calls}).", "Declare @io effect in the function header, or remove related calls to stay pure."),
+  CAPABILITY_INFER_MISSING_CPU("E304", Category.CAPABILITY, Severity.ERROR, "Function '{func}' performs CPU capability calls (e.g., {calls}) but declares neither @cpu nor @io effect.", "Add @cpu or @io effect to cover CPU capabilities."),
+  PII_HTTP_UNENCRYPTED("E400", Category.PII, Severity.ERROR, "PII data transmitted over HTTP without encryption", "Use an encrypted channel (HTTPS) or sanitize before transmitting PII data."),
+  PII_ANNOTATION_MISSING("E401", Category.PII, Severity.ERROR, "PII annotation missing for value flowing into '{sink}'", "Add @pii annotation to sensitive data for tracking."),
+  PII_SENSITIVITY_MISMATCH("E402", Category.PII, Severity.WARNING, "PII sensitivity mismatch: required {required}, got {actual}", "Adjust the data sensitivity level or update the process requirements."),
   // P0-R2: 与 TS 端 aster-lang-ts ErrorCode.PII_MISSING_CONSENT_CHECK 镜像
-  PII_MISSING_CONSENT_CHECK("E403", Category.PII, Severity.WARNING, "Function '%s' processes PII data without consent check (GDPR Art. 6)", "在处理 PII 前调用 checkConsent() 或添加 @consent_required 注解。"),
+  PII_MISSING_CONSENT_CHECK("E403", Category.PII, Severity.WARNING, "Function '{func}' processes PII data without consent check (GDPR Art. 6)", "Call checkConsent() or add @consent_required annotation before processing PII data."),
   // P0-R2 (codex review High #7): PII analyzer 内部失败的专用 code，与 TS
   // 端 aster-lang-ts ErrorCode.PII_ANALYZER_FAILED 镜像。
   // P0-R3 (codex review Medium #5): 文案与 TS 端对齐——业务用户友好语气，
   // 明确指引"this policy should not be deployed"。
-  PII_ANALYZER_FAILED("E404", Category.PII, Severity.ERROR, "PII safety analysis failed for this module — the editor cannot verify whether sensitive data is correctly handled. This policy should not be deployed until the analysis succeeds. Internal reason: %s", "保存源码并重试。如果错误持续，请联系管理员或附上源码提交 issue。"),
-  ASYNC_START_NOT_WAITED("E500", Category.ASYNC, Severity.ERROR, "Started async task '%s' not waited", "对启动的异步任务调用 wait，确保执行完毕。"),
-  ASYNC_WAIT_NOT_STARTED("E501", Category.ASYNC, Severity.ERROR, "Waiting for async task '%s' that was never started", "确认 wait 的任务名称在 Start 中正确出现。"),
-  ASYNC_DUPLICATE_START("E502", Category.ASYNC, Severity.ERROR, "Async task '%s' started multiple times (%s occurrences)", "避免重复启动同名任务，可复用已有任务或改用新名称。"),
-  ASYNC_DUPLICATE_WAIT("E503", Category.ASYNC, Severity.WARNING, "Async task '%s' waited multiple times (%s occurrences)", "确保每个任务仅等待一次，或使用单独的同步机制。"),
-  ASYNC_WAIT_BEFORE_START("E504", Category.ASYNC, Severity.ERROR, "Wait for async task '%s' occurs before any matching start", "在 wait for 之前先执行 start，并确保两者位于兼容的控制路径。"),
+  PII_ANALYZER_FAILED("E404", Category.PII, Severity.ERROR, "PII safety analysis failed for this module — the editor cannot verify whether sensitive data is correctly handled. This policy should not be deployed until the analysis succeeds. Internal reason: {reason}", "Try saving and reloading the file. If the error persists, contact your administrator or report this issue with the source code attached."),
+  ASYNC_START_NOT_WAITED("E500", Category.ASYNC, Severity.ERROR, "Started async task '{task}' not waited", "Call wait on started async tasks to ensure completion."),
+  ASYNC_WAIT_NOT_STARTED("E501", Category.ASYNC, Severity.ERROR, "Waiting for async task '{task}' that was never started", "Ensure the task name in wait matches a started task."),
+  ASYNC_DUPLICATE_START("E502", Category.ASYNC, Severity.ERROR, "Async task '{task}' started multiple times ({count} occurrences)", "Avoid starting the same task multiple times; reuse or rename."),
+  ASYNC_DUPLICATE_WAIT("E503", Category.ASYNC, Severity.WARNING, "Async task '{task}' waited multiple times ({count} occurrences)", "Ensure each task is waited on only once, or use a separate synchronization mechanism."),
+  ASYNC_WAIT_BEFORE_START("E504", Category.ASYNC, Severity.ERROR, "Wait for async task '{task}' occurs before any matching start", "Execute start before wait, and ensure both are on compatible control paths."),
   // P0-R3 (codex review High #3): 与 TS 端 ERROR_METADATA 对齐
-  PII_IMPLICIT_UPLEVEL("W071", Category.PII, Severity.WARNING, "检测到隐式 PII 等级提升: %s -> %s", "为等级变化添加显式类型注解以便审计。"),
-  PII_SINK_UNKNOWN("W074", Category.PII, Severity.WARNING, "可能有 PII 数据流向 %s 但缺少注解", "为数据增加 @pii 注解以追踪敏感数据流。"),
-  WORKFLOW_RETRY_INCONSISTENT("W105", Category.TYPE, Severity.WARNING, "Workflow retry 配置可能不合理: %s", "检查 retry 总等待时间、maxAttempts 与 backoff 策略的组合是否合理。"),
-  WORKFLOW_TIMEOUT_UNREASONABLE("W106", Category.TYPE, Severity.WARNING, "Workflow timeout 配置可能不合理: %s", "检查 timeout 值是否过大或过小。"),
+  PII_IMPLICIT_UPLEVEL("W071", Category.PII, Severity.WARNING, "Implicit PII level escalation detected: {source} -> {target}", "Add explicit type annotations for level changes to aid auditing."),
+  PII_SINK_UNKNOWN("W074", Category.PII, Severity.WARNING, "PII data may flow to {sinkKind} without annotation", "Add @pii annotation to track sensitive data flow."),
+  WORKFLOW_RETRY_INCONSISTENT("W105", Category.TYPE, Severity.WARNING, "Workflow retry configuration may be unreasonable: {reason}", "Check the combination of total wait time, maxAttempts, and backoff strategy."),
+  WORKFLOW_TIMEOUT_UNREASONABLE("W106", Category.TYPE, Severity.WARNING, "Workflow timeout configuration may be unreasonable: {reason}", "Check whether the timeout value is too large or too small."),
   ;
 
   private final String code;
@@ -138,11 +137,42 @@ public enum ErrorCode {
     return help;
   }
 
+  /** 命名占位符 `{name}` —— 与 shared/error_codes.json 逐字一致。 */
+  private static final java.util.regex.Pattern PLACEHOLDER =
+      java.util.regex.Pattern.compile("\\{(\\w+)}");
+
   /**
-   * 使用占位符顺序填充消息模板，调用方需确保参数顺序正确。
+   * 用**命名参数**渲染消息模板。
+   *
+   * <p>★这是全仓唯一的消息渲染实现（aster-lang-core#137）。此前存在两条互相矛盾的
+   * 路径：DiagnosticBuilder 走命名参数 `{name}`，而本类的 format(Object...) 走
+   * String.format 的 `%s`；生成器又把 json 的 `{name}` 一律改写成 `%s`，
+   * 于是走 DiagnosticBuilder 的 23 个码全部渲染出**字面的 `%s`**
+   * （实测 E101「Undefined variable: %s」连是哪个变量都不告诉用户）。
+   *
+   * <p>现在模板与 json 逐字一致，两个消费者共用本方法。
+   * 缺失的 key 保留原占位符（便于发现漏传，而不是渲染成 null）。
    */
-  public String format(Object... args) {
-    return String.format(Locale.ROOT, messageTemplate, args);
+  public String render(java.util.Map<String, Object> params) {
+    java.util.Map<String, Object> p = params == null ? java.util.Map.of() : params;
+    var matcher = PLACEHOLDER.matcher(messageTemplate);
+    var out = new StringBuilder();
+    while (matcher.find()) {
+      Object value = p.get(matcher.group(1));
+      String replacement;
+      if (value == null) {
+        replacement = "{" + matcher.group(1) + "}";
+      } else if (value instanceof java.util.List<?> list) {
+        replacement = String.join(", ", list.stream().map(String::valueOf).toList());
+      } else if (value instanceof Object[] array) {
+        replacement = String.join(", ", java.util.Arrays.stream(array).map(String::valueOf).toList());
+      } else {
+        replacement = String.valueOf(value);
+      }
+      matcher.appendReplacement(out, java.util.regex.Matcher.quoteReplacement(replacement));
+    }
+    matcher.appendTail(out);
+    return out.toString();
   }
 
   public enum Category {

--- a/src/main/java/aster/core/typecheck/checkers/CapabilityChecker.java
+++ b/src/main/java/aster/core/typecheck/checkers/CapabilityChecker.java
@@ -103,10 +103,7 @@ public final class CapabilityChecker {
             "func", func.name,
             "capabilities", capNames,
             "calls", sampleCalls
-          ),
-          func.name,
-          capNames,
-          sampleCalls
+          )
         );
       }
 
@@ -118,9 +115,7 @@ public final class CapabilityChecker {
           Map.of(
             "func", func.name,
             "calls", sampleCalls
-          ),
-          func.name,
-          sampleCalls
+          )
         );
       }
     }
@@ -149,10 +144,7 @@ public final class CapabilityChecker {
             "func", func.name,
             "cap", name,
             "declared", declaredJoined
-          ),
-          func.name,
-          name,
-          declaredJoined
+          )
         );
       }
     }
@@ -165,9 +157,7 @@ public final class CapabilityChecker {
           Map.of(
             "func", func.name,
             "cap", cap
-          ),
-          func.name,
-          cap
+          )
         );
       }
     }
@@ -185,8 +175,7 @@ public final class CapabilityChecker {
       emit(
         ErrorCode.WORKFLOW_MISSING_IO_EFFECT,
         func.origin,
-        Map.of("func", func.name),
-        func.name
+        Map.of("func", func.name)
       );
     }
     var declaredCapabilityKinds = toCapabilityKinds(normalizeEffectCaps(func.effectCaps));
@@ -263,10 +252,7 @@ public final class CapabilityChecker {
             "func", func.name,
             "step", step.name,
             "capability", cap.displayName()
-          ),
-          func.name,
-          step.name,
-          cap.displayName()
+          )
         );
       }
     }
@@ -291,10 +277,7 @@ public final class CapabilityChecker {
             "func", func.name,
             "step", step.name,
             "capability", cap.displayName()
-          ),
-          step.name,
-          func.name,
-          cap.displayName()
+          )
         );
       }
     }
@@ -354,15 +337,18 @@ public final class CapabilityChecker {
     return normalized;
   }
 
-  private void emit(ErrorCode code, CoreModel.Origin origin, Map<String, Object> data, Object... args) {
+  private void emit(ErrorCode code, CoreModel.Origin origin, Map<String, Object> data) {
     var severity = switch (code.severity()) {
       case ERROR -> Diagnostic.Severity.ERROR;
       case WARNING -> Diagnostic.Severity.WARNING;
       case INFO -> Diagnostic.Severity.INFO;
     };
-    var message = args == null || args.length == 0
-      ? code.messageTemplate()
-      : code.format(args);
+    // ★命名渲染（aster-lang-core#137）：模板现与 shared/error_codes.json 逐字一致，
+    //   用 `{name}` 而非 `%s`。data 里本就带齐模板所需的全部键——此前调用方
+    //   把同一批值**传了两遍**（一遍命名 data、一遍位置 args），位置那遍还出现过
+    //   顺序与模板不符的情形（COMPENSATE_NEW_CAPABILITY 的 func/step 反了）。
+    //   改走 data 后顺序不再有意义，那类错误从根上消失。
+    var message = code.render(data);
     diagnostics.add(new Diagnostic(
       severity,
       code,
@@ -411,11 +397,9 @@ public final class CapabilityChecker {
             "func", func.name,
             "module", moduleName == null ? "" : moduleName,
             "cap", cap.displayName()
-          ),
-          // 格式串顺序：Function '%s' requires %s capability but manifest for module '%s' denies it.
-          func.name,
-          cap.displayName(),
-          moduleName == null ? "" : moduleName
+          )
+          // 位置参数已删除：模板改用命名占位符 {func}/{cap}/{module} 后，
+          // 上面 data 里的键就是渲染依据，不再需要「记住顺序」这件事。
         );
       }
     }

--- a/src/main/java/aster/core/typecheck/pii/PiiTypeChecker.java
+++ b/src/main/java/aster/core/typecheck/pii/PiiTypeChecker.java
@@ -261,7 +261,7 @@ public final class PiiTypeChecker {
           "func", callee
         );
         var origin = argNodes.get(i) != null ? exprOrigin(argNodes.get(i)) : null;
-        emitDiagnostic(ErrorCode.PII_ARG_VIOLATION, origin, data, describeMeta(expected), describeMeta(actual));
+        emitDiagnostic(ErrorCode.PII_ARG_VIOLATION, origin, data);
       }
     }
   }
@@ -284,13 +284,13 @@ public final class PiiTypeChecker {
         "source", describeMeta(valueMeta),
         "target", describeMeta(targetMeta)
       );
-      emitDiagnostic(ErrorCode.PII_ASSIGN_DOWNGRADE, origin, data, describeMeta(valueMeta), describeMeta(targetMeta));
+      emitDiagnostic(ErrorCode.PII_ASSIGN_DOWNGRADE, origin, data);
     } else if (decision.warning) {
       var data = Map.<String, Object>of(
         "source", describeMeta(valueMeta),
         "target", describeMeta(targetMeta)
       );
-      emitDiagnostic(ErrorCode.PII_IMPLICIT_UPLEVEL, origin, data, describeMeta(valueMeta), describeMeta(targetMeta));
+      emitDiagnostic(ErrorCode.PII_IMPLICIT_UPLEVEL, origin, data);
     }
   }
 
@@ -333,7 +333,7 @@ public final class PiiTypeChecker {
   private void checkSinkAllowed(SinkDescriptor sink, PiiMeta meta, CoreModel.Expr argExpr, Map<String, PiiMeta> env, FunctionContext ctx) {
     if (meta == null) {
       if (argExpr instanceof CoreModel.Name name && !env.containsKey(name.name)) {
-        emitDiagnostic(ErrorCode.PII_SINK_UNKNOWN, exprOrigin(argExpr), Map.<String, Object>of("sinkKind", sink.label), sink.label);
+        emitDiagnostic(ErrorCode.PII_SINK_UNKNOWN, exprOrigin(argExpr), Map.<String, Object>of("sinkKind", sink.label));
       }
       return;
     }
@@ -342,7 +342,7 @@ public final class PiiTypeChecker {
       emitDiagnostic(ErrorCode.PII_SINK_UNSANITIZED, exprOrigin(argExpr), Map.<String, Object>of(
         "level", meta.getLevel().name(),
         "sinkKind", sink.label
-      ), meta.getLevel().name(), sink.label);
+      ));
       return;
     }
     // L2 在任何 sink（CONSOLE / NETWORK / DATABASE / EMIT）都同样需要脱敏；
@@ -351,7 +351,7 @@ public final class PiiTypeChecker {
       emitDiagnostic(ErrorCode.PII_SINK_UNSANITIZED, exprOrigin(argExpr), Map.<String, Object>of(
         "level", meta.getLevel().name(),
         "sinkKind", sink.label
-      ), meta.getLevel().name(), sink.label);
+      ));
     }
   }
 
@@ -553,15 +553,16 @@ public final class PiiTypeChecker {
     return null;
   }
 
-  private void emitDiagnostic(ErrorCode code, CoreModel.Origin origin, Map<String, Object> data, Object... args) {
+  private void emitDiagnostic(ErrorCode code, CoreModel.Origin origin, Map<String, Object> data) {
     var severity = switch (code.severity()) {
       case ERROR -> Diagnostic.Severity.ERROR;
       case WARNING -> Diagnostic.Severity.WARNING;
       case INFO -> Diagnostic.Severity.INFO;
     };
-    var message = args == null || args.length == 0
-      ? code.messageTemplate()
-      : String.format(Locale.ROOT, code.messageTemplate(), args);
+    // ★命名渲染（aster-lang-core#137）：模板与 shared/error_codes.json 逐字一致，
+    //   用 `{name}` 而非 `%s`。data 里本就带齐模板所需的键，此前位置 args 是同一批值
+    //   的第二份拷贝——删掉它即消除「两份可能不同步」的风险。
+    var message = code.render(data);
     var diagnostic = new Diagnostic(
       severity,
       code,

--- a/src/test/java/aster/core/typecheck/ErrorCodeParityTest.java
+++ b/src/test/java/aster/core/typecheck/ErrorCodeParityTest.java
@@ -25,10 +25,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Java 枚举 {@link ErrorCode} 与该 json 的「结构字段」一致——name 集合、code、
  * category、severity。
  *
- * <p>为何不逐字节比对 message/help：Java 侧历史生成物的 message 模板用
- * {@code %s} 位置占位符（{@code String.format} 路径），而 json 用 {@code {name}}
- * 命名占位符（{@link DiagnosticBuilder#error} 的 Map 命名参数路径），两种表示无法逐字节
- * 相等。ts 侧 error-codes-parity 测试对同一份 json 做「含 message/help」的强校验，
+ * <p>★message/help 现在**也逐字节比对**（aster-lang-core#137 修复后）。
+ * 此前不比对的理由是「Java 用 {@code %s} 位置占位符、json 用 {@code {name}} 命名占位符，
+ * 两种表示无法逐字节相等」——那个描述准确，却掩盖了真正的问题：Java 的主渲染路径
+ * {@code DiagnosticBuilder.formatMessage} **只认 {@code {name}}**，对 {@code %s}
+ * 不做任何替换，于是 23 个已 emit 的码把字面的 {@code %s} 直接呈现给用户
+ * （实测 E101「Undefined variable: %s」连是哪个变量都不说）。
+ * 生成器不再把 {@code {name}} 改写成 {@code %s}，两端逐字对齐，这条强校验随之可以打开——
+ * 它同时是防该缺陷复发的守卫。ts 侧 error-codes-parity 测试对同一份 json 做同样的强校验，
  * 两份 json 的 byte-identical 由 ts 侧断言保证——传递性上确保 ts ↔ Java 码表一致。
  */
 class ErrorCodeParityTest {
@@ -69,6 +73,63 @@ class ErrorCodeParityTest {
 
         assertEquals(jsonNames, enumNames,
                 "ErrorCode 枚举名集合必须与 shared/error_codes.json 完全一致（防码表 drift）");
+    }
+
+    /**
+     * ★message/help 与 json 逐字节一致（aster-lang-core#137 的复发守卫）。
+     *
+     * <p>没有这条，生成器再把 {@code {name}} 改写回 {@code %s}（或有人手改生成物）
+     * 都不会有任何测试变红——那正是本缺陷能存活到 23 个码的原因。
+     */
+    @Test
+    void messageAndHelpMatchJsonByteForByte() throws Exception {
+        JsonNode table = loadTable();
+        Map<String, ErrorCode> byName = new HashMap<>();
+        for (ErrorCode ec : ErrorCode.values()) {
+            byName.put(ec.name(), ec);
+        }
+
+        List<String> mismatches = new ArrayList<>();
+        for (Iterator<Map.Entry<String, JsonNode>> it = table.fields(); it.hasNext(); ) {
+            Map.Entry<String, JsonNode> e = it.next();
+            ErrorCode ec = byName.get(e.getKey());
+            if (ec == null) {
+                continue;   // 名集合由 enumNameSetMatchesJson 单独守
+            }
+            String jsonMessage = e.getValue().get("message").asText();
+            if (!jsonMessage.equals(ec.messageTemplate())) {
+                mismatches.add(e.getKey() + ".message: json=" + jsonMessage
+                        + " | java=" + ec.messageTemplate());
+            }
+            String jsonHelp = e.getValue().get("help").asText();
+            if (!jsonHelp.equals(ec.help())) {
+                mismatches.add(e.getKey() + ".help: json=" + jsonHelp
+                        + " | java=" + ec.help());
+            }
+        }
+
+        assertTrue(mismatches.isEmpty(),
+                "message/help 必须与 shared/error_codes.json 逐字节一致（单一真源）：\n"
+                        + String.join("\n", mismatches));
+    }
+
+    /**
+     * ★没有任何模板会渲染出字面 {@code %s}。
+     *
+     * <p>与上一条互补：上一条守「Java == json」，本条守「模板本身不含 %s」。
+     * 两条都在，才既防生成器改写、也防有人往真源里写 %s。
+     */
+    @Test
+    void noTemplateContainsPositionalPlaceholder() {
+        List<String> offenders = new ArrayList<>();
+        for (ErrorCode ec : ErrorCode.values()) {
+            if (ec.messageTemplate() != null && ec.messageTemplate().contains("%s")) {
+                offenders.add(ec.name() + ": " + ec.messageTemplate());
+            }
+        }
+        assertTrue(offenders.isEmpty(),
+                "消息模板不得含 %s —— DiagnosticBuilder 只替换 {name}，%s 会原样呈现给用户：\n"
+                        + String.join("\n", offenders));
     }
 
     @Test


### PR DESCRIPTION
Closes #137

## 问题

`ErrorCode` 的模板是 `%s`（由生成器把 json 的 `{name}` 改写而来），而 Java 侧主渲染路径
`DiagnosticBuilder.formatMessage` **只认 `{name}`**，对 `%s` 不做任何替换。
于是参数被放进 `Diagnostic.data` 却**从不进入 message**：

```
MSG[E003] = "Return type mismatch: expected %s, got %s"
MSG[E101] = "Undefined variable: %s"        ← 连是哪个变量都不告诉用户
```

## 影响面（脚本统计 + 实测）

67 个码里 57 个含 `%s`：

| 分类 | 数量 | 说明 |
|------|------|------|
| 走 `DiagnosticBuilder` | **23** | 真坏，渲染出字面 `%s` |
| 走 `format()`/Pii | 9 | 正常 |
| **两条路径都走** | 2 | `EFF_CAP_MISSING` / `EFF_CAP_SUPERFLUOUS` |

最后那 2 个是关键证据：**无论模板用哪种语法必有一边错**——这不是「忘了统一」，
而是同一份模板有两个语法要求相反的消费者。

## 修法（真源在生成器）

1. 生成器不再把 `{name}` 改写成 `%s`，Java 模板与 `shared/error_codes.json` **逐字一致**；
2. 生成的 `format(Object...)` 换成 `render(Map)`，**全仓只剩一条渲染实现**；
3. `CapabilityChecker` / `PiiTypeChecker` 改用 `code.render(data)`，并删除与 `data`
   重复的位置参数。

关于第 3 点——实测调用点把**同一批值传了两遍**（一遍命名 `data`、一遍位置 `args`），
且 `COMPENSATE_NEW_CAPABILITY` 两者**顺序不一致**（模板要 `{step}` 在前，data 键序 `func` 在前）。
还有个调用点写着注释「格式串顺序：`Function '%s' requires %s capability but ... '%s'`」——
正是这种「必须记住顺序」的脆弱性。改走 `data` 后该问题从根上消失。

## ★ErrorCode.java 是生成物

重新生成会丢掉 8 处手工注释块（DECIMAL_DOUBLE_MIXING / PII_* / DUPLICATE_SYMBOL 等
对 ADR 与历史裁决的说明），**已逐条恢复**。第一次恢复脚本只匹配 `E###` 漏了 `W0xx`，
已修正后重做。

## 守卫（两条互补，防复发）

- `messageAndHelpMatchJsonByteForByte` —— 守「Java == json」。
  这同时把 `ErrorCodeParityTest` 此前**有意跳过**的 message/help 比对打开了。
  原注释说的「两种表示无法逐字节相等」描述准确，**却掩盖了「参数根本没被渲染」这个真问题**——
  差异被当成可接受的表示差异，于是缺陷活到了 23 个码。
- `noTemplateContainsPositionalPlaceholder` —— 守「模板本身不含 `%s`」。

变异验证：把 E101 模板改回 `"%s"` → **两条守卫各自独立报红**。

## 验证

```
修复后:  MSG[E003]=Return type mismatch: expected Int, got String
        MSG[E101]=Undefined variable: foo
        MSG[E020]=List literal element type mismatch: expected Int, got String
```

- `aster-lang-core` 全量测试绿
- 跨引擎 parity eval 门 **712/712 identical，divergent 0**（本地实跑）
- 配套 PR：aster-cloud/aster-lang-ts#154（生成器）