### PR TITLE
fix(typecheck): 模块级重复声明降级为诊断，不再抛异常穿透

### DIFF
--- a/src/main/java/aster/core/typecheck/TypeChecker.java
+++ b/src/main/java/aster/core/typecheck/TypeChecker.java
@@ -122,7 +122,7 @@ public final class TypeChecker {
       if (module.decls != null) {
         for (var decl : module.decls) {
           if (decl instanceof CoreModel.Func func) {
-            defineFunctionSignature(func);
+            defineOrReportDuplicate(func.name, func.origin, () -> defineFunctionSignature(func));
           }
         }
       }
@@ -164,8 +164,10 @@ public final class TypeChecker {
     if (module == null || module.decls == null) return;
     for (var decl : module.decls) {
       switch (decl) {
-        case CoreModel.Data data -> defineDataType(data);
-        case CoreModel.Enum enumDecl -> defineEnumType(enumDecl);
+        case CoreModel.Data data ->
+          defineOrReportDuplicate(data.name, data.origin, () -> defineDataType(data));
+        case CoreModel.Enum enumDecl ->
+          defineOrReportDuplicate(enumDecl.name, enumDecl.origin, () -> defineEnumType(enumDecl));
         default -> {
           // Func 和 Import 在第二遍处理
         }
@@ -176,6 +178,34 @@ public final class TypeChecker {
   /**
    * 定义数据类型（product type）
    */
+  /**
+   * 把「模块作用域重复声明」从**抛异常**降级为诊断（issue #139）。
+   *
+   * <p>★此前 SymbolTable.define 的 DuplicateSymbolError 会直接穿透 typecheckModule
+   * 的返回契约——同一模块内写两个同名函数，用户得到的是**编译器崩溃**而不是一条
+   * 可展示的错误。实测三种形态全部抛出：同名函数、同名 Data、函数与 Data 同名。
+   *
+   * <p>ErrorCode.DUPLICATE_SYMBOL(E104) 早已定义好（且是少数本就用 {name} 命名
+   * 占位符、渲染正常的码之一），只是从来没有 emit 站点——与 E020 此前的处境相同。
+   *
+   * <p>降级后继续检查其余声明：一个重名不该让整个模块的其它错误都看不见。
+   *
+   * @return true 表示定义成功；false 表示重名（已记录诊断）
+   */
+  private boolean defineOrReportDuplicate(String name, CoreModel.Origin origin, Runnable define) {
+    try {
+      define.run();
+      return true;
+    } catch (SymbolTable.DuplicateSymbolError dup) {
+      diagnostics.error(
+        ErrorCode.DUPLICATE_SYMBOL,
+        Optional.ofNullable(origin),
+        Map.of("name", name)
+      );
+      return false;
+    }
+  }
+
   private void defineDataType(CoreModel.Data data) {
     var typeName = new CoreModel.TypeName();
     typeName.name = data.name;

--- a/src/test/java/aster/core/typecheck/TypeCheckerEdgeCaseTest.java
+++ b/src/test/java/aster/core/typecheck/TypeCheckerEdgeCaseTest.java
@@ -60,10 +60,14 @@ class TypeCheckerEdgeCaseTest {
     var module = new CoreModel.Module();
     module.decls = List.of(func1, func2);
 
-    // 应该捕获异常（SymbolTable.DuplicateSymbolError）或产生诊断
-    assertThrows(SymbolTable.DuplicateSymbolError.class, () -> {
-      checker.typecheckModule(module);
-    });
+    // ★改为断言**诊断**而非异常（issue #139）。
+    //   原断言把缺陷锁死了：注释自己写的是「或产生诊断」，断言却要求抛异常——
+    //   于是任何人把崩溃降级成诊断，反而会让这条测试变红。
+    //   typecheckModule 的契约是返回诊断列表；重名是普通用户输入，不该让编译器崩。
+    var diagnostics = assertDoesNotThrow(() -> checker.typecheckModule(module),
+      "重复声明必须返回诊断，不得让 DuplicateSymbolError 穿透返回契约");
+    assertTrue(diagnostics.stream().anyMatch(d -> d.code() == ErrorCode.DUPLICATE_SYMBOL),
+      "应报 DUPLICATE_SYMBOL；实际：" + diagnostics.stream().map(d -> d.code().name()).toList());
   }
 
   @Test
@@ -82,9 +86,14 @@ class TypeCheckerEdgeCaseTest {
     var module = new CoreModel.Module();
     module.decls = List.of(data1, data2);
 
-    assertThrows(SymbolTable.DuplicateSymbolError.class, () -> {
-      checker.typecheckModule(module);
-    });
+    // ★改为断言**诊断**而非异常（issue #139）。
+    //   原断言把缺陷锁死了：注释自己写的是「或产生诊断」，断言却要求抛异常——
+    //   于是任何人把崩溃降级成诊断，反而会让这条测试变红。
+    //   typecheckModule 的契约是返回诊断列表；重名是普通用户输入，不该让编译器崩。
+    var diagnostics = assertDoesNotThrow(() -> checker.typecheckModule(module),
+      "重复声明必须返回诊断，不得让 DuplicateSymbolError 穿透返回契约");
+    assertTrue(diagnostics.stream().anyMatch(d -> d.code() == ErrorCode.DUPLICATE_SYMBOL),
+      "应报 DUPLICATE_SYMBOL；实际：" + diagnostics.stream().map(d -> d.code().name()).toList());
   }
 
   @Test

--- a/src/test/java/aster/core/typecheck/TypeCheckerIntegrationTest.java
+++ b/src/test/java/aster/core/typecheck/TypeCheckerIntegrationTest.java
@@ -719,6 +719,107 @@ class TypeCheckerIntegrationTest {
       "多分支各自绑同名变量不得互相干扰；实际：" + undefined);
   }
 
+  private CoreModel.Data dataDecl(String name) {
+    var d = new CoreModel.Data();
+    d.name = name;
+    d.fields = List.of();
+    return d;
+  }
+
+  private List<Diagnostic> duplicateSymbols(CoreModel.Module module) {
+    return checker.typecheckModule(module).stream()
+      .filter(d -> d.code() == ErrorCode.DUPLICATE_SYMBOL)
+      .toList();
+  }
+
+  @Test
+  void duplicateFunctionNamesReportDiagnostic_notThrow() {
+    // ★issue #139：同一模块内两个同名函数会让 SymbolTable.define 抛
+    //   DuplicateSymbolError，而 TypeChecker 全文无 catch —— 异常直接穿透
+    //   typecheckModule 的返回契约，用户得到的是**编译器崩溃**而不是可展示的错误。
+    //   ErrorCode.DUPLICATE_SYMBOL(E104) 早已定义好却零 emit 站点。
+    var module = new CoreModel.Module();
+    module.decls = List.of(intFunc("dup", createIntLiteral(1)), intFunc("dup", createIntLiteral(2)));
+
+    // 关键是「不抛异常」——assertDoesNotThrow 本身就是这条测试的一半
+    var dups = assertDoesNotThrow(() -> duplicateSymbols(module),
+      "同名函数必须返回诊断，不得让异常穿透 typecheckModule");
+    assertFalse(dups.isEmpty(), "必须报 DUPLICATE_SYMBOL");
+  }
+
+  @Test
+  void duplicateDataNamesReportDiagnostic_notThrow() {
+    // 同类形态之二：两个同名 Data。
+    var module = new CoreModel.Module();
+    module.decls = List.of(dataDecl("D"), dataDecl("D"));
+
+    var dups = assertDoesNotThrow(() -> duplicateSymbols(module));
+    assertFalse(dups.isEmpty(), "同名 Data 必须报 DUPLICATE_SYMBOL");
+  }
+
+  @Test
+  void functionCollidingWithDataNameReportsDiagnostic_notThrow() {
+    // ★同类形态之三：跨种类重名（Data 与函数同名）。三种形态实测**全部**抛异常，
+    //   只修其中一种另两种照样崩。
+    var module = new CoreModel.Module();
+    module.decls = List.of(dataDecl("X"), intFunc("X", createIntLiteral(1)));
+
+    var dups = assertDoesNotThrow(() -> duplicateSymbols(module));
+    assertFalse(dups.isEmpty(), "函数与 Data 同名必须报 DUPLICATE_SYMBOL");
+  }
+
+  @Test
+  void duplicateDiagnosticNamesTheOffendingSymbol() {
+    // ★只断言「报错了」不够：消息必须点名是哪个符号，否则用户无从定位。
+    //   E104 是少数本就用 {name} 命名占位符、渲染正常的码。
+    var module = new CoreModel.Module();
+    module.decls = List.of(intFunc("collide", createIntLiteral(1)),
+                           intFunc("collide", createIntLiteral(2)));
+
+    var dups = duplicateSymbols(module);
+    assertFalse(dups.isEmpty(), "前置条件：应有诊断");
+    assertTrue(dups.get(0).message().contains("collide"),
+      "诊断须点名重复的符号；实际：" + dups.get(0).message());
+  }
+
+  @Test
+  void distinctNamesProduceNoDuplicateDiagnostic() {
+    // ★反向护栏：没有这条，把 defineOrReportDuplicate 写成「总是报重复」
+    //   也能让上面几条变绿。
+    var module = new CoreModel.Module();
+    module.decls = List.of(intFunc("a", createIntLiteral(1)),
+                           intFunc("b", createIntLiteral(2)),
+                           dataDecl("C"));
+
+    assertTrue(duplicateSymbols(module).isEmpty(), "不同名的声明不得报重复");
+  }
+
+  @Test
+  void checkingContinuesAfterDuplicate() {
+    // ★降级的意义在于「继续检查其余声明」：一个重名不该让模块里其它错误都看不见。
+    //   第三个函数返回类型不符，必须仍被报出来。
+    var badReturn = new CoreModel.Func();
+    badReturn.name = "bad";
+    badReturn.params = List.of();
+    badReturn.ret = createTypeName("String");
+    badReturn.effects = List.of();
+    var body = new CoreModel.Block();
+    body.statements = List.of(createReturnStmt(createIntLiteral(1)));
+    badReturn.body = body;
+
+    var module = new CoreModel.Module();
+    module.decls = List.of(intFunc("dup", createIntLiteral(1)),
+                           intFunc("dup", createIntLiteral(2)),
+                           badReturn);
+
+    var all = checker.typecheckModule(module);
+    assertTrue(all.stream().anyMatch(d -> d.code() == ErrorCode.DUPLICATE_SYMBOL),
+      "应报重复符号");
+    assertTrue(all.stream().anyMatch(d -> d.code() == ErrorCode.RETURN_TYPE_MISMATCH),
+      "重名之后的声明仍须被检查——否则降级毫无意义；实际诊断："
+        + all.stream().map(d -> d.code().name()).toList());
+  }
+
   @Test
   void testEffectPropagationThroughCalls() {
     // func ioFunc(): Int [io] { return 42 }


### PR DESCRIPTION
Closes #139

## 问题

`SymbolTable.define` 的 `DuplicateSymbolError` 直接穿透 `typecheckModule` 的返回契约——
同一模块内写两个同名函数，用户得到的是**编译器崩溃**，而不是一条可展示的错误。

## 实测：三种形态全部抛出

```
两个同名函数      → THREW DuplicateSymbolError: Duplicate symbol 'dup' ...
两个同名 Data     → THREW DuplicateSymbolError: Duplicate symbol 'D' ...
函数与 Data 同名  → THREW DuplicateSymbolError: Duplicate symbol 'X' ...
```

**只修其中一种，另两种照样崩**——所以三种形态各有一条测试。

修复后三者均返回 `[DUPLICATE_SYMBOL]` 诊断。

`ErrorCode.DUPLICATE_SYMBOL`(E104) 早已定义好（且是少数本就用 `{name}` 命名占位符、
渲染正常的码），只是**从来没有 emit 站点**——与 E020 此前的处境相同。

## 降级 ≠ 吞掉

`checkingContinuesAfterDuplicate` 专门锁这一点：重名之后的声明**仍须被检查**
（用一个返回类型不符的函数验证）。一个重名不该让模块里其它错误都看不见——
否则降级毫无意义。

## ★顺带修正两条把缺陷锁死的既有测试

`TypeCheckerEdgeCaseTest` 的 `testDuplicateFunctionDefinition` /
`testDuplicateDataTypeDefinition` 断言 `assertThrows(DuplicateSymbolError)`，
而它们**自己的注释写的是「应该捕获异常……或产生诊断」**——
于是任何人把崩溃降级成诊断，反而会让这两条测试变红。已改为断言诊断。

## 验证

| 检验 | 结果 |
|------|------|
| 在 main 上跑新测试 | **5 条红**（第 6 条是反向护栏，正确保持绿） |
| 变异：诊断里把符号名换成 `REDACTED` | `duplicateDiagnosticNamesTheOffendingSymbol` 红 |
| core 全量 | **1568 测试绿** |

## ★范围（如实标注，不假装已解决）

只修**模块作用域**。函数作用域的重复（重复形参、形参与 `Let` 同名）**仍抛**
`DuplicateSymbolError`，既有测试 `testDuplicateParameterNames` 等仍断言抛出。
那是独立的一层，未在本 PR 处理。