### PR TITLE
fix(parser): 词法期拦截深嵌套，修解析期 StackOverflowError

### DIFF
--- a/src/main/java/aster/core/parser/AstBuilder.java
+++ b/src/main/java/aster/core/parser/AstBuilder.java
@@ -44,8 +44,14 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
      * 红队 P2-H：表达式嵌套深度上限（防深嵌套 CNL 递归 StackOverflow DoS）。
      * 与 aster-lang-ts 的 MAX_RECURSION_DEPTH=300 对齐，维持双引擎行为一致。
      * 每进入一层 {@link #visitExpr} 计数，超限即抛（可恢复的解析错误，由错误恢复层
-     * 转成 Diagnostic）。ANTLR 生成解析器自身的解析期递归另由 64KB 源长度上限约束
-     * （见 SourcePolicyRequest @Size / CnlSourceLimits），此处守 AstBuilder 访问期递归。
+     * 转成 Diagnostic）。此处守的是 **AstBuilder 访问期**递归。
+     *
+     * <p>★ANTLR **解析期**递归由 {@code AsterCustomLexer.MAX_NESTING_DEPTH} 在词法期
+     * 拦下（issue #140）。此前这里注释声称由「64KB 源长度上限（SourcePolicyRequest
+     * @Size / CnlSourceLimits）」兜底——**那两个类型在本仓不存在**，全仓 grep 只命中
+     * 注释本身；该上限由外部 aster-api 服务层实施，直接用本库的调用方不受任何限制。
+     * 实测 depth=2000（仅约 4KB 源码）会在 {@code parser.module()} 阶段就抛
+     * {@code StackOverflowError}（Error 级，不可恢复），绕过本守卫。
      */
     static final int MAX_EXPR_DEPTH = 300;
     private int exprDepth = 0;

--- a/src/main/java/aster/core/parser/AsterCustomLexer.java
+++ b/src/main/java/aster/core/parser/AsterCustomLexer.java
@@ -173,11 +173,60 @@ public class AsterCustomLexer extends AsterLexer {
     }
 
     /**
+     * 词法期括号嵌套深度上限——**先于 ANTLR 解析**生效（issue #140）。
+     *
+     * <p>★为什么必须在这一层：{@code AstBuilder.MAX_EXPR_DEPTH} 的守卫位于
+     * **AstBuilder 访问期**（{@code visitExpr}），而 ANTLR 生成解析器自身的
+     * 解析期递归发生得更早。嵌套足够深时 {@code parser.module()} 阶段就先抛
+     * {@code StackOverflowError}——那是 {@code Error} 级，**不是**可恢复的解析错误，
+     * 不会被转成 Diagnostic。
+     *
+     * <p>实测（修复前，默认栈）：
+     * <pre>
+     *   depth=500   srcBytes=1043  → IllegalStateException（AstBuilder 守卫生效）
+     *   depth=1000  srcBytes=2043  → IllegalStateException（生效）
+     *   depth=2000  srcBytes=4043  → StackOverflowError（守卫被绕过）
+     * </pre>
+     * **只需约 4KB 源码**即可让守卫失效并抛出 Error。
+     *
+     * <p>而 {@code AstBuilder} 注释里声称的兜底「64KB 源长度上限
+     * （SourcePolicyRequest @Size / CnlSourceLimits）」这两个类型**在本仓不存在**——
+     * 全仓 grep 只命中注释本身。那个上限由外部 aster-api 服务层实施，
+     * 直接使用本库的调用方（含本仓自带的 TypeCheckCli）不受任何限制。
+     *
+     * <p>本守卫放在 {@code nextToken} 的公共路径上：token 流是**所有**解析入口的必经之处
+     * （本仓无统一 parser facade，各调用方自行组装 lexer+parser），
+     * 放这里才能覆盖全部路径，而不是只覆盖某一个入口。
+     *
+     * <p>上限取与 {@code MAX_EXPR_DEPTH} 同量级：括号深度是表达式深度的下界，
+     * 深度 300 的括号必然对应至少 300 层表达式嵌套，故越过它的输入本就会被
+     * AstBuilder 拒绝——本守卫只是让拒绝**发生得更早**（在栈溢出之前）。
+     */
+    static final int MAX_NESTING_DEPTH = 300;
+
+    private int nestingDepth = 0;
+
+    private void trackNestingDepth(int type) {
+        if (type == AsterParser.LPAREN || type == AsterParser.LBRACKET) {
+            if (++nestingDepth > MAX_NESTING_DEPTH) {
+                // 与 AstBuilder 深度守卫同一机制：抛可恢复的解析错误，而非放任 Error 穿透。
+                throw new IllegalStateException(
+                    "括号嵌套过深（> " + MAX_NESTING_DEPTH + "），拒绝以防栈溢出");
+            }
+        } else if (type == AsterParser.RPAREN || type == AsterParser.RBRACKET) {
+            if (nestingDepth > 0) {
+                nestingDepth--;
+            }
+        }
+    }
+
+    /**
      * 记录上一个有意义 token 的小写文本（用于标记位置判定）。
      * 跳过 NEWLINE/INDENT/DEDENT/EOF/隐藏通道——它们不影响"前驱是否结构关键词"判定。
      */
     private void recordMeaningful(Token t) {
         int type = t.getType();
+        trackNestingDepth(type);
         if (type == NEWLINE || type == AsterParser.INDENT || type == AsterParser.DEDENT
                 || type == Token.EOF || t.getChannel() == Token.HIDDEN_CHANNEL) {
             return;

--- a/src/test/java/aster/core/parser/ParseDepthPreGateTest.java
+++ b/src/test/java/aster/core/parser/ParseDepthPreGateTest.java
@@ -1,0 +1,99 @@
+package aster.core.parser;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import aster.core.canonicalizer.Canonicalizer;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 深嵌套必须在**词法期**被拒，而不是在 ANTLR 解析期栈溢出（issue #140）。
+ *
+ * <p>★真实缺陷：{@code AstBuilder.MAX_EXPR_DEPTH} 的守卫位于 **AstBuilder 访问期**
+ * （{@code visitExpr}），而 ANTLR 生成解析器自身的解析期递归发生得更早。嵌套足够深时
+ * {@code parser.module()} 阶段就先抛 {@code StackOverflowError}——那是 {@code Error} 级，
+ * <b>不是</b>注释所称的「可恢复的解析错误」，不会被转成 Diagnostic。
+ *
+ * <p>实测（修复前，默认栈）：
+ * <pre>
+ *   depth=500   srcBytes=1043  → IllegalStateException（AstBuilder 守卫生效）
+ *   depth=1000  srcBytes=2043  → IllegalStateException（生效）
+ *   depth=2000  srcBytes=4043  → StackOverflowError（守卫被绕过）
+ * </pre>
+ * <b>只需约 4KB 源码</b>即可让守卫失效并抛出 Error。
+ *
+ * <p>而 {@code AstBuilder} 注释里声称的兜底「64KB 源长度上限（SourcePolicyRequest
+ * @Size / CnlSourceLimits）」——这两个类型<b>在本仓不存在</b>，全仓 grep 只命中注释本身。
+ * 那个上限由外部 aster-api 服务层实施，直接使用本库的调用方不受任何限制。
+ *
+ * <p>★本测试<b>刻意不用大栈线程</b>。既有的 {@code ExprDepthLimitTest} 在 16MB 大栈
+ * 线程上跑，注释里明说那是「保证 ANTLR 解析期不先 StackOverflow」——即它靠<b>放大栈</b>
+ * 绕开了本缺陷，而生产调用方没有这个大栈。故这里用默认栈，才测得到真实行为。
+ */
+class ParseDepthPreGateTest {
+
+  /** 默认栈上完整走一遍 Canonicalizer → Lexer → ANTLR → AstBuilder。 */
+  private void build(String src) {
+    var lexer = new AsterCustomLexer(CharStreams.fromString(new Canonicalizer().canonicalize(src)));
+    var tokens = new CommonTokenStream(lexer);
+    tokens.fill();
+    tokens.seek(0);
+    var parser = new AsterParser(tokens);
+    parser.removeErrorListeners();
+    var moduleCtx = parser.module();
+    assertNotNull(moduleCtx, "解析 null");
+    new AstBuilder().visitModule(moduleCtx);
+  }
+
+  private String nestedParens(int depth) {
+    return "Module probe.\n\nRule r given x:\n  Return "
+        + "(".repeat(depth) + "1" + ")".repeat(depth) + ".\n";
+  }
+
+  @Test
+  void deepNestingIsRejectedAsRecoverableError_notStackOverflow() {
+    // ★核心回归：depth=2000（约 4KB 源码）修复前抛 StackOverflowError。
+    var ex = assertThrows(IllegalStateException.class, () -> build(nestedParens(2000)),
+        "深嵌套必须抛可恢复的解析错误，而不是 Error 级的 StackOverflowError");
+    assertTrue(ex.getMessage() != null && ex.getMessage().contains("嵌套过深"),
+        "实际: " + ex.getMessage());
+  }
+
+  @Test
+  void veryDeepNestingAlsoRejected_gateIsNotDepthDependent() {
+    // ★守卫本身不能随深度增加而失效——depth=5000 时同样必须是可恢复错误。
+    //   若守卫仍在解析期之后，更深的输入只会更早栈溢出。
+    assertThrows(IllegalStateException.class, () -> build(nestedParens(5000)));
+  }
+
+  @Test
+  void bracketNestingAlsoGated() {
+    // 列表字面量的方括号走同一条递归路径，必须一并守。
+    String src = "Module probe.\n\nRule r given x:\n  Return "
+        + "[".repeat(2000) + "1" + "]".repeat(2000) + ".\n";
+    assertThrows(IllegalStateException.class, () -> build(src));
+  }
+
+  @Test
+  void shallowNestingStillParses() {
+    // ★反向护栏：没有这条，把守卫写成「一律拒绝」也能让上面三条变绿。
+    assertDoesNotThrow(() -> build(nestedParens(100)),
+        "100 层嵌套远低于上限，必须正常解析");
+  }
+
+  @Test
+  void ordinaryProgramUnaffected() {
+    // ★反向护栏之二：括号计数是**配对**的，正常程序里大量括号不得累积成误报。
+    var sb = new StringBuilder("Module probe.\n\nRule r given x:\n");
+    for (int i = 0; i < 500; i++) {
+      sb.append("  Let v").append(i).append(" be double(x).\n");
+    }
+    sb.append("  Return x.\n");
+    assertDoesNotThrow(() -> build(sb.toString()),
+        "500 对**已闭合**的括号不得被计成 500 层深度");
+  }
+}


### PR DESCRIPTION
Closes #140

## 问题

表达式深度守卫 `MAX_EXPR_DEPTH` 位于 **AstBuilder 访问期**（`visitExpr`），
而 ANTLR 生成解析器**自身的解析期递归**发生得更早。嵌套足够深时
`parser.module()` 阶段就先抛 `StackOverflowError`——那是 `Error` 级，
**不是**注释所称的「可恢复的解析错误」，不会被转成 Diagnostic。

## 实测（默认栈）

```
修复前:  depth=500   bytes=1043  → IllegalStateException（守卫生效）
        depth=1000  bytes=2043  → IllegalStateException（生效）
        depth=2000  bytes=4043  → ★StackOverflowError（守卫被绕过）

修复后:  depth=100   bytes=243   → ok（正常解析）
        depth=2000  bytes=4043  → IllegalStateException: 括号嵌套过深（> 300）
        depth=5000  bytes=10043 → IllegalStateException: 括号嵌套过深（> 300）
```

**只需约 4KB 源码**即可让守卫失效并抛出 Error。

## ★注释声称的兜底不存在

`AstBuilder` 写着「另由 64KB 源长度上限约束（见 `SourcePolicyRequest` @Size /
`CnlSourceLimits`）」——**这两个类型在本仓不存在**，全仓 grep 只命中注释本身
（`AstBuilder.java` 与 `ExprDepthLimitTest.java` 各一处）。

该上限由外部 aster-api 服务层实施，**直接使用本库的调用方**（含本仓自带的
`TypeCheckCli`）不受任何长度限制。注释已更正为实际情况。

## 守卫位置

放在 `AsterCustomLexer.recordMeaningful`（`nextToken` 公共路径）。

本仓**没有统一的 parser facade**——各调用方自行组装 lexer + parser（实测
`grep "parser.module()" src/main/java/` 零命中）。token 流是**所有**解析入口的必经之处，
放这里才能覆盖全部路径，而不是只覆盖某一个入口。

括号与方括号都计数，且**配对递减**：正常程序里 500 对已闭合括号不会累积成误报
（`ordinaryProgramUnaffected` 专门锁这一点）。

## ★新测试刻意不用大栈线程

既有的 `ExprDepthLimitTest` 在 **16MB 大栈线程**上跑，其注释明说那是
「保证 ANTLR 解析期不先 StackOverflow」——**即它靠放大栈绕开了本缺陷**，
而生产调用方没有这个大栈。本测试用默认栈，才测得到真实行为。

## 验证

| 检验 | 结果 |
|------|------|
| 在 main 上跑新测试 | **3 条红**（`deepNesting` / `veryDeepNesting` / `bracketNesting`） |
| 另 2 条 | 反向护栏（浅嵌套仍解析、配对括号不误报），正确保持绿 |
| core 全量 | 绿 |