### PR TITLE
chore(codegen): 同步 CALL_ARITY_MISMATCH(E032) 码表

### DIFF
--- a/src/main/java/aster/core/typecheck/ErrorCode.java
+++ b/src/main/java/aster/core/typecheck/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
   // ADR 0025：Decimal↔Double 混算编译期拦截（与 TS E031 对齐）。Double 是二进制浮点，
   // 与精确 Decimal 混算会注入舍入误差，破坏可证明性；Int/Long→Decimal 精确提升放行。
   DECIMAL_DOUBLE_MIXING("E031", Category.TYPE, Severity.ERROR, "Cannot combine Decimal and Double in '{operator}'. Double is binary floating-point and would inject rounding error into an exact Decimal. Use Decimal literals (e.g. 1.08m) on both sides, or Int/Long (exact promotion).", "Make both operands Decimal (suffix m), or use Int/Long which promote exactly to Decimal."),
+  CALL_ARITY_MISMATCH("E032", Category.TYPE, Severity.ERROR, "Function '{func}' expects {expected} argument(s), got {actual}.", "Adjust the call to pass exactly the declared number of arguments."),
   // P0-R3 (codex review High #3): 与 TS 端 ERROR_METADATA category 对齐——
   // 5 个核心 PII codes 从 Category.TYPE 改为 Category.PII。之前的 'TYPE'
   // 分类是历史包袱，让任何按 category 派生 PII 集合的代码（如跨语言

--- a/src/test/resources/diagnostics/error_codes.json
+++ b/src/test/resources/diagnostics/error_codes.json
@@ -216,6 +216,13 @@
     "message": "Cannot combine Decimal and Double in '{operator}'. Double is binary floating-point and would inject rounding error into an exact Decimal. Use Decimal literals (e.g. 1.08m) on both sides, or Int/Long (exact promotion).",
     "help": "Make both operands Decimal (suffix m), or use Int/Long which promote exactly to Decimal."
   },
+  "CALL_ARITY_MISMATCH": {
+    "code": "E032",
+    "category": "type",
+    "severity": "error",
+    "message": "Function '{func}' expects {expected} argument(s), got {actual}.",
+    "help": "Adjust the call to pass exactly the declared number of arguments."
+  },
   "PII_ASSIGN_DOWNGRADE": {
     "code": "E070",
     "category": "pii",


### PR DESCRIPTION
配合 aster-cloud/aster-lang-ts#155（用户函数参数个数校验，ts#146）。

新码在 `shared/error_codes.json`（单一真源，位于 aster-lang-ts 仓）新增，
本仓的生成物 `ErrorCode.java` 与 test resources 下的 byte-identical 副本随之同步。

## ★两处易漏（本次都踩过）

1. **重新生成会丢掉 8 处手工注释块**——ADR 0025 / PII category / DUPLICATE_SYMBOL
   等对历史裁决的说明，需逐条恢复；
2. **`src/test/resources/diagnostics/error_codes.json` 是 `shared/` 的 byte-identical 副本**，
   不同步会让 `ErrorCodeParityTest.enumNameSetMatchesJson` 报红。

## 验证

- core 全量测试绿
- 跨引擎 parity eval 门 **712/712 identical**