### PR TITLE
fix(lexicon): 语言包加载失败记 WARNING + timeout 溢出守卫

### DIFF
--- a/src/main/java/aster/core/lexicon/LexiconRegistry.java
+++ b/src/main/java/aster/core/lexicon/LexiconRegistry.java
@@ -603,7 +603,14 @@ public final class LexiconRegistry {
                     register(lexicon);
                     loaded++;
                 } catch (Exception e) {
-                    // 单个文件加载失败不影响其他文件
+                    // ★不再空 catch（issue #130 body）。单个文件失败确实不该中断其余文件，
+                    //   但**静默吞掉**意味着：用户目录（~/.aster/lexicons/）里损坏或不合规的
+                    //   语言包 JSON 会无声消失——无日志、无失败清单，返回值只有成功计数，
+                    //   用户无从得知是哪个文件、为何失败。查起来只能靠猜。
+                    //   现记 WARNING 并带上文件名与原因；继续处理其余文件的行为不变。
+                    LOGGER.log(java.util.logging.Level.WARNING,
+                        "语言包加载失败，已跳过：" + jsonFile
+                            + "（" + e.getClass().getSimpleName() + ": " + e.getMessage() + "）", e);
                 }
             }
         } catch (IOException e) {

--- a/src/main/java/aster/core/parser/AstBuilder.java
+++ b/src/main/java/aster/core/parser/AstBuilder.java
@@ -905,6 +905,22 @@ public class AstBuilder extends AsterParserBaseVisitor<Object> {
         if (seconds < 0) {
             throw new IllegalStateException("timeout 数值必须为非负整数");
         }
+        // ★秒→毫秒的溢出守卫（issue #131 body）——**纵深防御，非当前可达路径**。
+        //
+        //   issue 描述的机制属实：parseLong 允许到 Long.MAX_VALUE，
+        //   而 seconds > Long.MAX_VALUE/1000 时 `seconds * 1000L` 会静默回绕为负值，
+        //   把上一行的非负校验作废。
+        //
+        //   但实测**从源码走不到这里**：INT_LITERAL 在词法/字面量层就被限制在 Int 范围
+        //   （超出即报「out of range for Int … Add the 'L' suffix」），
+        //   而 2147483647 * 1000L 远不溢出 Long。
+        //   保留本守卫是因为它零成本，且一旦将来放宽 timeout 字面量（如允许 L 后缀）
+        //   缺口会立刻变成可达——但**不为它写测试**：写不出能失败的用例，
+        //   那种测试只会是假绿。
+        if (seconds > Long.MAX_VALUE / 1000L) {
+            throw new IllegalStateException(
+                "timeout 数值过大（" + seconds + " 秒换算为毫秒会溢出 Long）");
+        }
         return new Stmt.Timeout(seconds * 1000L);
     }
 

--- a/src/test/java/aster/core/lexicon/LexiconLoadFailureLoggingTest.java
+++ b/src/test/java/aster/core/lexicon/LexiconLoadFailureLoggingTest.java
@@ -1,0 +1,100 @@
+package aster.core.lexicon;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+/**
+ * 语言包加载失败必须留下线索（issue aster-lang-core#130 正文）。
+ *
+ * <p>★真实缺陷：{@code loadFromDirectory} 对单个文件失败是**空 catch**——
+ * 用户目录（{@code ~/.aster/lexicons/}）里损坏或不合规的语言包 JSON 会**无声消失**：
+ * 无日志、无失败清单，返回值只有成功计数。用户无从得知是哪个文件、为何失败，
+ * 查起来只能靠猜。
+ *
+ * <p>「单个文件失败不中断其余文件」这个行为是对的，错的是**不留痕迹**。
+ */
+class LexiconLoadFailureLoggingTest {
+
+    /** 捕获 LexiconRegistry 的日志输出。 */
+    private static final class CapturingHandler extends Handler {
+        final List<LogRecord> records = new ArrayList<>();
+        @Override public void publish(LogRecord record) { records.add(record); }
+        @Override public void flush() { }
+        @Override public void close() { }
+    }
+
+    @Test
+    void corruptLexiconFileIsLoggedWithFileNameAndReason(@TempDir Path dir) throws Exception {
+        // 一个语法就坏的 JSON —— 必然加载失败
+        Path bad = dir.resolve("broken-pack.json");
+        Files.writeString(bad, "{ this is not valid json");
+
+        Logger logger = Logger.getLogger(LexiconRegistry.class.getName());
+        CapturingHandler handler = new CapturingHandler();
+        logger.addHandler(handler);
+        try {
+            int loaded = LexiconRegistry.getInstance().loadFromDirectory(dir);
+            assertEquals(0, loaded, "坏文件不应被计入成功数");
+
+            boolean logged = handler.records.stream()
+                .filter(r -> r.getLevel().intValue() >= Level.WARNING.intValue())
+                .anyMatch(r -> String.valueOf(r.getMessage()).contains("broken-pack.json"));
+            assertTrue(logged,
+                "加载失败必须记 WARNING 并**点名文件**，否则用户无从得知是哪个文件坏了；"
+                    + "实际日志：" + handler.records.stream().map(LogRecord::getMessage).toList());
+        } finally {
+            logger.removeHandler(handler);
+        }
+    }
+
+    @Test
+    void loadingContinuesAfterOneFailure(@TempDir Path dir) throws Exception {
+        // ★「不中断其余文件」这个既有行为必须保住——修「不留痕迹」不能顺手改成「一坏全停」。
+        Files.writeString(dir.resolve("a-broken.json"), "{ nope");
+        Files.writeString(dir.resolve("b-also-broken.json"), "also not json");
+
+        Logger logger = Logger.getLogger(LexiconRegistry.class.getName());
+        CapturingHandler handler = new CapturingHandler();
+        logger.addHandler(handler);
+        try {
+            LexiconRegistry.getInstance().loadFromDirectory(dir);
+            long warned = handler.records.stream()
+                .filter(r -> r.getLevel().intValue() >= Level.WARNING.intValue())
+                .filter(r -> String.valueOf(r.getMessage()).contains("broken"))
+                .count();
+            assertTrue(warned >= 2,
+                "两个坏文件都应被处理并各记一条日志（证明第一个失败没有中断循环）；实际 " + warned);
+        } finally {
+            logger.removeHandler(handler);
+        }
+    }
+
+    @Test
+    void emptyDirectoryProducesNoWarnings(@TempDir Path dir) {
+        // ★反向护栏：没有坏文件时不得产生噪声告警。
+        //   没有这条，把实现写成「无条件记一条 WARNING」也能让上面变绿。
+        Logger logger = Logger.getLogger(LexiconRegistry.class.getName());
+        CapturingHandler handler = new CapturingHandler();
+        logger.addHandler(handler);
+        try {
+            assertEquals(0, LexiconRegistry.getInstance().loadFromDirectory(dir));
+            boolean anyLoadWarning = handler.records.stream()
+                .anyMatch(r -> String.valueOf(r.getMessage()).contains("语言包加载失败"));
+            assertTrue(!anyLoadWarning, "空目录不应产生加载失败告警");
+        } finally {
+            logger.removeHandler(handler);
+        }
+    }
+}


### PR DESCRIPTION
Closes #130
Closes #131

> ⚠️ 本仓 #130/#131 的 **issue 标题与正文错位**：#130 标题写「手写 Lexer 死代码」而正文是
> 「空 catch 吞掉语言包加载失败」；#131 标题写「空 catch」而正文是「timeout 整数溢出」。
> 本 PR 按**正文**修。

## #130 正文：空 catch 吞掉语言包加载失败

`loadFromDirectory` 对单个文件失败是**空 catch**：

```java
} catch (Exception e) {
    // 单个文件加载失败不影响其他文件
}
```

用户目录（`~/.aster/lexicons/`）里损坏或不合规的语言包 JSON 会**无声消失**——
无日志、无失败清单，返回值只有成功计数。用户无从得知是哪个文件、为何失败。

**「单个文件失败不中断其余文件」这个行为是对的，错的是不留痕迹。**

现记 WARNING 并带上文件名与异常类型/消息；继续处理其余文件的行为不变，
并有专门测试锁住这一点（两个坏文件都应各记一条，证明第一个失败没中断循环）。

| 检验 | 结果 |
|------|------|
| 变异：退回空 catch | **两条日志测试红** |
| 反向护栏 | `emptyDirectoryProducesNoWarnings`——防「无条件记一条 WARNING」式实现 |

## #131 正文：timeout 溢出守卫（★纵深防御，非当前可达路径）

issue 描述的机制**属实**：`parseLong` 允许到 `Long.MAX_VALUE`，
`seconds > Long.MAX_VALUE/1000` 时 `seconds * 1000L` 静默回绕为负值，
把上一行的非负校验作废。

**但实测从源码走不到那里**：`INT_LITERAL` 在字面量层就被限制在 Int 范围
（超出即报 `out of range for Int … Add the 'L' suffix`），而 `2147483647 * 1000L`
远不溢出 Long。

故加守卫（零成本，且一旦将来放宽 timeout 字面量，缺口会立刻变成可达），
但**不为它写测试**——写不出能失败的用例，那种测试只会是假绿。
代码注释里写明了这个判断依据与将来何时会变成可达。

## 验证

core 全量测试绿。